### PR TITLE
modoptions: reenable `disco` anonymous mode

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/byar/ModOptions.lua
@@ -1037,7 +1037,7 @@ local options={
 			{key="allred", name="Force SimpleColors", desc="All players have simple colors enabled, enemies cannot be recognized from each other."},
 			{key="global", name="Shuffle Globally", desc="Player colors order is shuffled globally, everyone see the same colors"},
 			{key="local", name="Shuffle Locally", desc="Player colors order is shuffled locally, everyone see different colors"},
-			--{key="disco", name="Shuffle Locally - DiscoMode", desc="Player colors order is shuffled locally, everyone see different colors that change every once a while randomly"},
+			{key="disco", name="Shuffle Locally - DiscoMode", desc="Player colors order is shuffled locally, everyone see different colors that change every once a while randomly"},
 		}
 	},
 


### PR DESCRIPTION
This was disabled in 3410c83487c03c90d83e39d97a13a21ceec32bc4 due to quirks happening with other widgets/gadgets that use `GetTeamColor`, for example `unitcloaker.lua` responsible for setting transparent cloak color on cloaked units.

We reenable it with the intent to try and address these issues over time as they are discovered by players.