### PR TITLE
Added two new Lobby Settings

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -235,6 +235,7 @@ function Configuration:init()
 	self.lobbyIdleSleep = false
 	self.rememberQueuesOnStart = false
 	self.showConnectAtStartup = true
+	self.confirmExit = true
 	self.channels = {}
 	if self.gameConfig.defaultChatChannels ~= nil then
 		for _, channelName in ipairs(self.gameConfig.defaultChatChannels) do
@@ -561,6 +562,7 @@ function Configuration:GetConfigData()
 		lobbyIdleSleep = self.lobbyIdleSleep,
 		rememberQueuesOnStart = self.rememberQueuesOnStart,
 		showConnectAtStartup = self.showConnectAtStartup,
+		confirmExit = self.confirmExit,
 		loadLocalWidgets = self.loadLocalWidgets,
 		activeDebugConsole = self.activeDebugConsole,
 		onlyShowFeaturedMaps = self.onlyShowFeaturedMaps,

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -234,6 +234,7 @@ function Configuration:init()
 	self.lastGameSpectatorState = false
 	self.lobbyIdleSleep = false
 	self.rememberQueuesOnStart = false
+	self.showConnectAtStartup = true
 	self.channels = {}
 	if self.gameConfig.defaultChatChannels ~= nil then
 		for _, channelName in ipairs(self.gameConfig.defaultChatChannels) do
@@ -559,6 +560,7 @@ function Configuration:GetConfigData()
 		lastGameSpectatorState = self.lastGameSpectatorState,
 		lobbyIdleSleep = self.lobbyIdleSleep,
 		rememberQueuesOnStart = self.rememberQueuesOnStart,
+		showConnectAtStartup = self.showConnectAtStartup,
 		loadLocalWidgets = self.loadLocalWidgets,
 		activeDebugConsole = self.activeDebugConsole,
 		onlyShowFeaturedMaps = self.onlyShowFeaturedMaps,

--- a/LuaMenu/widgets/chobby/components/interface_root.lua
+++ b/LuaMenu/widgets/chobby/components/interface_root.lua
@@ -374,6 +374,17 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 		return true
 	end
 
