### PR TITLE
Fix Show Spectator Status

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -381,7 +381,7 @@ local function GetUserStatusImages(userName, isInBattle, userControl)
 		images[#images + 1] = IMAGE_PARTY_INVITE
 	end
 
-	if not isInBattle then
+	if not isInBattle or userControl.isPlaying == false then
 		if userInfo.isInGame or (userInfo.battleID and not isInBattle) and not userControl.hideStatusIngame then
 			if userInfo.isInGame then
 				if userInfo.battleID == nil and WG.Chobby.Configuration.gameConfig.showSinglePlayerIngame then


### PR DESCRIPTION
When ingame status was merged with ready and synced for players, status for spectators fell off.

-> Re-enabled status for spectators