### PR TITLE
Remove the override handicap in scenario013.lua to allow difficulty s…

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario013.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario013.lua
@@ -89,7 +89,6 @@ Scoring:
 	{
         Side = __PLAYERSIDE__;
 		Handicap = __PLAYERHANDICAP__;
-		Handicap = 0;
 		RgbColor = 0 0.20999999 0.97999997;
 		AllyTeam = 0;
 		TeamLeader = 0;


### PR DESCRIPTION
…election

Found out by a new player recently, difficulty selection currently does nothing as the scenario overrides player handicap back to 0.