### PR TITLE
fix UpdateUserBattleStatus and debug messages for readybutton

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -2993,12 +2993,15 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 			return
 		end
 
-		--Spring.Echo("isSpec nil?", status.isSpectator == nil, "isReady nil?", status.isReady == nil, "isSpec, isReady:", status.isSpectator, status.isReady)
+		Spring.Log(LOG_SECTION, LOG.NOTICE, "OnUpdateUserBattleStatus isSpec nil?", status.isSpectator == nil, "isReady nil?", status.isReady == nil, "isSpec:", status.isSpectator, "isReady:",status.isReady)
+		-- Spring.Utilities.TraceFullEcho()
 
 		local tooltipCandidate = ""
 		if status.isSpectator ~= nil then
+			Spring.Log(LOG_SECTION, LOG.NOTICE, status.isSpectator and "Disabling readyButton" or "Enabling readyButton")
 			readyButton:SetEnabled(not status.isSpectator)
 			if status.isSpectator then
+				Spring.Log(LOG_SECTION, LOG.NOTICE, "uncheck readyButton and StyleOff")
 				readyButtonCheckArrow.file = nil
 				readyButtonCheckArrow:Invalidate()
 				readyButton:StyleOff()
@@ -3007,11 +3010,13 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		end
 		if not status.isSpectator then
 			if status.isReady ~= nil and status.isReady then
+				Spring.Log(LOG_SECTION, LOG.NOTICE, "check readyButton and StyleReady")
 				readyButton:StyleReady()
 				readyButtonCheckArrow.file = IMG_CHECKARROW
 				readyButtonCheckArrow:Invalidate()
 				tooltipCandidate = i18n("ready_tooltip")
 			else
+				Spring.Log(LOG_SECTION, LOG.NOTICE, "uncheck readyButton and StyleUnready")
 				readyButton:StyleUnready()
 				readyButtonCheckArrow.file = nil
 				readyButtonCheckArrow:Invalidate()

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -355,7 +355,7 @@ function Interface:SetBattleStatus(status)
 	local teamColor = battleStatus.teamColor or { math.random(), math.random(), math.random(), 1 }
 	teamColor = EncodeTeamColor(teamColor)
 	self:_SendCommand(concat("MYBATTLESTATUS", battleStatusString, teamColor))
-	self:_OnUpdateUserBattleStatus(myUserName, battleStatus)
+	--self:_OnUpdateUserBattleStatus(myUserName, battleStatus) -- 2023/04/06 Fireball: don´t update here, but wait for CLIENTBATTLESTATUS to propagate this change
 	return self
 end
 

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -954,19 +954,20 @@ local function getDiffAndSetNewValuesToTable(origin, update)
 		if type(uVal) == "table" then
 			if type(oVal) == "table" then -- use recursion if value is table and key exists in origin table
 				_, changedSub = getDiffAndSetNewValuesToTable(oVal, uVal)
-				changed = changed or changedSub
+				--changed = changed or changedSub
 			else
-				changed = true
+				changedSub = true
 			end
 		else
 			-- Spring.Echo("uVal:", uVal, " oVal:", oVal, uVal ~= oVal)
-			changed = changed or (uVal ~= oVal)
+			changedSub = uVal ~= oVal
 		end
 
-		if changed then
+		if changedSub then
 			rawset(diff, uKey, uVal)
-			rawset(origin, uKey, uVal) -- this is the place where origin is updated, e.g. userData in _UpUpdateUserBattleStatus, which is self.userBattleStatus
+			rawset(origin, uKey, uVal) -- this is the place where origin is updated, e.g. battleStatus in _UpUpdateUserBattleStatus, which is self.userBattleStatus[userName]
 		end
+		changed = changed or changedSub
 	end
 	return diff, changed
 end
@@ -990,6 +991,7 @@ function Lobby:_OnUpdateUserBattleStatus(userName, status)
 	end
 
 	local battleStatus = self.userBattleStatus[userName]
+	-- local debugisReady = battleStatus.isReady
 
 	local battleStatusDiff, changed = getDiffAndSetNewValuesToTable(battleStatus, statusNew) -- use battleStatusDiff instead of statusNew to only propagate battleStatus properties, that really changed or which are new properties
 
@@ -998,6 +1000,11 @@ function Lobby:_OnUpdateUserBattleStatus(userName, status)
 			battleStatus.queuePos = 0 -- always change queuePos to 0, if we switch from spec to player = prevent showing queuePos e.g. in playerbattelist, if we didn�t receive the queue-update from server yet
 			battleStatusDiff.queuePos = 0
 		end
+
+		--if battleStatusDiff.isReady ~= nil then
+		--	Spring.Echo("isReady changed from", debugisReady, "to", battleStatusDiff.isReady)
+		--	Spring.Utilities.TraceFullEcho()
+		--end
 
 		self:_CallListeners("OnUpdateUserBattleStatus", userName, battleStatusDiff)
 


### PR DESCRIPTION
- fixed lobby UpdateUserBattleStatus - really only update changed pro…perties
- interface:SetBattleStatus: don´t update userBattleStatus internally and wait for CLIENTBATTLESTATS instead
- temporarily log all changes to ready button state for debugging purpose