### PR TITLE
updated editbox from ZK and workaround for autosize

### DIFF
--- a/libs/chiliui/chili/controls/editbox.lua
+++ b/libs/chiliui/chili/controls/editbox.lua
@@ -2,6 +2,16 @@
 
 --- EditBox module
 
+local spGetClipboard = Spring.GetClipboard
+local spGetKeyCode = Spring.GetKeyCode
+local spGetModKeyState = Spring.GetModKeyState
+local spGetTimer = Spring.GetTimer
+local spLog = Spring.Log
+local spSdlSetTextInputRect = Spring.SDLSetTextInputRect
+local spSdlStartTextInput = Spring.SDLStartTextInput
+local spSdlStopTextInput = Spring.SDLStopTextInput
+local spSetClipboard = Spring.SetClipboard
+
 --- EditBox fields.
 -- Inherits from Control.
 -- @see control.Control
@@ -54,21 +64,21 @@ EditBox = Control:Inherit{
 	cursorY = 1,
 
 	inedibleInput = {
-		[Spring.GetKeyCode("enter")] = true,
-		[Spring.GetKeyCode("numpad_enter")] = true,
-		[Spring.GetKeyCode("esc")] = true,
-		[Spring.GetKeyCode("f1")] = true,
-		[Spring.GetKeyCode("f2")] = true,
-		[Spring.GetKeyCode("f3")] = true,
-		[Spring.GetKeyCode("f4")] = true,
-		[Spring.GetKeyCode("f5")] = true,
-		[Spring.GetKeyCode("f6")] = true,
-		[Spring.GetKeyCode("f7")] = true,
-		[Spring.GetKeyCode("f8")] = true,
-		[Spring.GetKeyCode("f9")] = true,
-		[Spring.GetKeyCode("f10")] = true,
-		[Spring.GetKeyCode("f11")] = true,
-		[Spring.GetKeyCode("f12")] = true,
+		[spGetKeyCode("enter")] = true,
+		[spGetKeyCode("numpad_enter")] = true,
+		[spGetKeyCode("esc")] = true,
+		[spGetKeyCode("f1")] = true,
+		[spGetKeyCode("f2")] = true,
+		[spGetKeyCode("f3")] = true,
+		[spGetKeyCode("f4")] = true,
+		[spGetKeyCode("f5")] = true,
+		[spGetKeyCode("f6")] = true,
+		[spGetKeyCode("f7")] = true,
+		[spGetKeyCode("f8")] = true,
+		[spGetKeyCode("f9")] = true,
+		[spGetKeyCode("f10")] = true,
+		[spGetKeyCode("f11")] = true,
+		[spGetKeyCode("f12")] = true,
 	},
 
 	noFont = false,
@@ -78,9 +88,10 @@ local this = EditBox
 local inherited = this.inherited
 
 --// =============================================================================
+
 function EditBox:New(obj)
 	obj = inherited.New(self, obj)
-	obj._interactedTime = Spring.GetTimer()
+	obj._interactedTime = spGetTimer()
 		--// create font
 	if not obj.noHint then
 		if obj.objectOverrideHintFont then
@@ -192,8 +203,8 @@ function EditBox:_SetSelection(selStart, selStartY, selEnd, selEndY)
 	self.selEndY   = selEndY         or self.selEndY
 	if selStart or selStartY then
 		if not self.lines[self.selStartY] then
-				Spring.Log("chiliui", LOG.ERROR, "self.lines[self.selStartY] is nil for self.selStartY: " .. tostring(self.selStartY) .. " and #self.lines: " .. tostring(#self.lines))
-				Spring.Log("chiliui", LOG.ERROR, debug.traceback())
+				spLog("chiliui", LOG.ERROR, "self.lines[self.selStartY] is nil for self.selStartY: " .. tostring(self.selStartY) .. " and #self.lines: " .. tostring(#self.lines))
+				spLog("chiliui", LOG.ERROR, debug.traceback())
 		else
 			local logicalLine = self.lines[self.selStartY]
 			self.selStartPhysical, self.selStartPhysicalY = self:_LineLog2Phys(logicalLine, self.selStart)
@@ -202,8 +213,8 @@ function EditBox:_SetSelection(selStart, selStartY, selEnd, selEndY)
 
 	if selEnd or selEndY then
 		if not self.lines[self.selEndY] then
-				Spring.Log("chiliui", LOG.ERROR, "self.lines[self.selEndY] is nil for self.selEndY: " .. tostring(self.selEndY) .. " and #self.lines: " .. tostring(#self.lines))
-				Spring.Log("chiliui", LOG.ERROR, debug.traceback())
+				spLog("chiliui", LOG.ERROR, "self.lines[self.selEndY] is nil for self.selEndY: " .. tostring(self.selEndY) .. " and #self.lines: " .. tostring(#self.lines))
+				spLog("chiliui", LOG.ERROR, debug.traceback())
 		else
 			local logicalLine = self.lines[self.selEndY]
 			self.selEndPhysical, self.selEndPhysicalY  = self:_LineLog2Phys(logicalLine, self.selEnd)
@@ -211,7 +222,14 @@ function EditBox:_SetSelection(selStart, selStartY, selEnd, selEndY)
 	end
 end
 
-function EditBox:GetPhysicalLinePosition(distanceFromBottom)
+function EditBox:GetPhysicalLinePosition(distanceFromBottom, usePhysical)
+	if usePhysical then
+		local lineID = #self.physicalLines - distanceFromBottom + 1
+		if lineID and self.physicalLines[lineID] then
+			return self.physicalLines[lineID].y
+		end
+		return 0
+	end
 	local lineID = #self.lines - distanceFromBottom + 1
 	if lineID < 1 then
 		return 0
@@ -254,7 +272,10 @@ function EditBox:_GeneratePhysicalLines(logicalLineID)
 		height = 1e9
 	end
 
-	local wrappedText = font:WrapText(text, width, height)
+	-- 2023-09-17 FB: +0.1 as a workaround, because, when WrapText sums up the widths of each word,
+	-- it sometimes results in a slitghtly bigger width than GetTextWidth (+ ~ 0.000001),
+	-- so a line break gets applied, though it would fit in the line without a line break
+	local wrappedText = font:WrapText(text, width + 0.1, height)
 
 	local y = 0
 	local fontLineHeight = font:GetLineHeight() + self.lineSpacing
@@ -291,8 +312,8 @@ function EditBox:_GeneratePhysicalLines(logicalLineID)
 		if _txt:sub(#_txt - 1, #_txt - 1) ~= " " then
 			-- a lack of " " at the end might be caused by two things
 			-- 1) the string is continuous and there shouldn't be a " " in the first place
-				-- 2) there are two words and there is a " "
-		if text:sub(logLineX + 1, logLineX + 1) == " " then
+			-- 2) there are two words and there is a " "
+			if text:sub(logLineX + 1, logLineX + 1) == " " then
 				logLineX = logLineX + 1
 				physicalLine.extraSpace = true
 			end
@@ -304,23 +325,23 @@ function EditBox:_GeneratePhysicalLines(logicalLineID)
 
 		-- find color for next line
 		if #colors > 0 then
-		totalLength = totalLength + #_txt
-		local colorIndex = 1
-		while colorIndex <= #colors do
-			if colors[colorIndex] > totalLength then
-				break
+			totalLength = totalLength + #_txt
+			local colorIndex = 1
+			while colorIndex <= #colors do
+				if colors[colorIndex] > totalLength then
+					break
+				end
+				colorIndex = colorIndex + 1
 			end
-			colorIndex = colorIndex + 1
-		end
-		colorIndex = colorIndex - 1
+			colorIndex = colorIndex - 1
 
-		colorPrefix = ""
-		if colors[colorIndex] ~= nil then
-			local cp = colors[colorIndex]
-			colorPrefix = text:sub(cp, cp + 3)
+			colorPrefix = ""
+			if colors[colorIndex] ~= nil then
+				local cp = colors[colorIndex]
+				colorPrefix = text:sub(cp, cp + 3)
+			end
 		end
-		end
-		end
+	end
 
 	if self.autoHeight then
 		local totalHeight = #self.physicalLines * fontLineHeight
@@ -506,14 +527,14 @@ function EditBox:__GetStartX(text)
 end
 
 function EditBox:FocusUpdate(...)
-	if Spring.SDLStartTextInput and self.useSDLStartTextInput then
+	if spSdlStartTextInput and self.useSDLStartTextInput then
 		if not self.state.focused then
 			self.textEditing = ""
-			Spring.SDLStopTextInput()
+			spSdlStopTextInput()
 		else
-			Spring.SDLStartTextInput()
+			spSdlStartTextInput()
 			local x, y = self:CorrectlyImplementedLocalToScreen(self.x, self.y)
-			Spring.SDLSetTextInputRect(x, y, 30, 1000)
+			spSdlSetTextInputRect(x, y, 30, 1000)
 		end
 	end
 	self:InvalidateSelf()
@@ -652,7 +673,7 @@ function EditBox:MouseDown(x, y, ...)
 				for _, f in pairs(OnTextClick.OnTextClick) do
 					f(self, cx, cy, ...)
 				end
-				self._interactedTime = Spring.GetTimer()
+				self._interactedTime = spGetTimer()
 				inherited.MouseDown(self, x, y, ...)
 				self:Invalidate()
 				return self
@@ -663,7 +684,7 @@ function EditBox:MouseDown(x, y, ...)
 	if not self.selectable then
 		return false
 	end
-	local _, _, _, shift = Spring.GetModKeyState()
+	local _, _, _, shift = spGetModKeyState()
 	local cp, cpy = self.cursor, self.cursorY
 	self:_SetCursorByMousePos(x, y)
 	if shift then
@@ -678,7 +699,7 @@ function EditBox:MouseDown(x, y, ...)
 		self.selEndY = nil
 	end
 
-	self._interactedTime = Spring.GetTimer()
+	self._interactedTime = spGetTimer()
 	inherited.MouseDown(self, x, y, ...)
 	self:Invalidate()
 	return self
@@ -714,8 +735,7 @@ function EditBox:MouseMove(x, y, dx, dy, button)
 	if self.forgetMouseMove then
 		return self
 	end
-	
-	local _, _, _, shift = Spring.GetModKeyState()
+
 	local cp, cpy = self.cursor, self.cursorY
 	self:_SetCursorByMousePos(x, y)
 	if not self.selStart then
@@ -724,7 +744,7 @@ function EditBox:MouseMove(x, y, dx, dy, button)
 	self:_SetSelection(nil, nil, self.cursor, self.cursorY)
 	--Spring.Echo(self:GetSelectionText())
 
-	self._interactedTime = Spring.GetTimer()
+	self._interactedTime = spGetTimer()
 	inherited.MouseMove(self, x, y, dx, dy, button)
 	self:Invalidate()
 	return self
@@ -824,7 +844,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 	local eatInput = true
 
 	-- deletions
-	if key == Spring.GetKeyCode("backspace") and self.editable then
+	if key == spGetKeyCode("backspace") and self.editable then
 		if self.selStart == nil then
 			if mods.ctrl then
 				repeat
@@ -837,7 +857,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 		else
 			self:ClearSelected()
 		end
-	elseif key == Spring.GetKeyCode("delete") and self.editable then
+	elseif key == spGetKeyCode("delete") and self.editable then
 		if self.selStart == nil then
 			if mods.ctrl then
 				repeat
@@ -855,7 +875,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 
 	-- TODO: Fix cursor movement for multiline
 	-- cursor movement
-	elseif key == Spring.GetKeyCode("left") and not self.multiline then
+	elseif key == spGetKeyCode("left") and not self.multiline then
 		if mods.ctrl then
 			repeat
 				self.cursor = Utf8PrevChar(txt, self.cursor)
@@ -863,7 +883,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 		else
 			self.cursor = Utf8PrevChar(txt, cp)
 		end
-	elseif key == Spring.GetKeyCode("right") and not self.multiline then
+	elseif key == spGetKeyCode("right") and not self.multiline then
 		if mods.ctrl then
 			repeat
 				self.cursor = Utf8NextChar(txt, self.cursor)
@@ -871,26 +891,26 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 		else
 			self.cursor = Utf8NextChar(txt, cp)
 		end
-	elseif key == Spring.GetKeyCode("home") and not self.multiline then
+	elseif key == spGetKeyCode("home") and not self.multiline then
 		self.cursor = 1
-	elseif key == Spring.GetKeyCode("end") and not self.multiline then
+	elseif key == spGetKeyCode("end") and not self.multiline then
 		self.cursor = #txt + 1
 
 	-- copy & paste
-	elseif (mods.ctrl and key == Spring.GetKeyCode("c")) or (mods.ctrl and key == Spring.GetKeyCode("insert")) or
-		(self.editable and ((mods.ctrl and key == Spring.GetKeyCode("x")) or (mods.shift and key == Spring.GetKeyCode("delete")))) then
+	elseif (mods.ctrl and key == spGetKeyCode("c")) or (mods.ctrl and key == spGetKeyCode("insert")) or
+		(self.editable and ((mods.ctrl and key == spGetKeyCode("x")) or (mods.shift and key == spGetKeyCode("delete")))) then
 		txt = self:GetSelectionText()
 		if self.selStart and self.selEnd then
-			Spring.SetClipboard(txt)
-			if key == Spring.GetKeyCode("x") or key == Spring.GetKeyCode("delete") then
+			spSetClipboard(txt)
+			if key == spGetKeyCode("x") or key == spGetKeyCode("delete") then
 				self:ClearSelected()
 			end
 		end
-	elseif ((mods.ctrl and key == Spring.GetKeyCode("v")) or (mods.shift and key == Spring.GetKeyCode("insert"))) and self.editable then
-		self:TextInput(Spring.GetClipboard())
+	elseif ((mods.ctrl and key == spGetKeyCode("v")) or (mods.shift and key == spGetKeyCode("insert"))) and self.editable then
+		self:TextInput(spGetClipboard())
 
 	-- select all
-	elseif mods.ctrl and key == Spring.GetKeyCode("a") then
+	elseif mods.ctrl and key == spGetKeyCode("a") then
 		if not self.multiline then
 			self:_SetSelection(1, 1, #txt + 1, 1)
 		else
@@ -901,7 +921,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 	end
 
 	-- text selection handling
-	if key == Spring.GetKeyCode("left") or key == Spring.GetKeyCode("right") or key == Spring.GetKeyCode("home") or key == Spring.GetKeyCode("end") then
+	if key == spGetKeyCode("left") or key == spGetKeyCode("right") or key == spGetKeyCode("home") or key == spGetKeyCode("end") then
 		if mods.shift then
 			if not self.selStart then
 				self:_SetSelection(cp, cpy, nil, nil)
@@ -915,7 +935,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 		end
 	end
 
-	self._interactedTime = Spring.GetTimer()
+	self._interactedTime = spGetTimer()
 	eatInput = inherited.KeyPress(self, key, mods, isRepeat, label, unicode, ...) or eatInput
 	self:UpdateLayout()
 	self:Invalidate()
@@ -943,7 +963,7 @@ function EditBox:TextInput(utf8char, ...)
 		self.cursor = cp + unicode:len()
 	end
 
-	self._interactedTime = Spring.GetTimer()
+	self._interactedTime = spGetTimer()
 	inherited.TextInput(self, utf8char, ...)
 	inherited.TextModified(self, utf8char, ...)
 	self:UpdateLayout()


### PR DESCRIPTION
updated to current editbox.lua version of ZK and added a workaround for stopping wrapText to add unnecessary line breaks

ZK version:
- They replaced all direct calls to Spring functions by local ones (little speed and readability boost)
- They added an optional parameter to GetPhysicalLinePosition (=usePhysical) which is currently not used in byar-chobby -> so it doesn't change any functional behaviour in byar-chobby

WrapText:
- This workaround enables autosize to work for textboxes and editboxes, when the width shall increase to the used size of the largest line in the text paragraph
- The underlying origin of the mismatching line widths is located in engine's WrapText function, which sums up the width of each recognized word for the current line and can result in a slightly larger line width than the result of GetTextWidth (usually about 0.000001 px). Though it causes a line break, where no line break is needed.