### PR TITLE
Add Tab Weights Support

### DIFF
--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -367,6 +367,7 @@ local function CreateModoptionWindow()
 
 	for key, data in pairs(modoptionStructure.sections) do
 		local caption = modoptionStructure.sectionTitles[data.title] or data.title
+		local weight = modoptionStructure.sectionWeights[data.title] or -#tabs
 		local fontSize = 2
 		local tooltip = data.desc
 		local origCaption = caption
@@ -379,9 +380,12 @@ local function CreateModoptionWindow()
 			caption = caption,
 			tooltip = tooltip,
 			objectOverrideFont = WG.Chobby.Configuration:GetFont(fontSize),
-			children = PopulateTab(data.options)
+			children = PopulateTab(data.options),
+			weight = data.weight or weight
 		}
 	end
+
+	table.sort(tabs, function(a,b) return a.weight > b.weight end)
 
 	local tabPanel = Chili.DetachableTabPanel:New {
 		x = 4,
@@ -597,6 +601,7 @@ function ModoptionsPanel.RefreshModoptions()
 	local postpendHiddenOptions = {}
 	modoptionStructure = {
 		sectionTitles = {},
+		sectionWeights = {},
 		sections = {}
 	}
 
@@ -605,6 +610,7 @@ function ModoptionsPanel.RefreshModoptions()
 		local data = modoptions[i]
 		if data.type == "section" then
 			modoptionStructure.sectionTitles[data.key] = data.name
+			modoptionStructure.sectionWeights[data.key] = data.weight
 		else
 			if data.section then
 				if data.hidden ~= true then


### PR DESCRIPTION
Adds weight support for modoptions tabs for sorting purposes.
Section weight can be added to Sections in modoptions via an (int/float) weight variable.
If a weight is not present at the time of populataing the tabs the amount of tabs is used as a negative weight to maintain the current order.
# Testing done:
- [X] Modoption tabs maintain current order if no weights present
- [X] Weights added to the modoptions file affect tab sorting