### PR TITLE
Update ModOptions.lua

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/byar/ModOptions.lua
@@ -556,12 +556,12 @@ local options={
 	{
 		key    = 'multiplier_energyconversion',
 		name   = 'Energy Conversion Efficiency Multiplier ',
-		desc   = '(Range 0.1 - 10). lower means you get less metal per energy converted',
+		desc   = '(Range 0.1 - 2). lower means you get less metal per energy converted',
 		type   =  "number",
 		section = 'options_resources',
 		def    = 1,
 		min    = 0.1,
-		max    = 10,
+		max    = 2,
 		step   = 0.1,
 	},
 


### PR DESCRIPTION
Reduce the 10 max value for energy conversion to 2 to match the maximum value allowed by the game. This brings it into parity with another request here:

https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2562

The developers weren't keen on allowing energy conversion efficiency as high as 10, but said they'd be fine with 2.