### PR TITLE
Fix typo in scavenger game length setting display string

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/byar/ModOptions.lua
@@ -214,7 +214,7 @@ local options={
 	},
 	{
 		key    = 'scavtechcurve',
-		name   = 'Game Lenght Multiplier',
+		name   = 'Game Length Multiplier',
 		desc   = 'Higher than 1 - Longer, Lower than 1 - Shorter',
 		type   = 'number',
 		section= 'options_scavengers',


### PR DESCRIPTION
In line with https://github.com/beyond-all-reason/Beyond-All-Reason/pull/1226.
