### PR TITLE
Fix clean userBattleStatus on left battle

### DIFF
--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -911,6 +911,11 @@ function Lobby:_OnLeftBattle(battleID, userName)
 	end
 	local battle = self.battles[battleID]
 
+	-- remove userName from userBattleStatus
+	if self.userBattleStatus[userName] then
+		self.userBattleStatus[userName] = nil
+	end
+
 	local battleUsers = battle.users
 	for i, v in pairs(battleUsers) do
 		if v == userName then


### PR DESCRIPTION
Rejoining users weren't shown in chobby without battlestatus change. 