### PR TITLE
Change wording of Leave buttons

### DIFF
--- a/LuaMenu/widgets/chobby/components/interface_root.lua
+++ b/LuaMenu/widgets/chobby/components/interface_root.lua
@@ -989,7 +989,7 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 
 		OnClick = {
 			function ()
-				ConfirmationPopup(LeaveGameFunction, "Are you sure you want to leave the game?", nil, 315, 200)
+				ConfirmationPopup(LeaveGameFunction, "Are you sure you want to leave the battle?", nil, 315, 200)
 			end
 		}
 	}

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -3097,12 +3097,12 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 			name = 'btnQuitBattle',
 			right = 12,
 			y = 7,
-			width = 80,
+			width = 160,
 			height = 45,
 			objectOverrideFont = WG.Chobby.Configuration:GetFont(3),
-			caption = i18n("close"),
+			caption = "Leave Lobby",
 			classname = "negative_button",
-			tooltip = "Close the multiplayer battleroom",
+			tooltip = "Leave the multiplayer battleroom",
 			OnClick = {
 				function()
 					battleLobby:LeaveBattle()


### PR DESCRIPTION
![Screenshot_20240326](https://github.com/user-attachments/assets/c46b8577-b368-498e-974c-4528ca539099)

There is multiple suggestion threads expressing initial confusion over which Leave button does what, this changes the wording on the top right ones that appear when ingame to "Leave Battle" and "Return to Battle" and the wording on the red button that leaves the multiplayer lobby to "Close".