### PR TITLE
Replays_ShowResult

### DIFF
--- a/LuaMenu/widgets/sl_loopback.lua
+++ b/LuaMenu/widgets/sl_loopback.lua
@@ -144,7 +144,8 @@ local function ReplayInfo(command)
 		command.game,
 		command.map,
 		command.players,
-		command.gameTime
+		command.gameTime,
+		command.winningAllyTeamIds
 	)
 end
 


### PR DESCRIPTION
Replays: show result for battles we played actively
- shown results: "Won", "Lost", "Unknown Result"
- does not show results for: 1) single player (since demo file does not contain our account name, but always "player") 2) specced battles or downloaded, where we are not a player (would need much effort to display all teams and mark the won team then)

Depends on next spring-launcher version, which sends the additional info "winningAllyTeamIds" coming from sdfz-demo-parser
- chobby's functionality is disabled with current launcher version and gets active as soon as we retrieve the new parameter
- tested with clean install of current launcher version and next launcher version

![grafik](https://user-images.githubusercontent.com/32598847/236565585-8ab935d2-e79d-4e6d-a97a-efa3ff8f39a1.png)
