### PR TITLE
Drop "Alpha (No-CDN)" configuration option.

### DIFF
--- a/dist_cfg/config.json
+++ b/dist_cfg/config.json
@@ -84,69 +84,6 @@
         },
         {
             "package": {
-                "id": "manual-linux-no-cdn",
-                "display": "Alpha (no CDN)",
-                "platform": "linux"
-            },
-            "config_url": "https://launcher-config.beyondallreason.dev/config.json",
-            "env_variables": {
-                "PRD_RAPID_REPO_MASTER": "https://repos.beyondallreason.dev/repos.gz"
-            },
-            "auto_download": true,
-            "downloads": {
-                "games": ["byar:test", "byar-chobby:test"],
-                "resources": [
-                    {
-                        "url": "https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D105.1.1-2142-g35a026a/spring_bar_.BAR105.105.1.1-2142-g35a026a_linux-64-minimal-portable.7z",
-                        "destination": "engine/105.1.1-2142-g35a026a bar",
-                        "extract": true
-                    }
-                ]
-            },
-            "no_start_script": true,
-            "logs_s3_bucket": "bar-infologs",
-            "launch": {
-                "start_args": ["--menu", "rapid://byar-chobby:test"],
-                "engine": "105.1.1-2142-g35a026a bar",
-                "springsettings": {
-                    "RapidTagResolutionOrder": "repos.beyondallreason.dev"
-                }
-            }
-        },
-        {
-            "package": {
-                "id": "manual-win-no-cdn",
-                "display": "Alpha (no CDN)",
-                "platform": "win32"
-            },
-            "config_url": "https://launcher-config.beyondallreason.dev/config.json",
-            "env_variables": {
-                "PRD_RAPID_REPO_MASTER": "https://repos.beyondallreason.dev/repos.gz"
-            },
-            "silent": false,
-            "auto_download": true,
-            "downloads": {
-                "games": ["byar:test", "byar-chobby:test"],
-                "resources": [
-                    {
-                        "url": "https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D105.1.1-2142-g35a026a/spring_bar_.BAR105.105.1.1-2142-g35a026a_windows-64-minimal-portable.7z",
-                        "destination": "engine/105.1.1-2142-g35a026a bar",
-                        "extract": true
-                    }
-                ]
-            },
-            "no_start_script": true,
-            "logs_s3_bucket": "bar-infologs",
-            "launch": {
-                "start_args": ["--menu", "rapid://byar-chobby:test"],
-				"engine": "105.1.1-2142-g35a026a bar",
-                "springsettings": {
-                    "RapidTagResolutionOrder": "repos.beyondallreason.dev"
-                }
-            }
-        },
-        {
-            "package": {
                 "id": "manual-linux-test-engine",
                 "display": "Engine Test",
                 "platform": "linux"
@@ -186,7 +123,7 @@
         },
         {
             "package": {
-                "id": "manual-linux-test-engine",
+                "id": "manual-win-test-engine",
                 "display": "Engine Test",
                 "platform": "win32"
             },


### PR DESCRIPTION
The CDN got to the state of being very stable and we don't need to have additional No-CDN option that might cause other types of issues.

This will be reverted in case we get a legitimate reports about issues with the CDN setup.