### PR TITLE
Expand Username Blacklist

### DIFF
--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -1,5 +1,7 @@
 LoginWindow = LCS.class{}
 
+include "LuaMenu/widgets/chobby/utilities/word_library.lua"
+
 --TODO: make this a util function, maybe even add this support to chili as a whole?
 function createTabGroup(ctrls, visibleFunc)
 	for i = 1, #ctrls do
@@ -1071,8 +1073,6 @@ function LoginWindow:tryLogin()
 end
 
 function isInValidUserName(username)
-	local badwords = {"fuck","cunt","shit","cock","faggot","adolf","hitler","nigger"}
-
 	validUserNameRegex = "^[a-zA-Z%d%[%]_]+$"
 	if string.match(username,validUserNameRegex) and string.len( username) == string.len( string.match(username,validUserNameRegex)) then
 		--print (username .. " is OK")
@@ -1082,10 +1082,9 @@ function isInValidUserName(username)
 		if string.len(username) <3 then
 			return "Username too short, at least 3 characters"
 		end
-		for index, badword in ipairs(badwords) do
-			if string.match(string.lower( username),badword) then
-				return "Username contains banned word: "..badword
-			end
+		local blacklisted = Word_Library.FindBlacklistedString(username)
+		if blacklisted then
+			return "Username contains banned word/phrase: "..blacklisted
 		end
 		return false
 	else

