### PR TITLE
Enable startWithTabOpen in menu to auto-open the first item (esp.for Multiplater battles)

### DIFF
--- a/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
@@ -333,7 +333,7 @@ function BattleListWindow:UpdateInfoPanel()
 	if noBattles then
 		self.infoPanel:SetVisibility(true)
 		self.infoPanel:BringToFront()
-		self.infoLabel:SetCaption("No battle rooms found, report this to us on Discord!\nIf the server was just restarted\nwait a few minutes.")
+		self.infoLabel:SetCaption("No battle rooms found. Please log in first!\nIf you think it's a problem, report this to us on Discord.\nIf the server was just restarted, wait a few minutes.")
 		return
 	end
 

--- a/LuaMenu/widgets/chobby/components/interface_root.lua
+++ b/LuaMenu/widgets/chobby/components/interface_root.lua
@@ -508,6 +508,7 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 			name = "singleplayer",
 			tabs = Configuration.gameConfig.singleplayerConfig,
 			titleText = i18n("singleplayercoop"),
+			startWithTabOpen = 1,
 		},
 		{
 			name = "multiplayer",
@@ -515,6 +516,7 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 			tabs = multiPlayerTabs,
 			cleanupFunction = Configuration.leaveMultiplayerOnMainMenu and CleanMultiplayerState or nil,
 			twoline = true,
+			startWithTabOpen = 1,
 		},
 		{
 			name = "replays",
@@ -525,7 +527,8 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 		},
 		{
 			name = "help",
-			tabs = Configuration.gameConfig.helpSubmenuConfig
+			tabs = Configuration.gameConfig.helpSubmenuConfig,
+			startWithTabOpen = 1,
 		},
 	}
 


### PR DESCRIPTION
I find it annoying to have to click the "Battle List" button every time in Multiplayer menu, even though it's the only available option there. This PR fixes it by auto-opening the first menu item for Singleplayer (not sure about this one as there are 3 options in it), Multiplayer and Help menus -these only have one option in the menu. It also adjusts the text of the battles window when there are no rooms available, to explain that user needs to log in first.