### PR TITLE
modoptions: add `teamffa_start_boxes_shuffle`

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/byar/ModOptions.lua
@@ -1095,6 +1095,15 @@ local options={
 	},
 
 	{
+		key     = 'teamffa_start_boxes_shuffle',
+		name    = 'Shuffle TeamFFA start boxes',
+		desc    = "In TeamFFA games (more than 2 teams, excluding Raptors / Scavengers), start boxes will be randomly assigned to each team: team 1 might be assigned any start box rather than team 1 always being assigned start box 1.",
+		type    = 'bool',
+		section = 'options_extra',
+		def     = true,
+	},
+
+	{
 		key="ruins",
 		name="Ruins",
 		desc = "Remains of the battles once fought",

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1140,6 +1140,21 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 	}
 	leftOffset = leftOffset + 38
 
+	-- this is a kludge so that we can override default values for some specific ModOptions in singleplayer games
+	if battleLobby.name == "singleplayer" then
+		local modoptions = WG.Chobby.Configuration.gameConfig.defaultModoptions
+		for i = 1, #modoptions do
+			local data = modoptions[i]
+			-- default teamffa_start_boxes_shuffle to "off" for singleplayer games
+			-- teamffa_start_boxes_shuffle defaults to "on" for multiplayer games since it is desirable to hide start location
+			-- however in singleplayer it is a common scenario to play a pseudo-TeamFFA game against multiple AIs, and in this
+			-- case players typically do not want to be booted off their specifically chosen start box
+			if data.key == "teamffa_start_boxes_shuffle" then
+				data.def = false
+			end
+		end
+	end
+
 	WG.ModoptionsPanel.LoadModoptions(battle.gameName, battleLobby)
 	local btnModoptions = Button:New {
 		name = 'btnModoptions',


### PR DESCRIPTION
In 79a5ecf276cbbfafb2680d4485da7c9503b0b05d on the game repository (see [1]), we reworked FFA start points and additionally added a shuffling system for start boxes in TeamFFA games.

This was added because in multiplayer games it is desirable to hide start location, however in singleplayer it is a common scenario to play a pseudo-TeamFFA game against multiple AIs, and in this case players typically do not want to be booted off their specifically chosen start box.

To allow for toggling this behaviour on or off as needed, we add a new ModOption in the `Extra` tab (next to `Anonymous Mode` since it is another common setting tweaked in FFA games). This ModOption is set to "on" by default such that behaviour is unchanged in multiplayer games, however we also introduce a small QoL where it defaults to "off" in singleplayer games via a custom override done in Chobby.

[1]: https://github.com/beyond-all-reason/Beyond-All-Reason/commit/79a5ecf276cbbfafb2680d4485da7c9503b0b05d