--- a/LuaMenu/widgets/chobby/utilities/word_library.lua
+++ b/LuaMenu/widgets/chobby/utilities/word_library.lua
@@ -30,10 +30,116 @@ Word_Library.blacklisted_plain_strings = {
 	"adolf",
 	"hitler",
 	"nigger",
+	"coochie", -- CoochieStretcher
+	"gooch", -- Gooch_Snorkler
+	"jigaboo", -- GangBangerJigaboo
+	"molester", -- AdvancedMolester
+	"molestor", -- ginge_the_molestor
+	"pussy", -- Pussylover69 and XxPussySlayerXx
+	"retard", -- fatretardgaming
+	"semen", -- Semen_ and semen_swallow
 
 -- Section 2: 'Creative' mis-spellings and phrases
+	"1488", -- [1488]Thrump and [Azov]Bandera1488 (14 words, 88 = HH = Heil Hilter)
+	"analbeads", -- analbeadsunt
+	"bigdick", -- bigdickrick, THEBIGDICKBANDIT
+	"BigDik", -- BigDikVonQueefer
+	"BigDingDong", -- BigDingDong95
+	"C0ck", -- C0ckSlayer95
+	"H17L3R", -- [d604]K1llH17L3R, [G604]K1llH17L3R, K1llH17L3R
+	"negger", -- xXNEGGERHADERXx
+	"niggeer", -- niggeerwarrior
+	"nigguer", -- ISMELLNIGGUER
+	"nijjer", -- nijjerphaggot
+	"nikker", -- nikkerjew
+	"phaggot", -- nijjerphaggot
+	"SisterFister", -- ListerDaSisterFister
+	"SmallDick", -- SmallDickBigBrain
+	"zalupa", -- [zalupa2]vtlkru (zalupa apparently meaning dickhead in Russian)
+	"[KYS]", -- [KYS]HugeGuy
 
--- Section 3: previously moderated usernames
+-- Section 3: previously moderated usernames (beginning of time through 2024/1/15)
+	"AbuseYoungBoys", -- AbuseYoungBoys123
+	"Bambusneger", -- (translated: "Bamboo negro")
+	"BanAllRussians",
+	"Ban_Russians",
+	"BigNickDigger",
+	"BlacksVsTeens",
+	"CoonHunter",
+	"coonhunting",
+	"DebilPL", -- (translated: 'moron PL/Poland'
+	"dickassman",
+	"diggernick",
+	"ErikVonManstein", -- (was a nazi apparently)
+	"fagmuffin",
+	"FatKidsLagIRL",
+	"fatqueefclit",
+	"F_A_T_C_O_C_K",
+	"Gay_killer",
+	"GEORGfloydcantbreath", -- (keep politics out of BAR)
+	"GreaterIsrael",
+	"Himenhamburglar",
+	"HomoFaggins",
+	"Hugh_G_Rection",
+	"Hymenhamburglar",
+	"imurderamericans",
+	"IrishInbreeding",
+	"ISISRecruiter",
+	"KikeKiller",
+	"KillNazis", -- (see https://discord.com/channels/549281623154229250/774771372579880980/1097122276786319481)
+	"kill_nigers",
+	"kkk",
+	"kuroNIGHER",
+	"madarchode", -- (translated: motherfucker)
+	"MohammedwasLGBTQ",
+	"MrEnWord",
+	"Muschiduft", -- (translated: Pussysmell)
+	"NateHiggers",
+	"Necrosexual",
+	"ni999er",
+	"NIBBERSLAYER",
+	"NickGhur",
+	"NIG3R",
+	"nigerfrombehind",
+	"Nigg",
+	"nignog",
+	"Nigward",
+	"nig_ger",
+	"Nikher",
+	"NilleachKigger",
+	"NillKigger", -- (also renamed to "NillKiggerPls")
+	"nlackbigger",
+	"NuckFiggers",
+	"NupidStigger",
+	"NWord", -- TheNWord
+	"N_igger",
+	"N_WORD", -- N_WORDS_IN_PARIS
+	"ObamerTheRacistObama",
+	"onlytalk2whites",
+	"P3dospid3r",
+	"phatdik",
+	"Prigozhin",
+	"rapeepat",
+	"rasha_parasha", -- (translated: 'Russia shithole')
+	"reformthe3rdreich",
+	"RunGayRun",
+	"Schnaebichaetscher", -- (translated: Cocksucker)
+	"SchoolShootingsAreOK",
+	"sligghernayer", -- (spoonerism of niggherslayer)
+	"Slvtcrvsher", -- (gawlix of 'slut crusher')
+	"SmoakMyBenis",
+	"SpitOnWomen",
+	"TheFinalJew",
+	"THeThirdReich",
+	"The_3rd_Reich",
+	"Totenkopfverband", -- (pro-nazi name)
+	"Twateifion", -- Twateifion666
+	"UnInstallLyf", -- [DSM]UnInstallLyf
+	"Vaginafucker",
+	"warcrimeenjoyer", -- warcrimeenjoyer9999
+	"Womanbeater",
+	"yolocaust", -- yolocaust420
+	"ZOV_EBAT_AZOV", -- ('zov' is associated with the Russian military, 'ebat' is 'fuck' in Russian, and 'azov' is associated with the Ukranian military)
 }
 
 do

--- a/LuaMenu/widgets/chobby/utilities/word_library.lua
+++ b/LuaMenu/widgets/chobby/utilities/word_library.lua
@@ -1,0 +1,45 @@
+Word_Library = Word_Library or {}
+
+-- Returns a blacklisted string from the word library contained within the provided 'searchStr'.
+-- If 'searchStr' does not contain any blacklisted strings, nil is returned instead.
+-- The search is case-insensitive.
+function Word_Library.FindBlacklistedString(searchStr)
+	local lowerStr = string.lower(searchStr)
+	for index, badStr in ipairs(Word_Library.blacklisted_plain_strings) do
+		if string.match(lowerStr, badStr) then
+			return string.gsub(badStr, "%%", "") -- Remove any escape characters before returning.
+		end
+	end
+	return nil
+end
+
+-- A list of plain strings (not patterns) that are considered bad.
+-- Some postprocessing is performed on entries to allow for easier data entry; all strings are converted to lowercase and any special characters are escaped.
+
+-- Examples:
+-- "badword"
+-- "[bad]user_name"
+-- "[bAd]uSeR_nAmE"
+Word_Library.blacklisted_plain_strings = {
+-- Section 1: generic unwanted words
+	"fuck",
+	"cunt",
+	"shit",
+	"cock",
+	"faggot",
+	"adolf",
+	"hitler",
+	"nigger",
+
+-- Section 2: 'Creative' mis-spellings and phrases
+
+-- Section 3: previously moderated usernames
+}
+
+do
+	for index, word in ipairs(Word_Library.blacklisted_plain_strings) do
+		word = string.lower(word)
+		word = string.gsub(word, "([^%w])", "%%%1") -- Adds a '%' escape character before each non-alphanumeric character
+		Word_Library.blacklisted_plain_strings[index] = word
+	end
+end


### PR DESCRIPTION
This PR seeks to improve the utility and scope of the existing username validation checks performed in the login window.

It does this in two stages:

In the first patch, a new Word_Library module is added, and the Login_Window class is migrated to use this module instead of implementing it itself. The goal with this migration is to facilitate the bulk addition of blacklisted strings by automatically normalizing entries. The existing blacklist is preserved, so this patch should not cause any functional/visible changes.

In the second patch, many new entries are added to the Word_Library blacklist. These are based on previously-encountered usernames which the BAR moderation team has required users to change.