### PR TITLE
Replays delete

### DIFF
--- a/LuaMenu/widgets/chili/skins/Evolved/skin.lua
+++ b/LuaMenu/widgets/chili/skins/Evolved/skin.lua
@@ -129,7 +129,7 @@ skin.option_button = {
 skin.negative_button = {
   TileImageBK = ":cl:tech_button_bright_small_bk.png",
   TileImageFG = ":cl:tech_button_bright_small_fg.png",
-  tiles = {20, 20, 20, 20}, --// tile widths: left,top,right,bottom
+  tiles = {40, 40, 40, 40}, --// tile widths: left,top,right,bottom: updated to match skin.action_button
   padding = {10, 10, 10, 10},
 
   backgroundColor = {0.85, 0.05, 0.25, 0.65},

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -49,6 +49,9 @@ return {
 		refresh = "Refresh",
 		rescan_files = "Rescan Files",
 		more = "More",
+		delete_replay = "Delete",
+		delete_replay_confirm = "Are you sure you want to delete this replay?",
+		replay_not_found = "Replay file not found, refresh the list!",
 		--
 		start_download = 'Start download',
 		download_noun = 'Download',
@@ -303,6 +306,9 @@ return {
 		refresh = "Neu laden",
 		rescan_files = "Dateien neu scannen",
 		more = "Mehr",
+		delete_replay = "Löschen",
+		delete_replay_confirm = "Dieses Replay geht verloren. Trotzdem löschen?",
+		replay_not_found = "Replay Datei nicht gefunden, die Liste neu laden!",
 		--
 		start_download = 'Download starten',
 		download_noun = 'Download',


### PR DESCRIPTION
Screenshots here: https://discord.com/channels/549281623154229250/549282587487502347/857016281826590761

1. Implemented manual deletion of replays. Refreshing the whole list after each delete is costly, and isn't easy to do (calling a function in a parent window from a child), so I ended up changing a map picture to a blank one for deleted replays, until the list is refreshed again.
2. Also added a check for replay file existence before playing it (the whole game was crashing before in this case).
3. I had to fix the margins on a negative_button style (red buttons in the UI) because it didn't match those of a skin.action_button, which was very visible when buttons were side-by-side.