### PR TITLE
Keep buffering incoming commands while replaying buffer

### DIFF
--- a/LuaMenu/widgets/api_command_buffering.lua
+++ b/LuaMenu/widgets/api_command_buffering.lua
@@ -62,4 +62,6 @@ function widget:Update()
 	while repetitions <= CMD_PER_UPDATE and lobby:ProcessBuffer() do
 		repetitions = repetitions + 1
 	end
+
+	lobby.bufferCommandsEnabled = lobby.commandsInBuffer > 0
 end


### PR DESCRIPTION
If there are still commands in the buffer, we must play through the rest of the buffer before executing new commands, or else risk data corruption.