### PR TITLE
Fix UI not removing bonus when set to 0

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -520,11 +520,11 @@ local function UpdateUserBattleStatus(listener, userName)
 				data.imSyncStatus:Invalidate()
 			end
 			local battleStatus = data.lobby:GetUserBattleStatus(userName) or {}
-			local imageVisible = not battleStatus.isSpectator
+			local isPlaying = not battleStatus.isSpectator
 			if data.imTeamColor then
 				data.imTeamColor.color = battleStatus.teamColor
-				data.imTeamColor:SetVisibility(imageVisible)
-				if imageVisible then
+				data.imTeamColor:SetVisibility(isPlaying)
+				if isPlaying then
 					data.imTeamColor:Invalidate()
 				end
 			end
@@ -533,8 +533,8 @@ local function UpdateUserBattleStatus(listener, userName)
 				if sideSelected then
 					data.imSide.file = WG.Chobby.Configuration:GetSideById(battleStatus.side).logo
 				end
-				data.imSide:SetVisibility(imageVisible and sideSelected)
-				if imageVisible then
+				data.imSide:SetVisibility(isPlaying and sideSelected)
+				if isPlaying then
 					if data.imTeamColor == nil then
 						Spring.Echo("Warning: UpdateUserBattleStatus(): data.imTeamColor is nil for ", userName, battleStatus.isSpectator, battleStatus)
 					else
@@ -547,7 +547,6 @@ local function UpdateUserBattleStatus(listener, userName)
 				if handicap ~= nil then
 					local handicaptxt = ''
 					if battleStatus.handicap == 0 then
-
 						data.lblHandicap:SetVisibility(false)
 					else
 						if battleStatus.handicap > 0 then
@@ -559,9 +558,8 @@ local function UpdateUserBattleStatus(listener, userName)
 						data.lblHandicap:SetVisibility(true)
 					end
 				end
-				if imageVisible then
-					data.lblHandicap:SetVisibility(true)
-				else
+				if not isPlaying then
+					-- If the player is spectating, don't show handicap label regardless of its value.
 					data.lblHandicap:SetVisibility(false)
 				end
 				data.lblHandicap:Invalidate()


### PR DESCRIPTION
# Overview

Previously, when the player resets the bonus of a player (human or AI)
back to zero, the UI maintains the last selected bonus. This should fix
that bug, which was reported in #138 .

The reason for the bug was that the `UpdateUserBattleStatus` function
used to override the visibility status of the bonus (handicap) label
based on whether the user is playing or spectating. To elaborate, when
the bonus is set to zero, the function sets the visibility of the label
to false so nothing shows up. But then later in the code, the function
mistakenly reshows the label if the user is playing.

# Testing

I followed the instructions [here](https://github.com/beyond-all-reason/BYAR-Chobby#developing-the-lobby) to run the lobby locally. Before making the change, the bug is easily reproducible, whether playing alone or on a server. After the change, I covered the following scenarios:

1. Added myself as a player. Changed the bonus multiple times. When it is set to zero, the label of the bonus disappears as expected.
2. Added an AI and repeated the test. Again, the label disappears as expected when the bonus is set to 0.
3. Point 1 and 2 were tried for both, playing alone and in a server.
