### PR TITLE
sort teams teamnumber and optimized empty team removal and fix bot updates

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1662,6 +1662,13 @@ local function SortPlayersByQueued(a, b)
 	return string.lower(a.name) < string.lower(b.name)
 end
 
+local function SortTeams(a, b)
+	-- use abs to place queued(-1) above specs(-2)
+	local teamA = math.abs(tonumber(a.name))
+	local teamB = math.abs(tonumber(b.name))
+	return teamA < teamB
+end
+
 local function SetupPlayerPanel(playerParent, spectatorParent, battle, battleID)
 
 	local SPACING = 24
@@ -1714,6 +1721,7 @@ local function SetupPlayerPanel(playerParent, spectatorParent, battle, battleID)
 
 	local function PositionChildren(panel, minHeight)
 		local children = panel.children
+		table.sort(children, SortTeams)
 
 		minHeight = minHeight - 10
 
@@ -1982,7 +1990,6 @@ local function SetupPlayerPanel(playerParent, spectatorParent, battle, battleID)
 
 			function teamData.CheckRemoval()
 				if teamStack:IsEmpty() and teamIndex ~= -2 then
-					local removeHolder = false
 
 					if disallowCustomTeams then
 						if teamIndex > 1 then
@@ -1994,14 +2001,8 @@ local function SetupPlayerPanel(playerParent, spectatorParent, battle, battleID)
 						end
 					else
 						if teamIndex > 1 then
-							local maxTeam = 0
-							for teamID,_ in pairs(team) do
-								maxTeam = math.max(teamID, maxTeam)
-							end
-							if teamIndex == maxTeam then
-								teamData.RemoveTeam()
-								return true
-							end
+							teamData.RemoveTeam()
+							return true
 						elseif teamIndex == -1 then
 							teamHolder:SetVisibility(false)
 							return true

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -159,25 +159,20 @@ end
 ------------------------
 -- Battle commands
 ------------------------
-
--- 2023-03-08 Fireball: stop sneaky changes to lobby´s battleStatus properties here - listeners depend on lobby´s event OnUpdateUserBattleStatus
---                      instead call _OnUpdateUserBattleStatus in SetBattleStatus, which sets the new values and spreads them correctly
 local function UpdateAndCreateMerge(userData, status)
 	local battleStatus = {}
 	local updated = false
 	if status.isReady ~= nil then
 		updated = updated or userData.isReady ~= status.isReady
 		battleStatus.isReady = status.isReady
-		-- userData.isReady     = status.isReady
 	else
-		battleStatus.isReady = userData.isReady -- self:GetMyIsReady()
+		battleStatus.isReady = userData.isReady
 	end
 	if status.teamNumber ~= nil then
 		updated = updated or userData.teamNumber ~= status.teamNumber
 		battleStatus.teamNumber = status.teamNumber
-		-- userData.teamNumber     = status.teamNumber
 	else
-		battleStatus.teamNumber = userData.teamNumber or 0 -- self:GetMyTeamNumber() or 0
+		battleStatus.teamNumber = userData.teamNumber or 0
 	end
 	if status.teamColor ~= nil then
 		if userData.teamColor == nil then
@@ -190,40 +185,34 @@ local function UpdateAndCreateMerge(userData, status)
 			end
 		end
 		battleStatus.teamColor = status.teamColor
-		-- userData.teamColor     = status.teamColor
 	else
-		battleStatus.teamColor = userData.teamColor -- self:GetMyTeamColor()
+		battleStatus.teamColor = userData.teamColor
 	end
 	if status.allyNumber ~= nil then
 		updated = updated or userData.allyNumber ~= status.allyNumber
 		battleStatus.allyNumber = status.allyNumber
-		-- userData.allyNumber     = status.allyNumber
 	else
-		battleStatus.allyNumber = userData.allyNumber or 0 -- self:GetMyAllyNumber() or 0
+		battleStatus.allyNumber = userData.allyNumber or 0
 	end
 	if status.isSpectator ~= nil then
 		updated = updated or userData.isSpectator ~= status.isSpectator
 		battleStatus.isSpectator = status.isSpectator
-		-- userData.isSpectator     = status.isSpectator
 	else
-		battleStatus.isSpectator = userData.isSpectator -- self:GetMyIsSpectator()
+		battleStatus.isSpectator = userData.isSpectator
 	end
 	if status.sync ~= nil then
 		updated = updated or userData.sync ~= status.sync
 		battleStatus.sync = status.sync
-		-- userData.sync     = status.sync
 	else
-		battleStatus.sync = userData.sync -- self:GetMySync()
+		battleStatus.sync = userData.sync
 	end
 	if status.side ~= nil then
 		updated = updated or userData.side ~= status.side
 		battleStatus.side = status.side
-		-- userData.side     = status.side
 	else
-		battleStatus.side = userData.side or 0 -- self:GetMySide() or 0
+		battleStatus.side = userData.side or 0
 	end
 
-	--battleStatus.isReady = not battleStatus.isSpectator
 	return battleStatus, updated
 end
 
@@ -924,6 +913,12 @@ function Interface:_OnUpdateBot(battleID, name, battleStatus, teamColor)
 	battleID = tonumber(battleID)
 	local status = ParseBattleStatus(battleStatus)
 	status.teamColor = ParseTeamColor(teamColor)
+	local knownBattleAI = table.ifind(self.battleAis, name)
+	if not knownBattleAI then
+		Spring.Log(LOG_SECTION, LOG.ERROR, string.format("Tried to update unknown bot:%s in battle:%s", name, battleID))
+		return
+	end
+	status.owner = self.userBattleStatus[name] and self.userBattleStatus[name].owner
 	self:_OnUpdateUserBattleStatus(name, status)
 end
 Interface.commands["UPDATEBOT"] = Interface._OnUpdateBot

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -1071,7 +1071,7 @@ function Lobby:_OnUpdateUserBattleStatus(userName, status)
 	local statusNew = status
 
 	if (statusNew.owner == nil and not self.users[userName]) or
-	   (statusNew.owner ~= nil and not self.users[statusNew.owner]) then
+		(statusNew.owner ~= nil and not self.users[statusNew.owner]) then
 		Spring.Log(LOG_SECTION, LOG.ERROR, "Tried to update non connected user in battle: ", userName)
 		return
 	end


### PR DESCRIPTION
When changing from ffa/16 to team8v8 a lot of teams stayed empty and open, because only the team with highest teamIndex was removed.

Now the only possible empty teams are those of teamIndex 1 and 2. They could be removed too when more teams exists , but it's better for new players to always have team 1 and 2 existing, especially in Singleplayer. Otherwise they can easily end up with e.g. battle window showing team 3 and 5 and they would need to adjust the startboxes accordingly.

In multiplayer with spads autobalance turned on there won't be an empty team of teamID= 0 or 1. Without autobalance it's possible, but users can just fill up or keep it empty.