### PR TITLE
Intial download from archive and config URL

### DIFF
--- a/.github/workflows/publish_config.yml
+++ b/.github/workflows/publish_config.yml
@@ -1,0 +1,20 @@
+name: Publish launcher config.json
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  publish_config:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Publish config.json
+        run: |
+          curl --fail-with-body \
+            --request PUT \
+            --header "Content-Type: application/json" \
+            --header "AccessKey: $ACCESS_KEY" \
+            --upload-file dist_cfg/config.json \
+            https://bar-config.p2004a.com/config.json
+        env:
+          ACCESS_KEY: ${{ secrets.LAUNCHER_CONFIG_PUSH_ACCESS_KEY }}

--- a/dist_cfg/config.json
+++ b/dist_cfg/config.json
@@ -17,6 +17,11 @@
                 "games": ["byar:test", "chobby:test", "byar-chobby:test"],
                 "resources": [
                     {
+                        "url": "https://bar-springfiles-data.p2004a.com/init-pool.7z",
+                        "destination": "pool",
+                        "extract": true
+                    },
+                    {
                         "url": "https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D105.1.1-1214-gcf8d087/spring_bar_.BAR105.105.1.1-1214-gcf8d087_linux-64-minimal-portable.7z",
                         "destination": "engine/105.1.1-1214-gcf8d087 bar",
                         "extract": true
@@ -49,6 +54,11 @@
             "downloads": {
                 "games": ["byar:test", "chobby:test", "byar-chobby:test"],
                 "resources": [
+                    {
+                        "url": "https://bar-springfiles-data.p2004a.com/init-pool.7z",
+                        "destination": "pool",
+                        "extract": true
+                    },
                     {
                         "url": "https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D105.1.1-1214-gcf8d087/spring_bar_.BAR105.105.1.1-1214-gcf8d087_windows-64-minimal-portable.7z",
                         "destination": "engine/105.1.1-1214-gcf8d087 bar",

--- a/dist_cfg/config.json
+++ b/dist_cfg/config.json
@@ -7,6 +7,7 @@
                 "display": "Alpha",
                 "platform": "linux"
             },
+            "config_url": "https://bar-config.p2004a.com/config.json",
             "env_variables": {
                 "PRD_HTTP_SEARCH_URL": "https://bar-springfiles.p2004a.com/find",
                 "PRD_RAPID_USE_STREAMER": "false",
@@ -38,6 +39,7 @@
                 "display": "Alpha",
                 "platform": "win32"
             },
+            "config_url": "https://bar-config.p2004a.com/config.json",
             "env_variables": {
                 "PRD_HTTP_SEARCH_URL": "https://bar-springfiles.p2004a.com/find",
                 "PRD_RAPID_USE_STREAMER": "false",
@@ -70,6 +72,7 @@
                 "display": "Alpha (no CDN)",
                 "platform": "linux"
             },
+            "config_url": "https://bar-config.p2004a.com/config.json",
             "downloads": {
                 "games": ["byar:test", "chobby:test", "byar-chobby:test"],
                 "resources": [
@@ -96,6 +99,7 @@
                 "display": "Alpha (no CDN)",
                 "platform": "win32"
             },
+            "config_url": "https://bar-config.p2004a.com/config.json",
             "silent": false,
             "downloads": {
                 "games": ["byar:test", "chobby:test", "byar-chobby:test"],


### PR DESCRIPTION
Two changes that I would like to release.

One is not controvesial: initial content of the pool is being downloaded from a weekly rebuild https://bar-springfiles-data.p2004a.com/init-pool.7z archive. The main purpose of that is cost saving from CDN and it shouldn't impact reliability of downloads.

The second one, setting `config_url` is more controversial. With this setting set, launcher on update will first download `config.json` from https://bar-config.p2004a.com/config.json and compare with existing config. If they are the same, continues, if they are not, launcher updates config.json and relaunches.

Using `config_url` allows for quicker updates of config:
- in case e.g. of engine updates no need to reinstall
- allows to e.g. create temporarily a new option in launcher with a test engine version for easier testing
- no longer need to run flatpak update to update engine (we had confused users because of that)

Disadvantages are:
- additional round-trip on start: It is quite quick, IMHO quite negligible.
- bad update of config.json on that URL can brick game install: The config update functionality will be guarded by tests that ensure it's safe. (I've not yet written that code, but it's not much: make sure json parses, title matches, config_urls are fine so it can be updated etc.