### PR TITLE
Fix half-sized start button in singleplayer after loading multiplayer

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -772,7 +772,7 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 	end
 
 	btnStartBattle = Button:New {
-		x = ((readyButton == nil) and 0 or "50.5%"),
+		x = ((battleLobby.name == "singleplayer") and 0 or "50.5%"),
 		right = 0,
 		bottom = 0,
 		height = 48,


### PR DESCRIPTION
This is a 1loc change that fixes the bug wherein after the start button being scaled to half-size to accommodate the ready button it will not rescale to full-size again.

You can test this by loading skirmish panel, then loading the multiplayer battle panel once, then going back to the skirmish panel.