### PR TITLE
Update gui_battle_room_window.lua

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1771,6 +1771,13 @@ local function SetupPlayerPanel(playerParent, spectatorParent, battle, battleID)
 							end
 							if teamIndex == maxTeam then
 								teamData.RemoveTeam()
+								-- because it's only possible to remove the team on top of stack
+								-- we need to check, if next team on stack must also be removed
+								-- but always stay with 2 visible teams minimum: teamIndex 0 and 1
+								if (teamIndex-1 > 1) then
+									local teamObject = GetTeam(teamIndex-1)
+									teamObject.CheckRemoval()
+								end
 								return true
 							end
 						end


### PR DESCRIPTION
Background:
Number of users in teams are updated by a servermessage, which send the current state of a user.
After a user is removed from a team, the function checkRemoval will remove the team **only if it´s on top of team stack.**
So, if we get updates, that lead to an empty team, which is not on top of stack, it won´t be removed and stays empty in battle room.

Solution:
When top team of teamstack is empty and can be removed, also check next team on stack, if it can be removed.