### PR TITLE
limit calls to c.user.whois (interval 0.2 sec)

### DIFF
--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -177,8 +177,35 @@ end
 -- byar-chobby will ask for missing userID or userName depending on which info is known
 ------------------------------------------------------------------------------------------------
 
+local whoisQueueActive = false
+local whoisQueue = {}
+
 function Interface:Whois(userID)
-	self:_SendCommand(concat("c.user.whois", userID))
+	local function SendWhois(userID)
+		self:_SendCommand(concat("c.user.whois", userID))
+		return self
+	end
+
+	local function ProcessWhoisQueue()
+		if #whoisQueue == 0 then
+			whoisQueueActive = false
+			return self
+		end
+
+		SendWhois(whoisQueue[1])
+		
+		table.remove(whoisQueue, 1)
+		WG.Delay(ProcessWhoisQueue, 0.2)
+		return self
+	end
+
+	table.insert(whoisQueue, userID)
+	if whoisQueueActive then
+		return self
+	end
+	
+	whoisQueueActive = true
+	WG.Delay(ProcessWhoisQueue, 0.2)
 	return self
 end
 


### PR DESCRIPTION
For users with many friends a lot of whois commands are sent to teiserver.
This commit is buffering them and sending them with a delay of about 0.4 sec. each.
(WG.Delay is 0.2, but in full chobby context it's more like 0.4)