### PR TITLE
configuration.lua

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -258,6 +258,7 @@ function Configuration:init()
 	self.debugMode = false
 	self.devMode = (VFS.FileExists("devmode.txt") and true) or false
 	self.enableProfiler = false
+	self.enableInspector = false
 	self.enableCacheRapidPool = true
 	self.showCampaignButton = false
 	self.showPlanetUnlocks = false
@@ -621,6 +622,7 @@ function Configuration:GetConfigData()
 		debugMode = self.debugMode,
 		debugAutoWin = self.debugAutoWin,
 		enableProfiler = self.enableProfiler,
+		enableInspector = self.enableInspector,
 		enableCacheRapidPool= self.enableCacheRapidPool,
 		showCampaignButton = self.showCampaignButton,
 		showPlanetUnlocks = self.showPlanetUnlocks,

--- a/LuaMenu/widgets/dbg_chili_inspector.lua
+++ b/LuaMenu/widgets/dbg_chili_inspector.lua
@@ -197,7 +197,9 @@ function widget:Initialize()
 						caption="close",
 						classname = "negative_button",
 						OnMouseUp = {function()
-							widgetHandler:RemoveWidget() end},
+										widgetHandler:RemoveWidget()
+										WG.Chobby.Configuration:SetConfigValue("enableInspector", false)
+									end},
 					},
 				},
 			},

--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -556,10 +556,10 @@ local function AddCheckboxSetting(offset, caption, key, default, clickFunc, tool
 		checked = checked,
 		tooltip = tooltip,
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-		OnChange = {function (obj, newState)
-			Configuration:SetConfigValue(key, newState)
+		OnClick = {function (obj)
+			Configuration:SetConfigValue(key, obj.checked)
 			if clickFunc then
-				clickFunc(newState)
+				clickFunc(obj.checked)
 			end
 		end},
 	}
@@ -1237,7 +1237,12 @@ local function GetVoidTabControls()
 	end
 
 	local function EnableInspectorFunc(newState)
-		widgetHandler:ToggleWidget("ChiliInspector")
+		if newState then
+			widgetHandler:EnableWidget("ChiliInspector")
+		else
+			widgetHandler:DisableWidget("ChiliInspector")
+		end
+
 	end
 
 
@@ -1250,7 +1255,9 @@ local function GetVoidTabControls()
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("debugMode"), "debugMode", false)
 	children[#children + 1], offset = AddCheckboxSetting(offset, "Debug Auto Win", "debugAutoWin", false)
 	children[#children + 1], offset = AddCheckboxSetting(offset, "Enable Profiler", "enableProfiler", false, EnableProfilerFunc)
-	children[#children + 1], offset = AddCheckboxSetting(offset, "Enable Inspector", "enableInspector", false, EnableInspectorFunc)
+	local cbInspector
+	cbInspector, offset = AddCheckboxSetting(offset, "Enable Inspector", "enableInspector", false, EnableInspectorFunc)
+	children[#children + 1] = cbInspector
 	children[#children + 1], offset = AddCheckboxSetting(offset, "Show Campaign button", "showCampaignButton", false, toggleCampaignFunc)
 	children[#children + 1], offset = AddCheckboxSetting(offset, "Show Planet Unlocks", "showPlanetUnlocks", false)
 	children[#children + 1], offset = AddCheckboxSetting(offset, "Show Planet Enemy Units", "showPlanetEnemyUnits", false)
@@ -1491,7 +1498,18 @@ local function GetVoidTabControls()
 	}
 	offset = offset + ITEM_OFFSET
 
+	local function onConfigurationChange(listener, key, value)
+		if freezeSettings then
+			return
+		end
+		if key == "enableInspector" and cbInspector.checked ~= value then
+			cbInspector.SetToggle(value)
+		end
+	end
+
 	freezeSettings = false
+
+	Configuration:AddListener("OnConfigurationChange", onConfigurationChange)
 
 	return children
 end


### PR DESCRIPTION
- added key enableInspector (default = false)

dbg_chili_inspector.lua
- set conf value enableInspector to false onClose

gui_settings_window.lua

AddCheckboxSettings(..)
- use Object:onClick instead of Checkbox:onChange

Why onClick:
Because Checkbox:onChange Listeners are called BEFORE .checked of Checkbox is set to new value. (This feels totally wrong, but could be handled on another PR!)

If we want to ask for .checked property in a sub sub function of onchange(), it's still on old value. Bad. I changed this here, because chili_inspector can be closed by 2 actors:

1. dev-settings
2. close button of inspector itself

So, when inspector:close changes conf value to false, it triggers onConfigurationChange, which then must change the checked prop of settings window. But changing the checked value triggers onChange , which leads in re-checking it again.