+	-- Note: this is separate, so we can constrain optionally displaying a quit confirmation
+	--       popup to just the Menu button, not the ESC key as well.
+	local function HandleExitButton()
+		-- only ask for confirmation if asked
+		if not WG.Chobby.Configuration.confirmExit == false then
+			MakeExitPopup()
+			return true
+		end
+		ExitSpring()
+	end
+
 	local buttons_exit = Button:New {
 		x = BUTTON_SIDE_SPACING,
 		bottom = 0,
@@ -382,7 +393,7 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 		caption = i18n("exit"),
 		font = Configuration:GetFont(3),
 		parent = buttonsHolder_buttons,
-		OnClick = {MakeExitPopup},
+		OnClick = {HandleExitButton},
 	}
 
 	-----------------------------------

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -191,7 +191,8 @@ return {
 		displayBots_tooltip = "Shows various bots (TS ranking bot SLDB, battleroom host bots, user account management bots) in the chat channels if you need to interacti with them (you dont, unless you are developing)",
 		filterbattleroom = "Filter bot chatter",
 		filterbattleroom_tooltip = "Battleroom management bots are quite verbose, enable this if you want to see every debug message that the bots do (for SPADS)",
-
+		showConnectAtStartup = "Show Connect Window at Startup",
+		showConnectAtStartup_tooltip = "Whether to automatically display the Connect Window on startup.",
 
 		-- chat_windows.lua
 		server = "Server",

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -193,6 +193,8 @@ return {
 		filterbattleroom_tooltip = "Battleroom management bots are quite verbose, enable this if you want to see every debug message that the bots do (for SPADS)",
 		showConnectAtStartup = "Show Connect Window at Startup",
 		showConnectAtStartup_tooltip = "Whether to automatically display the Connect Window on startup.",
+		confirmExit = "Ask for Confirmation when Exiting",
+		confirmExit_tooltip = "Whether to ask for confirmation first after clicking the main Exit button.",
 
 		-- chat_windows.lua
 		server = "Server",

--- a/LuaMenu/widgets/gui_login_window.lua
+++ b/LuaMenu/widgets/gui_login_window.lua
@@ -1,0 +1,262 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function widget:GetInfo()
+	return {
+		name      = "Login Window",
+		desc      = "Handles login and registration.",
+		author    = "GoogleFrog",
+		date      = "4 July 2016",
+		license   = "GNU LGPL, v2.1 or later",
+		layer     = 0,
+		enabled   = true  --  loaded by default?
+	}
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- Local Variables
+
+local registerName, registerPassword, registerEmail
+
+local currentLoginWindow
+local loginAcceptedFunction
+
+local registerRecieved = false
+
+-- WG interface
+local LoginWindowHandler = {}
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- Initialization
+
+local function ResetRegisterRecieved()
+	registerRecieved = false
+end
+
+local function MultiplayerFailFunction()
+	WG.Chobby.interfaceRoot.GetMainWindowHandler().SetBackAtMainMenu()
+end
+
+local wantLoginStatus = {
+	["offline"] = true,
+	["closed"] = true,
+	["disconnected"] = true,
+}
+
+local function GetNewLoginWindow(failFunc)
+	if currentLoginWindow and currentLoginWindow.window then
+		currentLoginWindow.window:Dispose()
+		currentLoginWindow = nil
+	end
+	local Configuration = WG.Chobby.Configuration
+	local steamMode = Configuration.canAuthenticateWithSteam and Configuration.wantAuthenticateWithSteam
+	Spring.Echo("steamMode", Configuration.canAuthenticateWithSteam, Configuration.wantAuthenticateWithSteam)
+	emailRequired = (WG.Server.protocol == "spring")
+	if steamMode then
+		currentLoginWindow = WG.Chobby.SteamLoginWindow(failFunc, nil, "main_window")
+	else
+		currentLoginWindow = WG.Chobby.LoginWindow(failFunc, nil, "main_window", {loginAfterRegister = true, emailRequired = emailRequired})
+	end
+	return currentLoginWindow
+end
+
+local function TrySimpleSteamLogin()
+	local Configuration = WG.Chobby.Configuration
+	if not (Configuration.steamLinkComplete and Configuration.canAuthenticateWithSteam and Configuration.wantAuthenticateWithSteam) then
+		return false
+	end
+	if lobby.connected then
+		lobby:Login(Configuration.userName, Configuration.password, 3, nil, "Chobby", true)
+	else
+		lobby:Connect(Configuration:GetServerAddress(), Configuration:GetServerPort(), Configuration.userName, Configuration.password, 3, nil, "Chobby")
+	end
+	return true
+end
+
+local function TrySimpleLogin()
+	local Configuration = WG.Chobby.Configuration
+	if lobby.connected then
+		lobby:Login(Configuration.userName, Configuration.password, 3, nil, "Chobby")
+	else
+		lobby:Connect(Configuration:GetServerAddress(), Configuration:GetServerPort(), Configuration.userName, Configuration.password, 3, nil, "Chobby")
+	end
+end
+
+local function CheckAutologin()
+	local UserCountLimited = WG.CommunityWindow.LoadStaticCommunityData().UserCountLimited
+	if UserCountLimited then
+		Spring.Echo("No automatic login - UserCountLimited")
+		return
+	end
+	local Configuration = WG.Chobby.Configuration
+	if not TrySimpleSteamLogin() then
+		if Configuration.autoLogin and Configuration.userName then
+			TrySimpleLogin()
+		end
+	end
+end
+
+local function CheckFirstTimeRegister()
+	local UserCountLimited = WG.CommunityWindow.LoadStaticCommunityData().UserCountLimited
+	if UserCountLimited then
+		Spring.Echo("No automatic login - UserCountLimited")
+		return
+	end
+	local Configuration = WG.Chobby.Configuration
+	if Configuration.firstLoginEver and Configuration.showConnectAtStartup then
+		LoginWindowHandler.TryLogin()
+	end
+end
+
+local function InitializeListeners()
+	local Configuration = WG.Chobby.Configuration
+
+	-- Register and login response codes
+	local function OnRegistrationAccepted()
+		WG.Analytics.SendOnetimeEvent("lobby:account_created")
+		if currentLoginWindow then
+			registerRecieved = true
+			WG.Delay(ResetRegisterRecieved, 0.8)
+			currentLoginWindow.txtError:SetText(Configuration:GetSuccessColor() .. "Registered!")
+		end
+	end
+
+	local function OnRegistrationDenied(listener, err, accountAlreadyExists)
+		WG.Analytics.SendErrorEvent(err or "unknown")
+
+		if Configuration.canAuthenticateWithSteam and Configuration.wantAuthenticateWithSteam then
+			Configuration.steamLinkComplete = true
+		end
+
+		if currentLoginWindow then
+			if accountAlreadyExists and currentLoginWindow.ShowPassword then
+				currentLoginWindow:ShowPassword()
+			end
+			registerRecieved = true
+			WG.Delay(ResetRegisterRecieved, 0.8)
+			currentLoginWindow.txtError:SetText(Configuration:GetErrorColor() .. (err or "Unknown Error"))
+		end
+	end
+
+	local function OnLoginAccepted()
+		Configuration.firstLoginEver = false
+		WG.Analytics.SendOnetimeEvent("lobby:logged_in")
+
+		if Configuration.canAuthenticateWithSteam and Configuration.wantAuthenticateWithSteam then
+			Configuration.steamLinkComplete = true
+		end
+
+		if currentLoginWindow and currentLoginWindow.window then
+			currentLoginWindow.window:Dispose()
+		end
+		for channelName, _ in pairs(Configuration:GetChannels()) do
+			lobby:Join(channelName)
+		end
+
+		lobby:IgnoreList()
+
+		if loginAcceptedFunction then
+			loginAcceptedFunction()
+		end
+	end
+
+	local function OnLoginDenied(listener, err)
+		WG.Analytics.SendErrorEvent(err or "unknown")
+		lobby:Disconnect()
+		if currentLoginWindow and not registerRecieved then
+			currentLoginWindow.txtError:SetText(Configuration:GetErrorColor() .. (err or "Denied, unknown reason"))
+		end
+
+		if Configuration.steamLinkComplete and Configuration.canAuthenticateWithSteam and Configuration.wantAuthenticateWithSteam then
+			-- Something failed so prompt re-register
+			Configuration.steamLinkComplete = false
+		end
+
+		if not (currentLoginWindow and currentLoginWindow.window) then
+			local loginWindow = GetNewLoginWindow()
+			local popup = WG.Chobby.PriorityPopup(loginWindow.window, loginWindow.CancelFunc, loginWindow.AcceptFunc)
+		end
+	end
+
+	lobby:AddListener("OnRegistrationAccepted", OnRegistrationAccepted)
+	lobby:AddListener("OnRegistrationDenied", OnRegistrationDenied)
+	lobby:AddListener("OnAccepted", OnLoginAccepted)
+	lobby:AddListener("OnDenied", OnLoginDenied)
+
+	-- Stored register on connect
+	local function OnConnect()
+		WG.Analytics.SendOnetimeEvent("lobby:server_connect")
+		local steamMode = Configuration.canAuthenticateWithSteam and Configuration.wantAuthenticateWithSteam
+		if registerName then
+			WG.Analytics.SendOnetimeEvent("lobby:send_register")
+			lobby:Register(registerName, registerPassword, registerEmail, steamMode)
+			Configuration.userName = registerName
+			Configuration.password = registerPassword
+			registerName = nil
+		end
+		if Configuration.userName then
+			lobby:Login(Configuration.userName, Configuration.password, 3, nil, "Chobby", steamMode)
+		end
+	end
+
+	lobby:AddListener("OnConnect", OnConnect)
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- External Functions
+
+function LoginWindowHandler.QueueRegister(name, password, email)
+	registerName = name
+	registerPassword = password
+	registerEmail = email
+end
+
+function LoginWindowHandler.TryLoginMultiplayer(name, password)
+	if wantLoginStatus[lobby:GetConnectionStatus()] then
+		if not TrySimpleSteamLogin() then
+			local loginWindow = GetNewLoginWindow(MultiplayerFailFunction)
+			local popup = WG.Chobby.PriorityPopup(loginWindow.window, loginWindow.CancelFunc, loginWindow.AcceptFunc)
+		end
+	end
+end
+
+function LoginWindowHandler.TryLogin(newLoginAcceptedFunction)
+	loginAcceptedFunction = newLoginAcceptedFunction
+	if not TrySimpleSteamLogin() then
+		local loginWindow = GetNewLoginWindow()
+		local popup = WG.Chobby.PriorityPopup(loginWindow.window, loginWindow.CancelFunc, loginWindow.AcceptFunc)
+	end
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- Widget Interface
+
+function widget:Initialize()
+	CHOBBY_DIR = LUA_DIRNAME .. "widgets/chobby/"
+	VFS.Include(LUA_DIRNAME .. "widgets/chobby/headers/exports.lua", nil, VFS.RAW_FIRST)
+
+	LoginWindowHandler.TrySimpleSteamLogin = TrySimpleSteamLogin
+
+	WG.Delay(InitializeListeners, 0.1)
+	WG.LoginWindowHandler = LoginWindowHandler
+end
+
+function widget:Update()
+	WG.Delay(CheckAutologin, 1.5)
+	WG.Delay(CheckFirstTimeRegister, 1.8)
+	widgetHandler:RemoveCallIn("Update")
+end
+
+function widget:Shutdown()
+	lobby:RemoveListener("BattleAboutToStart", onBattleAboutToStart)
+	if WG.LibLobby then
+		WG.LibLobby.localLobby:RemoveListener("BattleAboutToStart", onBattleAboutToStart)
+	end
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------

--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -939,6 +939,7 @@ local function GetLobbyTabControls()
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("displayBots"), "displayBots", false, nil, i18n("displayBots_tooltip") )
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("filterbattleroom"), "filterbattleroom", true, nil, i18n("filterbattleroom_tooltip"))
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("showConnectAtStartup"), "showConnectAtStartup", true, nil, i18n("showConnectAtStartup_tooltip"))
+	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("confirmExit"), "confirmExit", true, nil, i18n("confirmExit_tooltip"))
 
 	--children[#children + 1], offset = AddCheckboxSetting(offset, i18n("keep_queues"), "rememberQueuesOnStart", false, nil, "Stay in matchmaker queues when a battle is launched.")
 

--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -32,7 +32,7 @@ local ITEM_OFFSET = 38
 
 local COMBO_X = 280
 local COMBO_WIDTH = 235
-local CHECK_WIDTH = 280
+local CHECK_WIDTH = 300
 local TEXT_OFFSET = 6
 
 local settingsWindowHandler
@@ -938,6 +938,7 @@ local function GetLobbyTabControls()
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("fixFlicker"), "fixFlicker", true, nil, i18n("fixFlicker_tooltip"))
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("displayBots"), "displayBots", false, nil, i18n("displayBots_tooltip") )
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("filterbattleroom"), "filterbattleroom", true, nil, i18n("filterbattleroom_tooltip"))
+	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("showConnectAtStartup"), "showConnectAtStartup", true, nil, i18n("showConnectAtStartup_tooltip"))
 
 	--children[#children + 1], offset = AddCheckboxSetting(offset, i18n("keep_queues"), "rememberQueuesOnStart", false, nil, "Stay in matchmaker queues when a battle is launched.")
 


### PR DESCRIPTION
Added two new Lobby settings to control whether to:
1: Display the connect window on start-up
2: Whether to display the confirmation message box when clicking the Exit button.

Both of these settings default to true, so functionality as-is, should be identical to how it is currently.

For 1, I had to copy LuaMenu/widgets/gui_login_window.lua from Chobby.lua, and for 2 I specialised the code so that even if this setting enabled, pressing ESC (which is easy to do mistakenly) will still always ask for confirmation.

I had to widen the width of the checkboxes for the text titles I chose, but they still take up less width than the sliders above them.