### PR TITLE
Bootstrapping unranked option

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/byar/ModOptions.lua
@@ -1256,11 +1256,11 @@ local options={
 
 	-- this setting is actually used as a top level/lobby option by chobby, this just bootstraps the process
 	{
-		key="unranked_game",
-		name   		= "Unranked Game",
-		desc   		= "Game results do not affect OpenSkill",
+		key="ranked_game",
+		name   		= "Ranked Game",
+		desc   		= "Should game results affect OpenSkill",
 		type   		= "bool",
-		def    		= false,
+		def    		= true,
 		hidden		= true,
 	},
 

--- a/LuaMenu/configs/gameConfig/byar/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/byar/ModOptions.lua
@@ -1254,6 +1254,15 @@ local options={
 
 
 
+	-- this setting is actually used as a top level/lobby option by chobby, this just bootstraps the process
+	{
+		key="unranked_game",
+		name   		= "Unranked Game",
+		desc   		= "Game results do not affect OpenSkill",
+		type   		= "bool",
+		def    		= false,
+		hidden		= true,
+	},
 
 
 


### PR DESCRIPTION
This is to allow unranked games without players using unintuitive and/or fragile hacks.

A chobby option will be added to the existing lobby controls, allowing people to change it and vote upon such, this is just to set default and bootstrap the process