### PR TITLE
Replay Menu: Full Playerlist via Tooltip

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -397,6 +397,7 @@ function Configuration:init()
 	self.USER_MP_TOOLTIP_PREFIX = "user_battle_"
 	self.BATTLE_TOOLTIP_PREFIX  = "battle_tooltip_"
 	self.MINIMAP_TOOLTIP_PREFIX = "minimap_tooltip_"
+	self.REPLAY_PLAYER_LIST		= "playerlist_tooltip_"
 
 	-- should be removed at about 1.1.2024 together with all other occurences of tempChangedShowSkill
 	-- remember if new default of showSkill was applied

--- a/LuaMenu/widgets/gui_replay_handler.lua
+++ b/LuaMenu/widgets/gui_replay_handler.lua
@@ -293,6 +293,8 @@ local function CreateReplayEntry(
 	local xOffset = 0
 	local yOffset = 0
 
+	local tooltipString = "playerlist_tooltip_"
+
 	-- Iterate over the teams structure
 	for allyTeamID, team in pairs(teams) do
 		if allyTeamID > 1 then
@@ -352,8 +354,19 @@ local function CreateReplayEntry(
 			playerControl._relativeBounds.right = 0
 			playerControl:UpdateClientArea()
 			yOffset = yOffset + PLAYER_HEIGHT
-		 end
+
+		end
 	end
+
+	for allyTeamID, team in pairs(teams) do
+		for _, player in pairs(team) do
+			tooltipString = tooltipString .. "name:" .. player.name .. ":" .. (player.aiId~=nil and ("aiId:" .. player.aiId) or ("rank:" .. player.rank)) .. ","
+		end
+		tooltipString = tooltipString .. "|"
+	end
+
+	userList.tooltip = tooltipString
+	userList.greedyHitTest = true
 
 	local function CheckReplayFileExists()
 		if not VFS.FileExists(replayPath) then


### PR DESCRIPTION
# Work Done
Updated the Replay Menu Player List to:
- Feature a tooltip that displays the full team/player list
- Reordered the team placement on the smaller list to order teams horizontal first, vertical second
![image](https://github.com/beyond-all-reason/BYAR-Chobby/assets/59885012/7cc1f918-303c-4346-b825-15b4d8a6a5d6)
![image](https://github.com/beyond-all-reason/BYAR-Chobby/assets/59885012/c7b6945f-2c48-43a1-a408-10681d854a7b)


# Testing done
The replay menu has been tested on the following team sizes:
1v1, 2v2, 4v4, 5v5, 8v8 20v20
6 teams of 2, 6 teams of 3, 8 teams of 2,
16 player ffa, 11 player ffa, 5 player ffa