### PR TITLE
Allow friends to join private battle directly

### DIFF
--- a/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
@@ -1412,7 +1412,7 @@ function BattleListWindow:OpenHostWindow()
 		height = 35,
 		boxalign = "left",
 		boxsize = 20,
-		caption = "Allow friends to join directly",
+		caption = "Friends only",
 		checked =  false,
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
 		OnChange = {
@@ -1422,7 +1422,7 @@ function BattleListWindow:OpenHostWindow()
 			end
 		},
 		parent = hostBattleWindow,
-		tooltip = "If you have a private battle, allow friends to join without entering a password.",
+		tooltip = "Only friends can join your battle, but they can do so without the password.",
 	}
 	friendCheckbox:Hide()
 


### PR DESCRIPTION
PR for issue #654 

Added a new checkbox in the hostBattleWindow which make it optionally possible to allow friends to join without a password. This checkbox sends a request in the battle lobby to set the gatekeeper to friends. 

In PR: https://github.com/beyond-all-reason/teiserver/pull/285
I would like to change the state of the gatekeeper friends to allow friends to join a private battle without entering a password.

Also when trying the to join a private lobby. The user directly tries to connect without a password.
(Users would directly join on reconnect, and as friends to private battles without having to click the join button)