### PR TITLE
Scaling max/min updates on `ViewResize()`

### DIFF
--- a/LuaMenu/widgets/gfx_resize_scaling.lua
+++ b/LuaMenu/widgets/gfx_resize_scaling.lua
@@ -12,6 +12,7 @@ end
 
 function widget:ViewResize()
     if WG.Chobby and WG.Chobby.Configuration then
+		WG.Chobby.Configuration:UpdateUiScaleMaxMin()
         WG.Chobby.Configuration:SetUiScale()
     end
 end

--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -875,6 +875,9 @@ local function GetLobbyTabControls()
 	Configuration:AddListener("OnUiScaleChange", function(_, newScale)
 		uiScaleTrackbar:SetValue(newScale * 100.0)
 	end)
+	Configuration:AddListener("OnUiScaleMaxMinChange", function(_, newMin, newMax)
+		uiScaleTrackbar:SetMinMax(newMin * 100.0, newMax * 100.0)
+	end)
 
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("autoLaunchAsSpectator"), "autoLaunchAsSpectator", true)
 


### PR DESCRIPTION
Adds `OnUiScaleMaxMinChange` event to the configuration object.
Also changes the min cap to font size 7, not 6 - font size 6 is either unreadable, or won't render altogether.