### PR TITLE
remove Tabula_Flooded_v04 from listed maps

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/mapDetails.lua
+++ b/LuaMenu/configs/gameConfig/byar/mapDetails.lua
@@ -129,7 +129,6 @@ return {
 ['Supreme Strait v1.4']={Width=24, Height=24, Is1v1=nil, IsTeam=1, IsFFA=nil, IsCertified=1, Special=nil, Flat=1, Hills=1, Water=1, IsInPool=1, PlayerCount=nil, TeamCount=nil, Author='Nikuksis', InfoText=nil},
 ['Supreme_Crossing 2.2']={Width=16, Height=16, Is1v1=nil, IsTeam=1, IsFFA=nil, IsCertified=1, Special=nil, Flat=1, Hills=nil, Water=1, IsInPool=1, PlayerCount=nil, TeamCount=nil, Author='Beherith', InfoText=nil},
 ['Supreme_Crossing_V1']={Width=16, Height=16, Is1v1=nil, IsTeam=1, IsFFA=nil, IsCertified=1, Special=nil, Flat=1, Hills=nil, Water=1, IsInPool=1, PlayerCount=nil, TeamCount=nil, Author='Beherith', InfoText=nil},
-['Tabula_Flooded_v04']={Width=16, Height=14, Is1v1=nil, IsTeam=1, IsFFA=nil, IsCertified=nil, Special=nil, Flat=nil, Hills=1, Water=1, IsInPool=1, PlayerCount=nil, TeamCount=nil, Author='Beherith', InfoText=nil},
 ['Tabula_Remake 1.5']={Width=16, Height=14, Is1v1=nil, IsTeam=1, IsFFA=nil, IsCertified=1, Special=nil, Flat=nil, Hills=1, Water=nil, IsInPool=1, PlayerCount=nil, TeamCount=nil, Author='IceXuick', InfoText=nil},
 ['Taldarim_V3']={Width=24, Height=18, Is1v1=nil, IsTeam=1, IsFFA=nil, IsCertified=1, Special=nil, Flat=nil, Hills=1, Water=nil, IsInPool=1, PlayerCount=nil, TeamCount=nil, Author='Beherith', InfoText=nil},
 ['Talus_v2']={Width=16, Height=16, Is1v1=nil, IsTeam=1, IsFFA=nil, IsCertified=1, Special=nil, Flat=nil, Hills=1, Water=nil, IsInPool=1, PlayerCount=nil, TeamCount=nil, Author='Beherith', InfoText=nil},


### PR DESCRIPTION
It seems this map is not available server side, as selecting it in a lobby yields an error:

```
me: !map Tabula_Flooded_v04
[teh]clusterEU5[01] * Could not find matching map for "Tabula_Flooded_v04" in current map list
```

Anyway we have Tabular Remake and water level can be set to accomodate for flooding, so I guess it's fine to remove.