### PR TITLE
disable giving commands through minimap

### DIFF
--- a/dist_cfg/springsettings.json
+++ b/dist_cfg/springsettings.json
@@ -42,6 +42,7 @@
     "MaxTextureAtlasSizeX": 4096,
     "MaxTextureAtlasSizeZ": 4096,
     "MiddleClickScrollSpeed": -0.005,
+    "MiniMapFullProxy": 0,
     "MinimapOnLeft": 1,
     "MouseDragScrollThreshold": 0.3,
     "MoveWarnings": 0,


### PR DESCRIPTION
seen a few complaints now that right click doesn't snap to location when clicking on the minimap and middle click is more awkward.

> ShoX — Yesterday at 13:28
> MiniMapFullProxy = 0 in springsettings.cfg i think it disables giving direct commands on the minimap but i dont use that anyway. can still use hotkey + command on minimap if you want to use it