### PR TITLE
add colors to self and friends for optimised visibility in lobbies

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -409,6 +409,12 @@ local function GetUserNameColorFont(userName, userControl)
 			return WG.Chobby.Configuration:GetFont(1, "Founder", {color = WG.Chobby.Configuration:GetFounderColor()} )
 		end
 	end
+	if userName == userControl.lobby:GetMyUserName() then
+		return WG.Chobby.Configuration:GetFont(1, "User", {color = WG.Chobby.Configuration:GetMyUserNameColor()} )
+	end
+	if userInfo.isFriend then
+		return WG.Chobby.Configuration:GetFont(1, "Friend", {color = WG.Chobby.Configuration:GetFriendsColor()})
+	end
 	if userInfo.isIgnored then
 		return WG.Chobby.Configuration:GetFont(1, "Ignored", {color = WG.Chobby.Configuration:GetIgnoredUserNameColor()} )
 	end

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -122,6 +122,8 @@ function Configuration:init()
 	self.founderColor = {0.7, 1, 0.65, 1}
 	self.ignoredUserNameColor = {0.6, 0.6, 0.6, 1}
 	self.userNameColor = {1, 1, 1, 1}
+	self.myUserNameColor = {0.8, 0.3, 0.9, 1}
+	self.friendsColor = {0.8, 0.4, 0.1, 1}
 
 	self.buttonFocusColor = {0.34,0.52,1,0.3}
 	self.buttonSelectedColor = {0.1, 0.58, 0.90, 0.9}--{1.0, 1.0, 1.0, 1.0}
@@ -775,6 +777,14 @@ end
 
 function Configuration:GetUserNameColor()
 	return self.userNameColor
+end
+
+function Configuration:GetMyUserNameColor()
+	return self.myUserNameColor
+end
+
+function Configuration:GetFriendsColor()
+	return self.friendsColor
 end
 
 -- NOTE: this one is in opengl range [0,1]

--- a/LuaMenu/widgets/gui_user_status_panel.lua
+++ b/LuaMenu/widgets/gui_user_status_panel.lua
@@ -163,13 +163,13 @@ local function InitializeControls(window)
 	}
 
 	local userControl
-	onAccepted = function(listener)
+	--[[ onAccepted = function(listener)
 		userControl = WG.UserHandler.GetStatusUser(lobby:GetMyUserName())
 		userControl:SetPos(40, 51, 265)
 		window:AddChild(userControl)
 		window:RemoveChild(connectivityText)
 		lobby:Ping()
-	end
+	end ]]
 
 	onDisconnected = function(listener)
 		if userControl and userControl.parent then


### PR DESCRIPTION
The lobby is sometimes difficult to oversee when it's filled to the brim with 16 people. By adding colorization to the player and their friends, they have a better overview of who they're up against, and who play with them.

At this moment the color for the player is purple, and the color for friends is orange. These can be changed in the configuration file, as for Founders and Admins.

@FIr3baL made it work in the end, so no functions are broken anymore :)