### PR TITLE
Change up ready button again and add a tooltip for when spectating

### DIFF
--- a/LuaMenu/widgets/chili/skins/Armada Blues/skin.lua
+++ b/LuaMenu/widgets/chili/skins/Armada Blues/skin.lua
@@ -132,21 +132,16 @@ skin.ready_button = {
   TileImageFG = ":cl:tech_button_bright_small_fg.png",
   tiles = {40, 40, 40, 40},--// tile widths: left,top,right,bottom
   padding = {10, 10, 10, 10},
-
   StyleReady = function(self)
-    TileImageBK = ":cl:tech_button_bright_small_bk.png"
-    TileImageFG = ":cl:tech_button_bright_small_fg.png"
     self.backgroundColor = {1.0, 1.0, 0.55, 0.75}
     self.focusColor  = {0.1, 1.0, 0.1, 1.0}
     self.borderColor = {0.0, 1.0, 0.0, 0.67}
     self:Invalidate()
   end,
   StyleUnready = function(self)
-    TileImageBK = ":cl:tech_button_bright_small_bk_grey.png"
-    TileImageFG = ":cl:tech_button_bright_small_fg.png"
-    self.backgroundColor = {0.9, 0.8, 0.55, 0.75}
-    self.focusColor  = {0.9, 0.8, 0.1, 1.0}
-    self.borderColor = {0.9, 0.8, 0.0, 0.67}
+    self.backgroundColor = {0.3, 0.3, 0.3, 0.75}
+    self.focusColor  = {0.8, 0.8, 0.8, 1.0}
+    self.borderColor = {0.8, 0.8, 0.8, 0.67}
     self:Invalidate()
   end,
 

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -206,7 +206,7 @@ return {
 		ready_tooltip = "Click to become unready. This will prevent the game from starting!",
 		unready = "Unready",
 		unready_tooltip = "Click to become ready. If you're not ready, the game can't start!",
-		unready_notplaying_tooltip = "You can't become Ready as you are Spectating. Press Play to join the game.",
+		unready_notplaying_tooltip = "You can't become ready as you are spectating. Press play to join the game.",
 
 		-- chat_windows.lua
 		server = "Server",

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -204,8 +204,9 @@ return {
 
 		ready = "Ready",
 		ready_tooltip = "Click to become unready. This will prevent the game from starting!",
-		unready = "Ready?",
+		unready = "Unready",
 		unready_tooltip = "Click to become ready. If you're not ready, the game can't start!",
+		unready_notplaying_tooltip = "You can't become Ready as you are Spectating. Press Play to join the game.",
 
 		-- chat_windows.lua
 		server = "Server",

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -2897,9 +2897,13 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 				readyButton:StyleReady()
 				readyButton:SetCaption(i18n("ready"))
 				readyButton.tooltip = i18n("ready_tooltip")
+			elseif status.isSpectator then
+				readyButton:StyleUnready()
+				readyButton:SetCaption(i18n("ready"))
+				readyButton.tooltip = i18n("unready_notplaying_tooltip")
 			else
 				readyButton:StyleUnready()
-				readyButton:SetCaption(i18n("unready"))
+				readyButton:SetCaption(i18n("ready"))
 				readyButton.tooltip = i18n("unready_tooltip")
 			end
 		end


### PR DESCRIPTION
![Screenshot_269](https://user-images.githubusercontent.com/1368663/188763742-f917dcdf-75f1-456d-8d47-d5fa4a3f6f4a.png)
![](https://cdn.discordapp.com/attachments/549282587487502347/1016871113285967964/Screenshot_272.png)
![Screenshot_270](https://user-images.githubusercontent.com/1368663/188763815-1471006e-f30e-4202-9ef3-c0f0fe729fc2.png)
![Screenshot_271](https://user-images.githubusercontent.com/1368663/188763926-2d0a34a9-0723-4700-80e3-1a4e91d3fd97.png)

Active/Ready is the same green as start
