### PR TITLE
remove newlines before register and login

### DIFF
--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -22,6 +22,9 @@ local forcePlayer = false
 ------------------------
 
 function Interface:Register(userName, password, email)
+	username = self:TextEraseNewline(userName)
+	password = self:TextEraseNewline(password)
+
 	self:super("Register", userName, password, email)
 	password = VFS.CalculateHash(password, 0)
 	self:_SendCommand(concat("REGISTER", userName, password, email))
@@ -51,6 +54,10 @@ local function GetLobbyName()
 end
 
 function Interface:Login(user, password, cpu, localIP, lobbyVersion)
+	-- erase newline-chars in case user copied over incorrectly
+	user = self:TextEraseNewline(user)
+	password = self:TextEraseNewline(password)
+
 	-- overwrite lobbyVersion by local function, since it´s not provided by caller right now or given as "Chobby"
 	lobbyVersion = GetLobbyName()
 

--- a/libs/liblobby/lobby/interface_shared.lua
+++ b/libs/liblobby/lobby/interface_shared.lua
@@ -65,7 +65,23 @@ function Interface:Disconnect()
 	self:_OnDisconnected(nil, true)
 end
 
+function Interface:TextEraseNewline(str)
+	-- if str == nil then
+	-- 	Spring.Utilities.TraceEcho()
+	-- end
+	-- Spring.Echo("str:", str)
+	local input_str = str
+	str = string.gsub(str, "\n", "")
+	str = string.gsub(str, "\r", "")
+	-- if input_str ~= str then
+	-- 	Spring.Echo("TextEraseNewline before:", input_str)
+	-- 	Spring.Echo("TextEraseNewline after:", str)
+	-- end
+	return str
+end
+
 function Interface:_SendCommand(command, sendMessageCount)
+	-- command = self:TextEraseNewline(command) -- produces errors with telemetry commands
 	if sendMessageCount then
 		self.messagesSentCount = self.messagesSentCount + 1
 		command = "#" .. self.messagesSentCount .. " " .. command


### PR DESCRIPTION
login and register:
- erase \r and \n from username and password