### PR TITLE
don't change focus when message received (give control back to user)

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/mainConfig.lua
+++ b/LuaMenu/configs/gameConfig/byar/mainConfig.lua
@@ -49,7 +49,6 @@ end
 local minimapOverridePath  = LUA_DIRNAME .. "configs/gameConfig/" .. shortname .. "/minimapOverride/"
 local minimapThumbnailPath = LUA_DIRNAME .. "configs/gameConfig/" .. shortname .. "/minimapThumbnail/"
 
-local sayPrivateSelectAndActivateChatTab = true
 local showSinglePlayerIngame = true
 local logoutOpensLoginPanel = true
 
@@ -78,7 +77,6 @@ local externalFuncAndData = {
 	--editor                 = "rapid://sb-byar:test",
 	--editor                 = "SpringBoard BYAR $VERSION",
 	defaultChatChannels    = {"main"},
-	sayPrivateSelectAndActivateChatTab = sayPrivateSelectAndActivateChatTab,
 	aiBlacklist            = aiBlacklist,
 	unversionedGameAis	   = {"SimpleAI","SimpleDefenderAI", "SimpleConstructorAI", "ScavengersAI", "RaptorsAI"},
 	GetAiSimpleName        = aiSimpleNames.GetAiSimpleName,

--- a/LuaMenu/widgets/chobby/components/chat_windows.lua
+++ b/LuaMenu/widgets/chobby/components/chat_windows.lua
@@ -460,7 +460,7 @@ function ChatWindows:ProcessChat(chanName, userName, message, msgDate, notifyCol
 	if not lobbyUserName then 
 		lobbyUserName = userName
 	end
-	local iAmMentioned = (string.find(message, lobbyUserName, 1, true) and userName ~= lobbyUserName) -- needs 1, true or brackets will screw it up
+	local iAmMentioned = lobby:GetMyUserName() and (string.find(message, lobby:GetMyUserName()) and userName ~= lobby:GetMyUserName())
 	local chatColour = (iAmMentioned and notifyColor) or chatColor
 	if self:IsChannelSelected(chanName) and self.activeUnreadMessages and self.activeUnreadMessages ~= 0 then
 		self.activeUnreadMessages = self.activeUnreadMessages + 1
@@ -591,10 +591,6 @@ end
 function ChatWindows:_NotifyTab(tabName, userName, chanName, nameMentioned, message, sound, popupDuration)
 	if tabName ~= self.currentTab then
 		-- TODO: Fix naming of self.tabbars (these are consoles)
-		if (nameMentioned or chanName == "Private") and WG.Chobby.Configuration.gameConfig.sayPrivateSelectAndActivateChatTab then
-			WG.Chobby.interfaceRoot.OpenRightPanelTab("chat")
-			self.tabPanel.tabBar:Select(tabName)
-		end
 		local console = self.tabbars[tabName]
 		local oldMessages = console.unreadMessages
 		console.unreadMessages = console.unreadMessages + 1


### PR DESCRIPTION
title says all

- Other users were able to annoy others by sending private messages. Each was triggering foreground.
- If you were typing in a private chat and press Enter it could happen, that you send it to another user, because this aggressive focus change happened.

(+ little safer implementation to iAmMentioned, copied from ZK)