### PR TITLE
Replace all occurrences of "─" with "-"

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -202,7 +202,7 @@ local function GetUserComboBoxOptions(userName, isInBattle, control, showTeamCol
 	if not (itsme or bs.aiLib) then																					comboOptions[#comboOptions + 1] = "Message" end
 	if isInBattle and not (itsme or bs.aiLib or info.isBot) then													comboOptions[#comboOptions + 1] = "Ring" end
 	if not (itsme or bs.aiLib or isInBattle) and info.battleID and validEngine then									comboOptions[#comboOptions + 1] = "Join Battle" end
-	if not (itsme or info.isBot) then																				comboOptions[#comboOptions + 1] = "────────────────" end
+	if not (itsme or info.isBot) then																				comboOptions[#comboOptions + 1] = "--------------" end
 	if not (itsme or bs.aiLib or info.isBot) then																	comboOptions[#comboOptions + 1] = info.isFriend and "Unfriend" or "Friend"
 									  if info.isDisregarded and info.isDisregarded == Configuration.IGNORE then     comboOptions[#comboOptions + 1] = "Unignore"
 																													comboOptions[#comboOptions + 1] = "Avoid"

--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -539,7 +539,7 @@ local function InitializeModoptionsDisplay()
 				local name = option.name and option.name or key
 				text = text .. "\255\120\120\120"
 				if text ~= "\255\120\120\120" then
-					text = text .. "──────\n"
+					text = text .. "------\n"
 				end
 				text = text .. tostring(name).. " = \255\255\255\255" .. shortenedValue(value) .. "\n"
 				empty = false

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -928,7 +928,7 @@ local function GetUserTooltip(userName, userInfo, userBattleInfo, inBattleroom)
 			n = "\n"
 		end
 		if next(userBattleInfo) then
-			text = text .. "\n" .. "────────────────"
+			text = text .. "\n" .. "----------------"
 			st = sortfunc(userBattleInfo)
 			for _, kv in ipairs(st) do
 				text = text .. "\n" .. kv[1] .. " = " .. tostring(kv[2])


### PR DESCRIPTION
This fixes the broken glyph that appears in the modoptions panel and other places.
![Screenshot_382](https://github.com/beyond-all-reason/BYAR-Chobby/assets/124457076/43b6cc5b-f109-4810-821b-39a405180db7)
