### PR TITLE
Removed modoption 'noise' in lobby

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/byar/ModOptions.lua
@@ -877,6 +877,15 @@ local options={
 		section = 'options_experimental',
 		def = false,
 	},
+	
+	{
+		key = 'lategame_rebalance',
+		name = 'Lategame Rebalance',
+		desc = 'T2 defenses and anti-air is weaker, giving more time for late T2 strategies to be effective.  Early T3 unit prices increased. Increased price of calamity/ragnarock by 20% so late T3 has more time to be effective.',
+		type = 'bool',
+		section = 'options_experimental',
+		def = false,
+	},
 
 	{
 		key    = 'experimentalimprovedtransports',
@@ -1071,6 +1080,16 @@ local options={
 			{key="disco", name="Local (Disco)", desc="Same as local, except that colors are reshuffled every 2 mins for extra spicyness."},
 			{key="allred", name="All red", desc="You cannot distinguish different players, they all have the same color (red by default, can be changed in accessibility settings). Diplomacy is very hard."},
 		},
+	},
+	
+	
+	{
+		key     = 'teamffa_start_boxes_shuffle',
+		name    = 'Shuffle TeamFFA start boxes',
+		desc    = "In TeamFFA games (more than 2 teams, excluding Raptors / Scavengers), start boxes will be randomly assigned to each team: team 1 might be assigned any start box rather than team 1 always being assigned start box 1.",
+		type    = 'bool',
+		section = 'options_extra',
+		def     = true,
 	},
 
 	{


### PR DESCRIPTION
In which FFA startboxes and lategame rebalance no longer noise the lobby display up even when default values