### PR TITLE
Add player counts for teams, join queue and spectators in lobby room

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1803,6 +1803,22 @@ local function SetupPlayerPanel(playerParent, spectatorParent, battle, battleID)
 				preserveChildrenOrder = true,
 			}
 
+			local labelTeamPlayerCountWidth = 35 -- about enough pixel space for 2 symbols for font 2
+			local labelTeamPlayerCount = Label:New {
+				x = teamHolder.width - labelTeamPlayerCountWidth,
+				y = 0,
+				width = labelTeamPlayerCountWidth,
+				height = 25, -- same as label (for team names)
+				align = "right",
+				valign = "center",
+				font = WG.Chobby.Configuration:GetFont(2),
+				caption = "0",
+				parent = teamHolder,
+			}
+			local function UpdateTeamPlayerCount()
+				labelTeamPlayerCount.caption = tostring(#teamStack.children)
+			end
+
 			local function UpdatePlayerPositions()
 				if teamIndex ~= -1 and teamIndex ~= -2 then
 					table.sort(teamStack.children, SortPlayersBySkill)
@@ -1894,6 +1910,7 @@ local function SetupPlayerPanel(playerParent, spectatorParent, battle, battleID)
 					teamHolder:SetVisibility(true)
 					UpdatePlayerPositions()
 				end
+				UpdateTeamPlayerCount()
 			end
 
 			function teamData.RemoveTeam()
@@ -1961,6 +1978,7 @@ local function SetupPlayerPanel(playerParent, spectatorParent, battle, battleID)
 
 				teamData.CheckRemoval()
 				PositionChildren(parentStack, parentScroll.height)
+				UpdateTeamPlayerCount()
 			end
 
 			team[teamIndex] = teamData

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1803,11 +1803,10 @@ local function SetupPlayerPanel(playerParent, spectatorParent, battle, battleID)
 				preserveChildrenOrder = true,
 			}
 
-			local labelTeamPlayerCountWidth = 35 -- about enough pixel space for 2 symbols for font 2
 			local labelTeamPlayerCount = Label:New {
-				x = teamHolder.width - labelTeamPlayerCountWidth,
+				x = -20, -- hand crafted
 				y = 0,
-				width = labelTeamPlayerCountWidth,
+				width = 40,
 				height = 25, -- same as label (for team names)
 				align = "right",
 				valign = "center",
@@ -1816,7 +1815,7 @@ local function SetupPlayerPanel(playerParent, spectatorParent, battle, battleID)
 				parent = teamHolder,
 			}
 			local function UpdateTeamPlayerCount()
-				labelTeamPlayerCount.caption = tostring(#teamStack.children)
+				labelTeamPlayerCount.caption = string.format("%d", #teamStack.children)
 			end
 
 			local function UpdatePlayerPositions()


### PR DESCRIPTION
Shows total amount of players in a team (as well as join queue and spectators).

It works pretty well for normal lobbies, though just I tried this with PtaQs enormous FFA (32 players? one player per team) and when there is a lot of redraws in for the teams then the numbers seem to jump few or a lot of pixels to the right, might have to do something with team names taking more space when there is a lot of them (Team 8 vs Team 11, Team 17, etc).

![image](https://github.com/beyond-all-reason/BYAR-Chobby/assets/8504482/81758476-91ee-4dd7-ba96-9984020d3c55)

 