### PR TITLE
Fix Archive Already Loaded

### DIFF
--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -660,7 +660,19 @@ function ModoptionsPanel.LoadModoptions(gameName, newBattleLobby)
 		return VFS.Include("modoptions.lua", nil, VFS.ZIP)
 	end
 
-	modoptions = VFS.UseArchive(gameName, LoadModOptions)
+	do
+		local alreadyLoaded = false
+		for _, archive in pairs(VFS.GetLoadedArchives()) do
+			if archive == gameName then
+				alreadyLoaded = true
+			end
+		end
+		if alreadyLoaded then
+			modoptions = VFS.Include("modoptions.lua", nil, VFS.ZIP)
+		else
+			modoptions = VFS.UseArchive(gameName, LoadModOptions)
+		end
+	end
 
 	modoptionDefaults = {}
 	if not modoptions then


### PR DESCRIPTION
# Work Done
Loading modoptions now checks if the archive it wished to open for modoptions is already loaded via GetLoadedArchives, this is diffrent from the lua exposed HasArchive check which in engine makes a call to a diffrent object.
This prevents failure to open lobby if already in game of the same version.
# Test Steps
1. Open Singleplayer, normal bar game, not dev lobby.
2. Start Game
3. While Game is in the background try to join a Multiplayer Lobby
**|** With Fix, joins correctly
**|** Without multiplayer browser closes, no lobby opens
