### PR TITLE
Fix login window opening off screen when height is larger than available room

### DIFF
--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -957,7 +957,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.window = Window:New {
 		x = math.floor((ww - width) / 2),
-		y = math.floor((wh - self.windowHeight) / 2),
+		y = math.floor(math.max(0,(wh - self.windowHeight) / 2)),
 		width = width,
 		height = self.windowHeight,
 		caption = "",


### PR DESCRIPTION
![Screenshot_T_d](https://github.com/beyond-all-reason/BYAR-Chobby/assets/124457076/bededf14-055a-4673-ac63-0b65bc498942)
