### PR TITLE
Don't send OnJoined and OnLeft to irrelevant channels

### DIFF
--- a/LuaMenu/widgets/chobby/components/chat_windows.lua
+++ b/LuaMenu/widgets/chobby/components/chat_windows.lua
@@ -32,6 +32,10 @@ function ChatWindows:init()
 	)
 
 	self.onJoined = function(listener, chanName, userName)
+		if chanName ~= self.currentTab then
+			return
+		end
+
 		if self.currentTab and self.userListPanels[self.currentTab] then
 			self.userListPanels[self.currentTab]:OnJoined(userName)
 		end
@@ -39,6 +43,10 @@ function ChatWindows:init()
 	lobby:AddListener("OnJoined", self.onJoined)
 
 	self.onLeft = function(listener, chanName, userName)
+		if chanName ~= self.currentTab then
+			return
+		end
+
 		if self.currentTab and self.userListPanels[self.currentTab] then
 			self.userListPanels[self.currentTab]:OnLeft(userName)
 		end


### PR DESCRIPTION
Not sure why this wasn't designed as such to begin with.. Hopefully I'm not overlooking something big again :) 