### PR TITLE
Update replays UI for a different engine version

### DIFF
--- a/LuaMenu/widgets/chili/skins/Evolved/skin.lua
+++ b/LuaMenu/widgets/chili/skins/Evolved/skin.lua
@@ -116,7 +116,7 @@ skin.action_button = {
 skin.option_button = {
   TileImageBK = ":cl:tech_button_bright_small_bk.png",
   TileImageFG = ":cl:tech_button_bright_small_fg.png",
-  tiles = {20, 20, 20, 20}, --// tile widths: left,top,right,bottom
+  tiles = {40, 40, 40, 40}, --// tile widths: left,top,right,bottom: updated to match skin.action_button
   padding = {10, 10, 10, 10},
 
   backgroundColor = {0.70, 0.70, 0.75, 0.65},

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -52,6 +52,7 @@ return {
 		delete_replay = "Delete",
 		delete_replay_confirm = "Are you sure you want to delete this replay?",
 		replay_not_found = "Replay file not found, refresh the list!",
+		replay_different_version = "This replay requires a different engine version (will be downloaded automatically if necessary)",
 		--
 		start_download = 'Start download',
 		download_noun = 'Download',
@@ -309,6 +310,7 @@ return {
 		delete_replay = "Löschen",
 		delete_replay_confirm = "Dieses Replay geht verloren. Trotzdem löschen?",
 		replay_not_found = "Replay Datei nicht gefunden, die Liste neu laden!",
+		replay_different_version = "Dieses Replay erfordert eine andere Engine-Version (wird bei Bedarf automatisch heruntergeladen)",
 		--
 		start_download = 'Download starten',
 		download_noun = 'Download',

--- a/LuaMenu/widgets/gui_replay_handler.lua
+++ b/LuaMenu/widgets/gui_replay_handler.lua
@@ -339,6 +339,11 @@ local function CreateReplayEntry(
 		bottom = "55%",
 		width = "8%",
 		caption = i18n("start"),
+		tooltip = ternary(
+			WG.Chobby.Configuration:IsValidEngineVersion(engineName),
+			nil,
+			i18n("replay_different_version")
+		),
 		classname = ternary(
 			WG.Chobby.Configuration:IsValidEngineVersion(engineName),
 			"action_button",
@@ -366,11 +371,7 @@ local function CreateReplayEntry(
 		bottom = "10%",
 		width = "8%",
 		caption = i18n("delete_replay"),
-		classname = ternary(
-			WG.Chobby.Configuration:IsValidEngineVersion(engineName),
-			"negative_button",
-			"option_button"
-		),
+		classname = "negative_button",
 		font = WG.Chobby.Configuration:GetFont(2),
 		OnClick = {
 			function()


### PR DESCRIPTION
1. Update option_button style to match action_button and negative_button
2. Make Delete replay button always red, regardless of replay version
3. Add a tooltip to a Play button for replays from a different engine version