### PR TITLE
ONREMOVEUSER also remove user from all channels

### DIFF
--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -540,6 +540,9 @@ Interface.commands["ADDUSER"] = Interface._OnAddUser
 Interface.commandPattern["ADDUSER"] = "(%S+)%s+(%S%S%-?%S?%S?%S?)%s+(%S+)%s*(.*)"
 
 function Interface:_OnRemoveUser(userName)
+	for channelName, _ in pairs(self:GetChannels()) do
+		self:_OnLeft(channelName, userName, "")
+	end
 	self:super("_OnRemoveUser", userName)
 end
 Interface.commands["REMOVEUSER"] = Interface._OnRemoveUser


### PR DESCRIPTION
This should fix chobby showing already disconnected users.

On chobby repo, this is not done in interface_shared.lua, which is the base of byar-chobby interface.lua

See chobby repo interface_zerok.lua function Interface:_UserDisconnected(data)
https://github.com/Spring-Chobby/Chobby/blob/33ebb37b0271726e4679c85df9f975003730ab09/libs/liblobby/lobby/interface_zerok.lua#L883-L885
Here it´s done on UserDisconnected event.

When we don´t want to touch chobby repo, best place should be here in byar-chobby´s interface.lua