### PR TITLE
Hide bonus label when AI kicked

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -754,7 +754,7 @@ local function UpdateUserBattleStatus(listener, userName)
 						userControls.lblHandicap:SetVisibility(true)
 					end
 				end
-				if not userControls.isPlaying then
+				if not userControls.isPlaying or handicap == nil then
 					-- If the player is spectating, don't show handicap label regardless of its value.
 					userControls.lblHandicap:SetVisibility(false)
 				end


### PR DESCRIPTION
The issue could lie deeper within updating battleStatus on RemoveAi (different handlers for MP and SP)