### PR TITLE
Change alt-account keyword, and store it as a hash.

### DIFF
--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -1185,7 +1185,7 @@ function LoginWindow:tryRegister()
 		return
 	end
 
-    if (not Configuration.firstLoginEver) and (self.TextAcknowledgementBox.text ~= "Gargamel") then
+    if (not Configuration.firstLoginEver) and (VFS.CalculateHash(self.TextAcknowledgementBox.text, 1) ~= "a374635fe062d9b6694049d64b3f3c69527e7a0a63628b2374fed654da7388e549aa7a5294e3b05295b6a450edf22b5b4f289955c56e281085f65680fbdbe052") then
 		self.txtErrorRegister:SetText(Configuration:GetErrorColor() .. "Contact moderation first (#open-ticket on Discord).")
         return
     end


### PR DESCRIPTION
Currently, the keyword to allow creation of a second account is stored in plaintext within the Chobby code.

This patch:
1. Changes the specific keyword that Chobby checks for (known by the Moderation team)
2. Only stores a hashed copy of the keyword within Chobby's code.

Ideally we would validate the keyword server-side, but this lesser change is simple, self-contained, and provides at least some benefit to confidentiality.