### PR TITLE
Allow any file extension for devmode.txt

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -273,6 +273,17 @@ function Configuration:init()
 		end
 	end
 
+	self.devMode = false
+	local dirList = VFS.DirList("/")
+	for i = 1,#dirList do
+		local match = string.find(dirList[i], "devmode")
+		if match ~= nil then
+			Spring.Echo("Found devmode file, enabling developer mode", dirList[i])
+			self.devMode = true
+			break
+		end
+	end
+
 	self.autoLaunchAsSpectator = true
 	self.lastLoginChatLength = 25
 	self.notifyForAllChat = true
@@ -282,7 +293,6 @@ function Configuration:init()
 	self.addFriendWindowButton = true
 	self.simplifiedSkirmishSetup = false
 	self.debugMode = false
-	self.devMode = (VFS.FileExists("devmode.txt") and true) or false
 	self.ShowhiddenModopions = false
 	self.enableProfiler = false
 	self.enableInspector = false


### PR DESCRIPTION
Because windows can hide real file extensions, some people mistakenly make `devmode.txt.txt` or `devmode.rtf.txt`. This makes it so any file extension (or none, for that matter) will work.