### PR TITLE
Safety fix for replays with mangled file names

### DIFF
--- a/LuaMenu/widgets/gui_replay_handler.lua
+++ b/LuaMenu/widgets/gui_replay_handler.lua
@@ -164,10 +164,11 @@ local function CreateReplayEntry(
 	fileName = string.gsub(fileName, "%.sdfz", "")
 
 	-- Extract replay time from the filename
-	local replayDateString = string.format(
-		"%s-%s-%s %s:%s",
-		string.match(fileName, "(%d%d%d%d)-?(%d%d)-?(%d%d)_(%d%d)-?(%d%d)")
-	)
+	local t1, t2, t3, t4, t5 = string.match(fileName, "(%d%d%d%d)-?(%d%d)-?(%d%d)_(%d%d)-?(%d%d)")
+	if not (t1 and t2 and t3 and t4 and t5) then
+		return
+	end
+	local replayDateString = string.format("%s-%s-%s %s:%s", t1, t2, t3, t4, t5)
 
 	-- Compute the time of the replay
 	local hours, minutes = math.floor(time / 3600), math.floor(time / 60) % 60


### PR DESCRIPTION
See https://github.com/ZeroK-RTS/Chobby/pull/873#issuecomment-1837001487 and https://github.com/ZeroK-RTS/Chobby/commit/cb2e20672cfb12df42f5f31fb77fef86ec611fce

I tested and the mentioned "empty replay list" doesn't happen in BAR Chobby when a replay filename is missing data, but this is safer code and should prevent replays with changed filenames creating problems in other components.