### PR TITLE
show `startpostype` in singleplayer games

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -720,7 +720,7 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		}
 	end
 	]]--
-	if config.devMode then 
+	if battleLobby.name == "singleplayer" or config.devMode then 
 		local comboboxstartpostype = ComboBox:New{
 			name = 'comboboxstartpostype',
 			x = 0,


### PR DESCRIPTION
If you want to play FFA in singleplayer, you currently have no choice but to manually position start boxes for every ally team. We already have a combobox available to change `startpostype` when in dev mode, so let's just expose it in singleplayer.