### PR TITLE
gui_community_window.lua

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/welcomePanelItems.lua
+++ b/LuaMenu/configs/gameConfig/byar/welcomePanelItems.lua
@@ -13,14 +13,6 @@
 
 local welcomePanelItems = {
     {
-        Header = "Alpha Championship Cup #3",
-        Image = "LuaMenu/images/1vs1Tournament.png",
-        Url = "https://www.beyondallreason.info/news/bar-alpha-championship-3-is-on-the-way",
-        Time = "2023-04-08T14:00:00",
-        Text = "See the brackets for upcoming championship and join the tourney or see the official stream on 8th of April!\n",
-        UrlText = "Sign-Up"
-    },
-    {
         Header = "Welcome to Beyond All Reason",
         Text = "Welcome back Commander. We hope you are ready for epic single player and multiplayer battles. Check out our Discord and join the community!\n",
     },

--- a/LuaMenu/configs/gameConfig/byar/welcomePanelItems.lua
+++ b/LuaMenu/configs/gameConfig/byar/welcomePanelItems.lua
@@ -13,6 +13,14 @@
 
 local welcomePanelItems = {
     {
+        Header = "Alpha Championship Cup #3",
+        Image = "LuaMenu/images/1vs1Tournament.png",
+        Url = "https://www.beyondallreason.info/news/bar-alpha-championship-3-is-on-the-way",
+        Time = "2023-04-08T14:00:00",
+        Text = "See the brackets for upcoming championship and join the tourney or see the official stream on 8th of April!\n",
+        UrlText = "Sign-Up"
+    },
+    {
         Header = "Welcome to Beyond All Reason",
         Text = "Welcome back Commander. We hope you are ready for epic single player and multiplayer battles. Check out our Discord and join the community!\n",
     },

--- a/LuaMenu/widgets/gui_community_window.lua
+++ b/LuaMenu/widgets/gui_community_window.lua
@@ -383,7 +383,7 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 				controls.image = Image:New{
 					name = "news" .. index,
 					x = 4, -- Fireball: Why not textpos(=6) ?
-					y = offset + 6,
+					y = offset + headFormat.vSpacing,
 					width = headFormat.imageSize,
 					height = headFormat.imageSize,
 					keepAspect = true,
@@ -397,18 +397,18 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 				controls.image:Invalidate()
 				controls.image:SetVisibility(true)
 			end
-			offset = offset + 6 + headFormat.imageSize
+			offset = offset + headFormat.vSpacing + headFormat.imageSize
 		elseif controls.image then
 			controls.image:SetVisibility(false)
 		end
 
 		if entryData.atTime and not timeAsTooltip then
 			if not controls.dateTime then
-				controls.dateTime = GetDateTimeDisplay(holder, textPos, offset + 6, entryData.atTime)
+				controls.dateTime = GetDateTimeDisplay(holder, textPos, offset + headFormat.vSpacing, entryData.atTime)
 			else
 				controls.dateTime.SetVisibility(true)
 			end
-			offset = offset + 6 + controls.dateTime.GetHeight()
+			offset = offset + headFormat.vSpacing + controls.dateTime.GetHeight()
 		elseif controls.dateTime then
 			controls.dateTime.SetVisibility(false)
 		end
@@ -417,7 +417,7 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 			if not controls.text then
 				controls.text = TextBox:New{
 					x = textPos,
-					y = offset + 6,
+					y = offset + headFormat.vSpacing,
 					right = 4,
 					height = 120,
 					align = "left",
@@ -429,11 +429,11 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 			else
 				controls.text:SetText(entryData.text)
 				controls.text:SetVisibility(true)
-				controls.text:SetPos(textPos, offset + 6)
+				controls.text:SetPos(textPos, offset + headFormat.vSpacing)
 				controls.text._relativeBounds.right = 4
 				controls.text:UpdateClientArea(false)
 			end
-			offset = offset + 6 + controls.text.height
+			offset = offset + headFormat.vSpacing + controls.text.height
 		elseif controls.text then
 			controls.text:SetVisibility(false)
 		end
@@ -474,12 +474,12 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 		end
 
 		if controls.linkButton and controls.linkButton.visible then
-			offset = math.max(offset, offsetImage) + 6
+			offset = math.max(offset, offsetImage) + headFormat.vSpacing
 			controls.linkButton:SetPos(nil, offset)
 			offset = offset + controls.linkButton.height
+		else
+			offset = math.max(offset, offsetImage)	
 		end
-
-		offset = math.max(offset, offsetImage)
 
 		holder:SetPos(nil, parentPosition, nil, offset)
 		return parentPosition + offset + headFormat.paragraphSpacing

--- a/LuaMenu/widgets/gui_community_window.lua
+++ b/LuaMenu/widgets/gui_community_window.lua
@@ -213,7 +213,7 @@ local function GetDateTimeDisplay(parentControl, xPosition, yPosition, timeStrin
 
 	local localStart = TextBox:New{
 		x = xPosition,
-		y = yPosition + 6,
+		y = yPosition,
 		right = 4,
 		height = 22,
 		align = "left",
@@ -226,7 +226,7 @@ local function GetDateTimeDisplay(parentControl, xPosition, yPosition, timeStrin
 
 	local countdown = TextBox:New{
 		x = xPosition,
-		y = yPosition + 26,
+		y = yPosition + localStart.height,
 		right = 4,
 		height = 22,
 		align = "left",
@@ -245,8 +245,12 @@ local function GetDateTimeDisplay(parentControl, xPosition, yPosition, timeStrin
 	}
 
 	function externalFunctions.SetPosition(newY)
-		localStart:SetPos(nil, newY + 6)
-		countdown:SetPos(nil, newY + 26)
+		localStart:SetPos(nil, newY)
+		countdown:SetPos(nil, newY + localStart.height)
+	end
+
+	function externalFunctions.GetHeight()
+		return localStart.height + countdown.height
 	end
 
 	function externalFunctions.SetVisibility(visible)
@@ -283,6 +287,7 @@ local headingFormats = {
 		topHeadingOffset = 60,
 		imageSize = 120,
 		buttonBot = 6,
+		vSpacing = 6,
 	},
 	[4] = {
 		buttonSize = 40,
@@ -295,9 +300,14 @@ local headingFormats = {
 		topHeadingOffset = 80,
 		imageSize = 120,
 		buttonBot = 10,
+		vSpacing = 6,
 	},
 }
 
+-- 2023/03/28 Fireball: we always use "headingFormats[2]"
+--						we never use "showBulletHeading"
+--						in result "freeHeading" and "heading" is same
+--						i simplified this function to use always "heading" and deleted bullets
 local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, topHeading, showBulletHeading)
 	local linkString
 	local controls = {}
@@ -315,31 +325,18 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 
 	local externalFunctions = {}
 
+	-- Fireball: vPositioning doesn´t matter here, overwritten by DoResize as soon as the control was created
 	function externalFunctions.AddEntry(entryData, parentPosition)
 		local textPos = 6
 		local headingPos = 2
 		local offset = 0
-
-		if showBulletHeading then
-			if not controls.bullet then
-				controls.bullet = Image:New{
-					x = 2,
-					y = offset + 5,
-					width = 16,
-					height = 16,
-					file = IMG_BULLET,
-					parent = holder,
-				}
-			end
-			headingPos = 18
-		end
 
 		if entryData.link then
 			linkString = entryData.link
 			if not controls.linkButton then
 				controls.linkButton = Button:New {
 					x = 2,
-					y = offset + 6,
+					y = offset + 6, -- Fireball: doesn´t matter, overwritten by DoResize, this is totally wrong
 					width = 280,
 					--right = 400,
 					align = "left",
@@ -359,67 +356,25 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 			else
 				controls.linkButton:SetVisibility(true)
 			end
-
-			if not controls.heading then
-				controls.heading = TextBox:New{
-					x = 4,
-					y = headFormat.inButton,
-					right = 4,
-					height = headFormat.height,
-					align = "center",
-					valign = "top",
-					text = entryData.heading,
-					objectOverrideFont = myFont7,
-					parent = holder,
-				}
-			else
-				controls.heading:SetText(entryData.heading)
-			end
-
-			-- Possibly looks nicer without link image.
-			--[[ if not showBulletHeading then
-				if not controls.linkImage then
-					controls.linkImage = Image:New {
-						x = 0,
-						y = 5,
-						width = headFormat.linkSize,
-						height = headFormat.linkSize,
-						keepAspect = true,
-						file = IMG_LINK,
-						parent = controls.linkButton,
-					}
-				end
-
-				local length = controls.heading.font:GetTextWidth(entryData.heading)
-				controls.linkImage:SetPos(length + 8)
-			end ]]
-
-			if controls.freeHeading then
-				controls.freeHeading:SetVisibility(false)
-			end
-		else
-			if not controls.freeHeading then
-				controls.freeHeading = TextBox:New{
-					x = headingPos + 4,
-					y = offset + 12,
-					right = 4,
-					height = headFormat.height,
-					align = "left",
-					valign = "top",
-					text = entryData.heading,
-					objectOverrideFont = myFont7,
-					parent = holder,
-				}
-			else
-				controls.freeHeading:SetText(entryData.heading)
-				controls.freeHeading:SetVisibility(true)
-			end
-
-			if controls.linkButton then
-				controls.linkButton:SetVisibility(false)
-			end
 		end
-		offset = offset + 40
+
+		if not controls.heading then
+			controls.heading = TextBox:New{
+				x = 4, -- Fireball: Why not textpos(=6) ?
+				y = headFormat.inButton,	-- Fireball: doesn´t matter, overwritten by DoResize
+				right = 4,
+				height = headFormat.height,
+				align = "center", -- Fireball: What do we want to center here ? the heading is shown aligned to the left and it´s good. is this working at all ?
+				valign = "top",
+				text = entryData.heading,
+				objectOverrideFont = myFont7,
+				parent = holder,
+			}
+		else
+			controls.heading:SetText(entryData.heading)
+		end
+
+		offset = offset + controls.heading.height
 
 		if entryData.imageFile then
 			textPos = headFormat.imageSize + 12
@@ -427,7 +382,7 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 			if not controls.image then
 				controls.image = Image:New{
 					name = "news" .. index,
-					x = 4,
+					x = 4, -- Fireball: Why not textpos(=6) ?
 					y = offset + 6,
 					width = headFormat.imageSize,
 					height = headFormat.imageSize,
@@ -442,17 +397,18 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 				controls.image:Invalidate()
 				controls.image:SetVisibility(true)
 			end
+			offset = offset + 6 + headFormat.imageSize
 		elseif controls.image then
 			controls.image:SetVisibility(false)
 		end
 
 		if entryData.atTime and not timeAsTooltip then
 			if not controls.dateTime then
-				controls.dateTime = GetDateTimeDisplay(holder, textPos, offset, entryData.atTime)
+				controls.dateTime = GetDateTimeDisplay(holder, textPos, offset + 6, entryData.atTime)
 			else
 				controls.dateTime.SetVisibility(true)
 			end
-			offset = offset + 45
+			offset = offset + 6 + controls.dateTime.GetHeight()
 		elseif controls.dateTime then
 			controls.dateTime.SetVisibility(false)
 		end
@@ -477,6 +433,7 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 				controls.text._relativeBounds.right = 4
 				controls.text:UpdateClientArea(false)
 			end
+			offset = offset + 6 + controls.text.height
 		elseif controls.text then
 			controls.text:SetVisibility(false)
 		end
@@ -493,47 +450,39 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 
 		local offset = 0
 
-		if controls.bullet then
-			controls.bullet:SetPos(nil, offset + 5)
-		end
-
 		local headingSize
 		if controls.heading and controls.heading.visible then
 			headingSize = (#controls.heading.physicalLines)*headFormat.fontSize
 			controls.heading:SetPos(nil, nil, nil, headingSize)
-		elseif controls.freeHeading then
-			headingSize = (#controls.freeHeading.physicalLines)*headFormat.fontSize
-			controls.freeHeading:SetPos(nil, nil, nil, headingSize)
 		end
 		offset = offset + headingSize + headFormat.spacing
 
+		local offsetImage = 0
 		if controls.image and controls.image.visible then
-			controls.image:SetPos(nil, offset + 6)
+			controls.image:SetPos(nil, offset + headFormat.vSpacing)
+			offsetImage = offset + headFormat.vSpacing + headFormat.imageSize
 		end
+
 		if controls.dateTime and controls.dateTime.visible then
-			controls.dateTime.SetPosition(offset)
-			offset = offset + 46
+			controls.dateTime.SetPosition(offset + headFormat.vSpacing)
+			offset = offset + headFormat.vSpacing + controls.dateTime.GetHeight()
 		end
+
 		if controls.text and controls.text.visible then
-			controls.text:SetPos(nil, offset + 6)
+			controls.text:SetPos(nil, offset + headFormat.vSpacing)
+			offset = offset + headFormat.vSpacing + controls.text.height
 		end
 
 		if controls.linkButton and controls.linkButton.visible then
-			offset = offset + controls.text.height + 20
+			offset = math.max(offset, offsetImage) + 6
 			controls.linkButton:SetPos(nil, offset)
+			offset = offset + controls.linkButton.height
 		end
 
-		if controls.text and controls.text.height <= 20 then
-			offset = offset + 20
-		end
+		offset = math.max(offset, offsetImage)
 
-		local offsetSize = (controls.text and (#controls.text.physicalLines)*18) or 6
-		if controls.image and controls.image.visible and ((not controls.text) or (offsetSize < headFormat.imageSize - (controls.dateTime and 46 or 0))) then
-			offsetSize = headFormat.imageSize - (controls.dateTime and 46 or 0)
-		end
-
-		holder:SetPos(nil, parentPosition, nil, offset + offsetSize + 10)
-		return parentPosition + offset + offsetSize + headFormat.paragraphSpacing
+		holder:SetPos(nil, parentPosition, nil, offset)
+		return parentPosition + offset + headFormat.paragraphSpacing
 	end
 
 	function externalFunctions.UpdateCountdown()


### PR DESCRIPTION
- deleted bullets and freeHeading, which were not used at all
- simplified it then
- walked through all items inside news and rearranged offsets
- fixed vSpacing , when timed events are used
- made vSpacing compatible with either image is used or not, time is used or not or whatever

welcomePanelItems.lua
- added next tournament event (with time)