### PR TITLE
Fixes for Ready Button: Ingame, Join Battle, Unspec, Singleplayer

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -923,7 +923,7 @@ local function GetUserControls(userName, opts)
 			keepAspect = true,
 			file = GetUserReadyStatus(userName, userControls),
 		}
-		userControls.imReadyStatus:SetVisibility(false)
+		userControls.imReadyStatus:SetVisibility(not lobby:GetUserBattleStatus(userName).isSpectator)
 		offset = offset + 21
 	end
 

--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -535,7 +535,7 @@ local function UpdateUserBattleStatus(listener, userName)
 			local battleStatus = data.lobby:GetUserBattleStatus(userName) or {}
 			local isPlaying = not battleStatus.isSpectator
 
-			if data.imReadyStatus then
+			if data.imReadyStatus and not isSingleplayer then
 				data.imReadyStatus.file = GetUserReadyStatus(userName, data)
 				data.imReadyStatus:SetVisibility(isPlaying)
 				if isPlaying then
@@ -911,7 +911,7 @@ local function GetUserControls(userName, opts)
 		offset = offset + 21
 	end
 
-	if isInBattle then
+	if isInBattle and not isSingleplayer then
 		offset = offset + 1
 		userControls.imReadyStatus = Image:New {
 			name = "imReadyStatus",
@@ -921,7 +921,7 @@ local function GetUserControls(userName, opts)
 			height = 19,
 			parent = userControls.mainControl,
 			keepAspect = true,
-			file = GetUserSyncStatus(userName, userControls),
+			file = GetUserReadyStatus(userName, userControls),
 		}
 		userControls.imReadyStatus:SetVisibility(false)
 		offset = offset + 21

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -734,24 +734,26 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		parent = rightInfo,
 	}
 
-	readyButton = Button:New {
-		x = 0,
-		bottom = 102,
-		right = 0,
-		height = 48,
-		caption = "", -- Set in OnUpdateUserBattleStatus
-		classname = "ready_button",
-		font = config:GetFont(4),
-		tooltip = "", -- Set in OnUpdateUserBattleStatus
-		OnClick = {
-			function()
-				local newReady = not battleLobby.userBattleStatus[battleLobby.myUserName].isReady
-				battleLobby:SetBattleStatus({ isReady = newReady })
-			end
-		},
-		parent = rightInfo,
-	}
-	readyButton:SetVisibility(false)
+	if battleLobby.name ~= "singleplayer" then
+		readyButton = Button:New {
+			x = 0,
+			bottom = 102,
+			right = 0,
+			height = 48,
+			caption = "", -- Set in OnUpdateUserBattleStatus
+			classname = "ready_button",
+			font = config:GetFont(4),
+			tooltip = "", -- Set in OnUpdateUserBattleStatus
+			OnClick = {
+				function()
+					local newReady = not battleLobby.userBattleStatus[battleLobby.myUserName].isReady
+					battleLobby:SetBattleStatus({ isReady = newReady })
+				end
+			},
+			parent = rightInfo,
+		}
+		readyButton:SetVisibility(false)
+	end
 
 	local btnPlay
 	local btnSpectate = Button:New {
@@ -792,6 +794,7 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 				--Spring.Echo("unusedTeamID",unusedTeamID)
 				battleLobby:SetBattleStatus({
 					isSpectator = false,
+					isReady = false,
 					side = (WG.Chobby.Configuration.lastFactionChoice or 0),
 					teamNumber = unusedTeamID})
 				ButtonUtilities.SetButtonDeselected(btnSpectate)
@@ -2830,7 +2833,7 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 
 	-- Lobby interface
 	local function OnUpdateUserBattleStatus(listener, username, status)
-		if username == battleLobby.myUserName then
+		if battleLobby.name ~= "singleplayer" and username == battleLobby.myUserName then
 			readyButton:SetVisibility(not status.isSpectator)
 
 			if status.isReady then
@@ -3235,6 +3238,7 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		--Spring.Echo("OnRequestBattleStatus, wespecnow?:",wespecnow,WG.Chobby.Configuration.lastGameSpectatorState)
 		battleLobby:SetBattleStatus({
 			isSpectator = wespecnow,
+			isReady = false,
 			side = (WG.Chobby.Configuration.lastFactionChoice or 0) ,
 			sync = (haveMapAndGame and 1) or 2, -- 0 = unknown, 1 = synced, 2 = unsynced
 			-- tamColor = PickRandomColor()

--- a/LuaMenu/widgets/gui_chili_lobby.lua
+++ b/LuaMenu/widgets/gui_chili_lobby.lua
@@ -102,6 +102,7 @@ function widget:Initialize()
 
 	local function OnBattleAboutToStart()
 		lobby:SetIngameStatus(true)
+		lobby:SetBattleStatus({ isReady = false })
 	end
 	WG.LibLobby.localLobby:AddListener("OnBattleAboutToStart", OnBattleAboutToStart)
 	WG.LibLobby.lobby:AddListener("OnBattleAboutToStart", OnBattleAboutToStart)


### PR DESCRIPTION
Sets unready on ingame, join battle, & unspec
Hides related interface elements for singleplayer, where ready is redundant.