### PR TITLE
FixBattleTooltip and ApplyConfigsDirectly and fix StatusImages and UncertaintyOptional

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -116,7 +116,7 @@ function Configuration:init()
 	}
 
 	self.showRank    = true
-	self.showSkill   = false
+	self.showSkillOpt = 1 -- 1: No 2: Yes 3: Detailed (with Uncertainty)
 	self.showCountry = false
 
 	self.loadLocalWidgets = false
@@ -655,6 +655,7 @@ function Configuration:GetConfigData()
 		steamReleasePopupSeen = self.steamReleasePopupSeen,
 		campaignConfigName = self.campaignConfigName,
 		showSkill   = self.showSkill,
+		showSkillOpt   = self.showSkillOpt,
 		showRank    = self.showRank,
 		showCountry = self.showCountry,
 	}

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -203,11 +203,11 @@ return {
 		filterbattleroom_tooltip = "Battleroom management bots are quite verbose, enable this if you want to see every debug message that the bots do (for SPADS)",
 
 		showRank = "Show rank icons",
-		showRanktooltip = "Requires a restart, Displays the rank icon next to the players name in the battleroom",
+		showRanktooltip = "Displays the rank icon next to the players name in the battleroom",
 		showSkill = "Show OpenSkill values",
-		showSkilltooltip = "Requires a restart, Displays the OpenSkill value next to the players name in the battleroom",
+		showSkillOpttooltip = "Displays the OpenSkill value next to the players name in the battleroom. On Detailed OS-uncertainty is reflected by color saturation of OS-value.",
 		showCountry = "Show country flags",
-		showCountrytooltip = "Requires a restart, Displays the country flag next to the players name in the battleroom",
+		showCountrytooltip = "Displays the country flag next to the players name in the battleroom",
 
 		-- gui_battle_room_window.lua
 

--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -887,10 +887,47 @@ local function GetLobbyTabControls()
 	end)
 
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("autoLaunchAsSpectator"), "autoLaunchAsSpectator", true)
-
-	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("showRank"), "showRank", true, nil, i18n("showRanktooltip"))
-	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("showSkill"), "showSkill", true, nil, i18n("showSkilltooltip"))
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("showCountry"), "showCountry", true, nil, i18n("showCountrytooltip"))
+	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("showRank"), "showRank", true, nil, i18n("showRanktooltip"))
+	children[#children + 1] = Label:New {
+		x = 20,
+		y = offset + TEXT_OFFSET,
+		width = 90,
+		height = 40,
+		valign = "top",
+		align = "left",
+		objectOverrideFont = settingsFont2,
+		caption = i18n("showSkill"),
+	}
+	local showSkillOptions = {"No", "Yes", "Detailed"}
+	local selectedShowSkillOption = 1
+	for k,v in ipairs(showSkillOptions) do
+		if v == Configuration.showSkillOpt then
+			selectedShowSkillOption = k
+		end
+	end
+
+	children[#children + 1] = ComboBox:New {
+		x = COMBO_X,
+		y = offset,
+		width = COMBO_WIDTH,
+		right = 18,
+		height = 30,
+		items = {"No", "Yes", "Detailed"},
+		objectOverrideFont = settingsFont2,
+		itemFontSize = Configuration:GetFont(2).size,
+		selected = Configuration.showSkillOpt or 1,
+		OnSelect = {
+			function (obj)
+				if freezeSettings then
+					return
+				end
+				Configuration:SetConfigValue("showSkillOpt", obj.selected)
+			end
+		},
+		tooltip = i18n("showSkillOpttooltip"),
+	}
+	offset = offset + ITEM_OFFSET
 
 	local randomSkirmishOption = Spring.GetConfigInt("randomSkirmishSetup", 1)
 	if randomSkirmishOption == 1 then


### PR DESCRIPTION
- show rank and country in tooltip of battle according to user´s preferences
- apply user´s perferences of showCountry, showRank, shoeSkillOpt without restart
- show rank for spectators as well - this was necessary to show rank in battle´s tooltip
- rearrange statusimages right of userName after battleStatusUpdate and configuration change correctly
- changed configuration option showSkil to showSkillOpt allowing 3 options: no, yes, detailed (detailed=saturation of skill color reflects uncertainty)
- i18n texts adjusted