### PR TITLE
Remove non-functioning random faction

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/sidedata.lua
+++ b/LuaMenu/configs/gameConfig/byar/sidedata.lua
@@ -9,8 +9,4 @@ return {
 		name = "Cortex",
 		logo = SIDEPICS_DIR .. "cortex.png",
 	},
-	{
-		name = "Random",
-		logo = SIDEPICS_DIR .. "random.png",
-	},
 }


### PR DESCRIPTION
Currently choosing the Random faction in lobby makes the user unable to ready up. I don't know how to fix this. Unless someone does then this broken option should be removed from the faction chooser, which this PR does.