### PR TITLE
Disable "Mines, all mine" scenario

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario012.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario012.lua
@@ -432,7 +432,7 @@ Scoring:
 
 }
 
-return scenariodata
+return nil -- scenariodata
 
 --[[
  [Game]


### PR DESCRIPTION
"Mines, all mine" in its current form offers very narrow and tedious gameplay compared to the surrounding scenarios.

This imo is not outweighed by the educational value of the scenario. Mines are not necessary to gameplay, are rarely used in pvp and never used by the AIs. 

I propose disabling the scenario until it is reworked to have more engaging gameplay, either after finishing the mission api or, if considered necessary, before that with the existing scripting tools.