### PR TITLE
feat(liblobby): handle multiple newline separated commands

### DIFF
--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -432,9 +432,13 @@ end
 -- end
 
 function Interface:SayBattle(message)
-	self:super("SayBattle", message)
-	self:_SendCommand(concat("SAYBATTLE", message))
-	return self
+	if (message:find("!") or message:find("$")) and message:find("\n") then
+		for _, multiMessage in ipairs(parseMultiCommandMessage(message)) do
+			self:super("SayBattle", multiMessage):_SendCommand(concat("SAYBATTLE", multiMessage))
+		end
+		return self
+	end
+	return self:super("SayBattle", message):_SendCommand(concat("SAYBATTLE", message))
 end
 
 function Interface:SayBattleEx(message)

--- a/libs/liblobby/lobby/utilities.lua
+++ b/libs/liblobby/lobby/utilities.lua
@@ -65,11 +65,15 @@ function parseTags(tags)
 	return tagsMap
 end
 
+function trim6(s)
+	return s:match "^()%s*$" and "" or s:match "^%s*(.*%S)"
+ end
+
 function parseMultiCommandMessage(message)
 	local trimmedFilteredMatches = {}
 	for commandPart in message:gmatch "[^\n]+" do
 		if commandPart:len() > 0 and (commandPart:find "!" or commandPart:find "$") then
-			table.insert(trimmedFilteredMatches, commandPart:match "^()%s*$" and '' or commandPart:match "^%s*(.*%S)")
+			table.insert(trimmedFilteredMatches, trim6(commandPart))
 		end
 	end
 

--- a/libs/liblobby/lobby/utilities.lua
+++ b/libs/liblobby/lobby/utilities.lua
@@ -65,6 +65,17 @@ function parseTags(tags)
 	return tagsMap
 end
 
+function parseMultiCommandMessage(message)
+	local trimmedFilteredMatches = {}
+	for commandPart in message:gmatch "[^\n]+" do
+		if commandPart:len() > 0 and (commandPart:find "!" or commandPart:find "$") then
+			table.insert(trimmedFilteredMatches, commandPart:match "^()%s*$" and '' or commandPart:match "^%s*(.*%S)")
+		end
+	end
+
+	return trimmedFilteredMatches
+end
+
 function getTag(tags, tagName, mandatory)
 	local value = tags[tagName]
 	if mandatory and value == nil then


### PR DESCRIPTION
This code aims to speed up lobby setup by letting the user submit multiple commands like battlesettings etc in a single input message.
Some samples:
![image](https://github.com/beyond-all-reason/BYAR-Chobby/assets/89279737/2a1b369d-7cad-4178-93a3-de0a452388f2)
![image](https://github.com/beyond-all-reason/BYAR-Chobby/assets/89279737/35b08692-8842-4214-a810-0c60e6bd1812)
![image](https://github.com/beyond-all-reason/BYAR-Chobby/assets/89279737/7efbbabe-60f1-4326-b99c-ad72faa4a5a1)

Tested:
- [ x] standard commands
- [ x] long tweakdefs (bit of a freeze in my dev environment on paste)
- [x ] empty values
- [x] broken line copies
