### PR TITLE
Fb add copy and refactor user drop down list

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -190,10 +190,6 @@ local function GetUserClanImage(userName, userControl)
 	return file, needDownload
 end
 
-local function battleWatchable()
-
-end
-
 local function GetUserComboBoxOptions(userName, isInBattle, control, showTeamColor, showSide)
 	local info = control.lobby:GetUser(userName) or {}
 	local bs = control.lobby:GetUserBattleStatus(userName) or {}

--- a/libs/chiliui/chili/controls/combobox.lua
+++ b/libs/chiliui/chili/controls/combobox.lua
@@ -17,6 +17,7 @@ ComboBox = Button:Inherit{
 	items = { "items" },
 	itemHeight = 20,
 	selected = 1,
+	showSelection = true,
 	OnOpen = {},
 	OnClose = {},
 	OnSelect = {},
@@ -120,7 +121,7 @@ function ComboBox:MouseDown(x, y)
 					height = self.itemHeight,
 					fontsize = self.itemFontSize,
 					objectOverrideFont = self.objectOverrideFont,
-					state = {focused = (i == self.selected), selected = (i == self.selected)},
+					state = {focused = (self.showSelection and i == self.selected), selected = (self.showSelection and i == self.selected)},
 					OnMouseUp = {
 						function()
 							if selectByName then


### PR DESCRIPTION
**This PR was inspired by adding "Copy User name" to user dropdown menu.
Took the chance to refactor the menu and its dependencies to match BAR's infrastructure and current command rights.**

Tech: Extended Chilly's combobox to not force any selection if not wanted.
- named it showSelection - if it's set to false, you won't see a focus when opening that same dropdown menu again
e.g.: it makes no sense to have "Change Faction" selected on next mouse click on a user

**refactored GetUserComboBoxOptions (big change) aka "user dropdown menu"**
- deleted all unused stuff
- made the code more readable in general
- merged conditions of each element to current bar's spads/server settings !!!
	this really needed update, can't count all changes, giving some examples:
	- don't show options which create a vote, if we are a spec - since we are not allowed to start votes as a spec: Change Team, Add Bonus, Force Spectator, Make Boss...
	- remove bot options, when we are not owner of bot: Remove, Change Faction
	- only show "Make Boss", if the user is not already boss
	- update comboboxoptions on 2 new events:
	1. if boss changes
	2. if we change our spectatorstatus - **because spectatorstatus changes what options we are allowed to vote for !!!**

- changed maxDropDownHeight for battle users user dropdown menu to fit the maximum amount of options without scrolling
before 300 -> 340
- added namedUserList to api_user_handler to check by name which userlist we handle right now