### PR TITLE
modoptions: remove `ffa_mode`

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/byar/ModOptions.lua
@@ -561,15 +561,6 @@ local options={
 		section= "options",
 	},
 	{
-		key    = "ffa_mode",
-		name   = "FFA Mode",
-		desc   = "Units with no player control are removed/destroyed \nUse FFA spawning mode",
-		hidden = true,
-		type   = "bool",
-		def    = false,
-		section= "options",
-	},
-	{
 		key    = "ffa_wreckage",
 		name   = "FFA Mode Wreckage",
 		desc   = "Killed players will blow up but leave wreckages",


### PR DESCRIPTION
Following the changes merged on the game side via [1], we update the modoptions here accordingly.

[1]: https://github.com/beyond-all-reason/Beyond-All-Reason/commit/141d4946b7cfac92664eab61128aae18e427bd71