### PR TITLE
replace default !kick with !kickban

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -941,7 +941,7 @@ local function GetUserControls(userName, opts)
 						if userBattleInfo and userBattleInfo.aiLib then
 							userControls.lobby:RemoveAi(userName)
 						else
-							lobby:SayBattle("!kick "..userName)
+							lobby:SayBattle("!kickban "..userName)
 						end
 					elseif selectedName == "Unfriend" then
 						userControls.lobby:Unfriend(userName)


### PR DESCRIPTION
A simple change that rewires the default kick button to use !kickban instead of !kick as per https://discord.com/channels/549281623154229250/549281623577722899/1127608504677576734

From !help:

```
!kick <username> - kicks <username> from channel, battle or game, depending on the way the command is sent to AutoHost
!kickBan <username> - kicks and bans <username> temporarily from channel, battle and game
```

Myself and @Teifion saw no use case for the first one, and the latter is usually what you want to do.