### PR TITLE
Control command capture and replay widget state through UI

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -261,6 +261,8 @@ function Configuration:init()
 	self.showAiOptions = true
 	self.drawAtFullSpeed = false
 	self.fixFlicker = true
+	self.captureServerCommands = false
+	self.replayServerCommands = false
 	self.lastFactionChoice = 0
 	self.lastGameSpectatorState = false
 	self.lobbyIdleSleep = false
@@ -615,6 +617,8 @@ function Configuration:GetConfigData()
 		confirmation_battleFromBattle = self.confirmation_battleFromBattle,
 		drawAtFullSpeed = self.drawAtFullSpeed,
 		fixFlicker = self.fixFlicker,
+		captureServerCommands = self.captureServerCommands,
+		replayServerCommands = self.replayServerCommands,
 		lastFactionChoice = self.lastFactionChoice,
 		lastGameSpectatorState = self.lastGameSpectatorState,
 		lobbyIdleSleep = self.lobbyIdleSleep,

--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -1250,6 +1250,8 @@ local function GetVoidTabControls()
 	children[#children + 1], offset = AddCheckboxSetting(offset, "Use wrong engine", "useWrongEngine", false)
 	children[#children + 1], offset = AddCheckboxSetting(offset, "Show old AI versions", "showOldAiVersions", false)
 	children[#children + 1], offset = AddCheckboxSetting(offset, "Show AIOptions", "showAiOptions", true)
+	children[#children + 1], offset = AddCheckboxSetting(offset, "Capture commands", "captureServerCommands", false)
+	children[#children + 1], offset = AddCheckboxSetting(offset, "Replay commands", "replayServerCommands", false)
 	if Configuration.gameConfig.filterEmptyRegionalAutohosts then
 		children[#children + 1], offset = AddCheckboxSetting(offset, "Filter redundant battles", "battleFilterRedundant", true, nil, "Hides redundant empty regional autohosts.")
 	end

--- a/profile/parse_and_plot.ipynb
+++ b/profile/parse_and_plot.ipynb
@@ -16,11 +16,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use this notebook to generate commands (as `commands.json`) that you can use to reproduce input.\n",
-    "This is necessary so that benchmarking is based on identical data, and is generally faster than waiting for data to be sent from the server."
+    "Use this notebook to parse server commands, store them locally and plot profiling info.\n",
+    "\n",
+    "These commands can then be used for replaying, which can be done for benchmarking and testing purposes, and is generally faster than waiting for data to be sent from the server."
    ]
   },
   {
@@ -39,8 +41,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "LOG_CAPTURES_DIR = DATA_DIR / \"log_captures\"\n",
     "INFOLOG = DATA_DIR / \"infolog.txt\"\n",
+    "COMMANDS_LOG = DATA_DIR / \"commands.log\"\n",
+    "LOG_CAPTURES_DIR = DATA_DIR / \"log_captures\"\n",
     "COMMANDS_JSON = DATA_DIR / \"commands.json\""
    ]
   },
@@ -54,7 +57,6 @@
     "def parse_commands(path: Path) -> list[dict]:\n",
     "    with open(path, \"r\") as f:\n",
     "        commands = f.readlines()\n",
-    "    commands = [ cmd.split(\"|CAPTURE|\", maxsplit=1)[1] for cmd in commands if \"|CAPTURE|\" in cmd]\n",
     "    commands = [ json.loads(cmd) for cmd in commands ]\n",
     "    if len(commands) == 0:\n",
     "        raise ValueError(\"No commands found. Did you forget to enable command capture in dbg_command_capture.lua or login to the server?\")\n",
@@ -117,14 +119,15 @@
     "# Load, parse, and store captures\n",
     "os.makedirs(LOG_CAPTURES_DIR, exist_ok=True)\n",
     "\n",
-    "dt = datetime.datetime.fromtimestamp(INFOLOG.stat().st_ctime)\n",
+    "dt = datetime.datetime.fromtimestamp(COMMANDS_LOG.stat().st_ctime)\n",
     "timestamp = dt.strftime(\"%Y-%m-%d_%H-%M-%S\")\n",
     "\n",
-    "commands = parse_commands(INFOLOG)\n",
+    "commands = parse_commands(COMMANDS_LOG)\n",
     "df = make_dataframe_from_commands(commands)\n",
     "save_commands_for_replay(df, COMMANDS_JSON)\n",
     "\n",
     "shutil.copy(INFOLOG, LOG_CAPTURES_DIR / f\"infolog-{timestamp}.txt\")\n",
+    "shutil.copy(COMMANDS_LOG, LOG_CAPTURES_DIR / f\"commands-{timestamp}.log\")\n",
     "shutil.copy(COMMANDS_JSON, LOG_CAPTURES_DIR / f\"commands-{timestamp}.json\")\n",
     "df.to_csv(LOG_CAPTURES_DIR / f'parsed-{timestamp}.csv', index=False)\n",
     "\n",


### PR DESCRIPTION
For capture, also write directly to file so infolog isn't polluted and so it's easier to extract desired commands

@Beherith 
Would like some eyes on this - I'm a bit unsure with how to properly initialize these widgets so they're:
1) actually disabled as desired
2) don't cause load when disabled
3) loaded at exactly the right time (after lobby and Configuration are available, but before autologin/connect, which seems to be 1.8s usually - although it's disabled now)

Also it'd be great if you have any pointers on how to have user configuration for options like `AUTO_QUIT_ON_FINISH` which seem too dangerous even for devs. Always worried I don't accidentally commit it like https://github.com/beyond-all-reason/BYAR-Chobby/commit/153619fcf359928a2bd5fbc9dd3bd3a4f37a5435 ...