### PR TITLE
add experimental standard gravity modoption

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/byar/ModOptions.lua
@@ -1233,6 +1233,21 @@ local options={
 	},
 
 	{
+		key    = 'experimentalstandardgravity',
+		name   = 'Standard Gravity',
+		desc   = 'Override map gravity for weapons',
+		type   = 'list',
+		section = 'options_experimental',
+		def  = "mapgravity",
+		items={
+			{key="mapgravity", name="Map Gravity", desc="Uses map defined gravity"},
+			{key="low", name="Low Gravity", desc="80 gravity"},
+			{key="standard", name="Standard Gravity", desc="120 gravity"},
+			{key="high", name="High Gravity", desc="150 gravity"},
+		}
+	},
+
+	{
 		key    = 'experimentalextraunits',
 		name   = 'Extra Unit Pack',
 		desc   = 'Formerly known as Scavenger units. Addon pack of units for Armada and Cortex, including various "fun" units',


### PR DESCRIPTION
New modoption to override map gravity, by setting a standard mygravity value for all weapons that do not have a mygravity value defined.