### PR TITLE
Decode and display first line of tweakunits/tweakdefs modoptions

### DIFF
--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -563,7 +563,7 @@ local function InitializeModoptionsDisplay()
 			return tweakText
 		end
 		local rawValue = Spring.Utilities.Base64Decode(value):gmatch("([^\r\n]*)[\r\n]?")():sub(1,27)
-		if not rawValue:sub(1,2) == "--" then -- First line doesn't start with a comment
+		if not (rawValue:sub(1,2) == "--") then -- First line doesn't start with a comment
 			return tweakText
 		end
 		rawValue = rawValue:sub(3)

--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -555,6 +555,24 @@ local function InitializeModoptionsDisplay()
 		return value
 	end
 
+	local function tweakSummary(value)
+		value = tostring(value)
+		local hash = Spring.Utilities.Base64Encode(VFS.CalculateHash(value,1))
+		local tweakText = string.format("%d:%s", value:len(), hash:sub(1,4))
+		if value:find("[^%w%+/=]") then -- non-base64 character found
+			return tweakText
+		end
+		local rawValue = Spring.Utilities.Base64Decode(value):gmatch("([^\r\n]*)[\r\n]?")():sub(1,27)
+		if not rawValue:sub(1,2) == "--" then -- First line doesn't start with a comment
+			return tweakText
+		end
+		rawValue = rawValue:sub(3)
+		if rawValue:find("[^%w%p ]") then -- (unexpected) non-printable characters found
+			return tweakText
+		end
+		return tweakText .. "\n[" .. rawValue .. "]"
+	end
+
 	local panelModoptions
 
 	local function OnSetModOptions(listener, modopts)
@@ -570,7 +588,13 @@ local function InitializeModoptionsDisplay()
 				if text ~= "\255\255\255\255" then
 					text = text .. "\255\120\120\120" .. "------" .. "\n"
 				end
-				text = text .. tostring(name).. " = \255\255\255\255" .. shortenedValue(value) .. "\n"
+				text = text .. tostring(name).. " = \255\255\255\255"
+				if (key:sub(1,10) == "tweakunits" or key:sub(1,9) == "tweakdefs") then
+					text = text .. tweakSummary(value)
+				else
+					text = text .. shortenedValue(value)
+				end
+				text = text .. "\n"
 				empty = false
 			end
 		end


### PR DESCRIPTION
Currently, players who have just joined a lobby with tweakunits/tweakdefs configured do not have an easy way to know what they do. This is sometimes alleviated by setting a Welcome message, but many players do not notice those messages. As a result, such lobbies often have a stream of new players asking "what does the tweak do?".

This PR updates gui_modoptions_panel.lua to:
- Display the length and a 4-character hash of tweakunits[N]/tweakdefs[N] values (in case tamper-detection is desired)
- If validation is successful, also display up to 25 characters from the first line of the decoded text

The following validation is performed on the configured tweakunits/tweakdefs values. If any validation fails, then only the length and 4-character hash is displayed.
- The configured text does not contain any non-Base64 characters (nothing is decoded if this is false)
- The decoded text begins with "--" (these characters are stripped and not displayed)
- The next 25 characters, or the entire first line (whichever comes first), do not contain any non-printable characters

Before:
![BeforeChange](https://github.com/beyond-all-reason/BYAR-Chobby/assets/1916917/47088014-0a76-4608-9413-973affab9398)

After:
![AfterChange](https://github.com/beyond-all-reason/BYAR-Chobby/assets/1916917/3ee980b8-f01b-4012-8c9e-26a2bf06120a)

Example Base64-encoded tweakunits string (with comment added):
[ExampleTweakunit.txt](https://github.com/user-attachments/files/16093004/ExampleTweakunit.txt)
