### PR TITLE
fix(lobby): fix precedence error

### DIFF
--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -1440,7 +1440,7 @@ function Lobby:_OnUpdateUserBattleStatus(userName, status)
 		return
 	end
 
-	if userInfo and not userInfo.battleID or userInfo.battleID ~= self:GetMyBattleID() then
+	if userInfo and (not userInfo.battleID or userInfo.battleID ~= self:GetMyBattleID()) then
 		Spring.Log(LOG_SECTION, LOG.WARNING, "Can't update user's battle status, user is not in our battle:  ", userName)
 		return
 	end


### PR DESCRIPTION
I'm not sure this is exactly what was intended, but does seem to fix the
error.

This was introduced in 10cc30b58d6b262cea74e3a97c30bca9a5187daa .

Bug report: https://discord.com/channels/549281623154229250/1270420358616584318"

Error:

```
[t=00:00:39.911512][f=-000001] [Chili] Error: in `Battle Room Window`:singleplayerWrapper : [string "libs/liblobby/lobby/lobby.lua"]:1443: attempt to index local 'userInfo' (a nil value)
[t=00:00:39.911678][f=-000001] [Chili] Error: stacktrace:
    [string "libs/liblobby/lobby/lobby.lua"]:1443: in _OnUpdateUserBattleStatus
    [string "libs/liblobby/lobby/lobby.lua"]:1483: in _OnAddAi
    [string "libs/liblobby/lobby/interface_skirmish.lua"]:492: in AddAi
    [string "LuaMenu/Widgets/gui_battle_room_window.lua"]:4018: in AddAI
    ... (18 calls)
    [string "LuaHandler/Utilities/specialCallinHandlers.lua"]:229
    [string "libs/chiliui/chili/controls/object.lua"]:277: in SetParent
    ```