### PR TITLE
[Modoption cleanup] Remove reverse gear modoption

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/byar/ModOptions.lua
@@ -752,15 +752,6 @@ local options={
 	},
 
 	{
-		key		= "experimentalreversegear",
-		name	= "Reverse gear",
-		desc	= "Allows units to move backwards over short distances",
-		type	= "bool",
-		def		= false,
-		section	= "options_unit_modifiers",
-	},
-
-	{
 		key     = "tweakunits",
 		name    = "Tweak Units",
 		desc    = "For advanced users!!! A base64 encoded lua table of unit parameters to change.",


### PR DESCRIPTION
### Work done
Remove reverse gear modoption
Game PR: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2745