### PR TITLE
OnUpdateBot stop overwriting owner by nil

### DIFF
--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -881,9 +881,11 @@ function Interface:_OnUpdateBot(battleID, name, battleStatus, teamColor)
 	battleID = tonumber(battleID)
 	local status = ParseBattleStatus(battleStatus)
 	status.teamColor = ParseTeamColor(teamColor)
-	-- local ai, dll = unpack(explode("\t", aiDll)))
-	status.aiLib = aiDll
-	status.owner = owner
+
+	-- add owner to status to tell lobby:OnUpdateUserBattleStatus that it´s a bot
+	if self.userBattleStatus[name] and self.userBattleStatus[name].owner ~= nil then
+			status.owner = self.userBattleStatus[name].owner
+	end
 	self:_OnUpdateUserBattleStatus(name, status)
 end
 Interface.commands["UPDATEBOT"] = Interface._OnUpdateBot

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -881,11 +881,6 @@ function Interface:_OnUpdateBot(battleID, name, battleStatus, teamColor)
 	battleID = tonumber(battleID)
 	local status = ParseBattleStatus(battleStatus)
 	status.teamColor = ParseTeamColor(teamColor)
-
-	-- add owner to status to tell lobby:OnUpdateUserBattleStatus that it´s a bot
-	if self.userBattleStatus[name] and self.userBattleStatus[name].owner ~= nil then
-			status.owner = self.userBattleStatus[name].owner
-	end
 	self:_OnUpdateUserBattleStatus(name, status)
 end
 Interface.commands["UPDATEBOT"] = Interface._OnUpdateBot


### PR DESCRIPTION
Maybe and old copy/paste error in OnUpdateBot

Spring protocol doesn´t provide owner nor aiLib on Servermessage **onUpdateBot**

The info about owner and ailib is provided by **AddBot** Servermessage before.

Prior implementation was overwriting already known owner and ailib on each UpdateBot Servermessage.

This fix checks if the 2 properties are already known and puts them into status. This enables OnUpdateUserBattleStatus to recognize a botupdate.