### PR TITLE
Scenario reordering within difficulties

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario005.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario005.lua
@@ -28,7 +28,7 @@ Tips:
 	playerstarty	= "85%", -- Y position of where player comm icon should be drawn, from top left of the map
 	partime 		= 3000, -- par time in seconds
 	parresources	= 1000000, -- par resource amount
-	difficulty		= 5, -- Percieved difficulty at 'normal' level: integer 1-10
+	difficulty		= 5.2, -- Percieved difficulty at 'normal' level: integer 1-10
     defaultdifficulty = "Normal", -- an entry of the difficulty table
     difficulties    = { -- Array for sortedness, Keys are text that appears in selector (as well as in scoring!), values are handicap levels
     -- handicap values range [-100 - +100], with 0 being regular resources

--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario006.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario006.lua
@@ -28,7 +28,7 @@ Tips:
     playerstarty    = "50%", -- Y position of where player comm icon should be drawn, from top left of the map
     partime         = 1800, -- par time in seconds
     parresources    = 1000000, -- par resource amount
-    difficulty      = 7, -- Percieved difficulty at 'normal' level: integer 1-10
+    difficulty      = 7.1, -- Percieved difficulty at 'normal' level: integer 1-10
     defaultdifficulty = "Normal", -- an entry of the difficulty table
     difficulties    = { -- Array for sortedness, Keys are text that appears in selector (as well as in scoring!), values are handicap levels
     -- handicap values range [-100 - +100], with 0 being regular resources

--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario007.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario007.lua
@@ -31,7 +31,7 @@ Scoring:
 	playerstarty	= "75%", -- Y position of where player comm icon should be drawn, from top left of the map
 	partime 		= 1800, -- par time in seconds
 	parresources	= 1000000, -- par resource amount
-	difficulty		= 4, -- Percieved difficulty at 'normal' level: integer 1-10
+	difficulty		= 4.3, -- Percieved difficulty at 'normal' level: integer 1-10
     defaultdifficulty = "Normal", -- an entry of the difficulty table
     difficulties    = { -- Array for sortedness, Keys are text that appears in selector (as well as in scoring!), values are handicap levels
     -- handicap values range [-100 - +100], with 0 being regular resources

--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario009.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario009.lua
@@ -29,7 +29,7 @@ Scoring:
 	playerstarty	= "15%", -- Y position of where player comm icon should be drawn, from top left of the map
 	partime 		= 2000, -- par time in seconds (time a mission is expected to take on average)
 	parresources	= 1000000, -- par resource amount (amount of metal one is expected to spend on mission)
-	difficulty		= 4, -- Percieved difficulty at 'normal' level: integer 1-10
+	difficulty		= 4.2, -- Percieved difficulty at 'normal' level: integer 1-10
     defaultdifficulty = "Normal", -- an entry of the difficulty table
     difficulties    = { -- Array for sortedness, Keys are text that appears in selector (as well as in scoring!), values are handicap levels
     -- handicap values range [-100 - +100], with 0 being regular resources

--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario010.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario010.lua
@@ -27,7 +27,7 @@ Scoring:
 	playerstarty	= "85%", -- Y position of where player comm icon should be drawn, from top left of the map
 	partime 		= 3000, -- par time in seconds (time a mission is expected to take on average)
 	parresources	= 1000000, -- par resource amount (amount of metal one is expected to spend on mission)
-	difficulty		= 5, -- Percieved difficulty at 'normal' level: integer 1-10
+	difficulty		= 5.1, -- Percieved difficulty at 'normal' level: integer 1-10
     defaultdifficulty = "Normal", -- an entry of the difficulty table
     difficulties    = { -- Array for sortedness, Keys are text that appears in selector (as well as in scoring!), values are handicap levels
     -- handicap values range [-100 - +100], with 0 being regular resources

--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario011.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario011.lua
@@ -26,7 +26,7 @@ Scoring:
 	playerstarty	= "45%", -- Y position of where player comm icon should be drawn, from top left of the map
 	partime 		= 300, -- par time in seconds (time a mission is expected to take on average)
 	parresources	= 8000, -- par resource amount (amount of metal one is expected to spend on mission)
-	difficulty		= 9, -- Percieved difficulty at 'normal' level: integer 1-10
+	difficulty		= 9.1, -- Percieved difficulty at 'normal' level: integer 1-10
     defaultdifficulty = "Normal", -- an entry of the difficulty table
     difficulties    = { -- Array for sortedness, Keys are text that appears in selector (as well as in scoring!), values are handicap levels
     -- handicap values range [-100 - +100], with 0 being regular resources

--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario013.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario013.lua
@@ -39,7 +39,7 @@ Scoring:
 	playerstarty	= "50%", -- Y position of where player comm icon should be drawn, from top left of the map
 	partime 		= 1800, -- par time in seconds
 	parresources	= 1000000, -- par resource amount
-	difficulty		= 4, -- Percieved difficulty at 'normal' level: integer 1-10
+	difficulty		= 4.1, -- Percieved difficulty at 'normal' level: integer 1-10
     defaultdifficulty = "Normal", -- an entry of the difficulty table
     difficulties    = { -- Array for sortedness, Keys are text that appears in selector (as well as in scoring!), values are handicap levels
         {name = "Beginner", playerhandicap = 50 , enemyhandicap = -50},

--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario018.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario018.lua
@@ -40,7 +40,7 @@ The difficulty modifier will change the amount of resources you and the enemy re
 	playerstarty	= "25%", -- Y position of where player comm icon should be drawn, from top left of the map
 	partime 		= 1200, -- par time in seconds
 	parresources	= 50000, -- par resource amount
-	difficulty		= 4, -- Percieved difficulty at 'normal' level: integer 1-10
+	difficulty		= 4.4, -- Percieved difficulty at 'normal' level: integer 1-10
     defaultdifficulty = "Normal", -- an entry of the difficulty table
     difficulties    = { -- Array for sortedness, Keys are text that appears in selector (as well as in scoring!), values are handicap levels
         {name = "Beginner", playerhandicap = 50 , enemyhandicap = -50},

--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario021.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario021.lua
@@ -20,7 +20,7 @@ Commander...intel report that it is cortex ba... ,it is...functio...,seek and de
 	playerstarty	= "87%", -- Y position of where player comm icon should be drawn, from top left of the map
 	partime 		= 2400, -- par time in seconds (time a mission is expected to take on average)
 	parresources	= 4000000, -- par resource amount (amount of metal one is expected to spend on mission)
-	difficulty		= 8, -- Percieved difficulty at 'normal' level: integer 1-10
+	difficulty		= 8.1, -- Percieved difficulty at 'normal' level: integer 1-10
     defaultdifficulty = "Normal", -- an entry of the difficulty table
     difficulties    = { -- Array for sortedness, Keys are text that appears in selector (as well as in scoring!), values are handicap levels
     -- handicap values range [-100 - +100], with 0 being regular resources

--- a/LuaMenu/configs/gameConfig/byar/scenarios/scenario022.lua
+++ b/LuaMenu/configs/gameConfig/byar/scenarios/scenario022.lua
@@ -42,7 +42,7 @@ Scoring:
 	playerstarty	= "26%", -- Y position of where player comm icon should be drawn, from top left of the map
 	partime 		= 5400, -- par time in seconds (time a mission is expected to take on average)
 	parresources	= 1500000, -- par resource amount (amount of metal one is expected to spend on mission)
-	difficulty		= 10, -- Percieved difficulty at 'normal' level: integer 1-10
+	difficulty		= 10.1, -- Percieved difficulty at 'normal' level: integer 1-10
     defaultdifficulty = "Normal", -- an entry of the difficulty table
     difficulties    = { -- Array for sortedness, Keys are text that appears in selector (as well as in scoring!), values are handicap levels
     -- handicap values range [-100 - +100], with 0 being regular resources

--- a/LuaMenu/widgets/gui_scenario_window.lua
+++ b/LuaMenu/widgets/gui_scenario_window.lua
@@ -326,7 +326,7 @@ local function CreateScenarioPanel(shortname, sPanel)
 		height = "5%",
 		parent = sPanel,
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-		caption = tostring(scen.difficulty) .. "/15",
+		caption = tostring(math.floor(scen.difficulty)) .. "/15",
 	}
 
 	local lblpartimeText = Label:New{


### PR DESCRIPTION
The current problem is that while the scenario difficulties allow for reordering scenarios in difficulty blocks, the ordering within the same difficulty is random and may change with any update to the scenarios, which may result in poor pacing of scenarios.

This PR changes the scenario window display to round down the displayed difficulty to an integer. This allows non-integer scenario difficulties in their .lua files.

The scenarios are then changed to appear in the following order:

001. Fortress Assault - only 1/10, no change
002. A Head Start - only 2/10, no change
003. A Helping Hand - only 3/10, no change
004. A Safe Haven - this 4/10 scenario has very straightforward gameplay and is the most appropriate as an entry into this difficulty bracket. Allows a buffer to finally understand the units and expanding to your half of the map.
005. Testing The Waters - 4/10 in difficulty, but with less straightforward ways to win, which sometimes leads to new player confusion if placed earlier.
006. Back from the Dead - 4/10, resurrection tutorial aside, this is objectively more difficult than A Safe Haven and belongs here.
007. The Sky is the Limit - 4/10, a bit of a gimmick scenario so placed further into its difficulty block, hopefully the player is invested enough by now to sit through an air tutorial despite air gameplay being comparatively limited in BAR
008. One Robot Army - 4/10, the player should have to macro basics down, time to learn micro.
009. King of the Hill - 5/10. The culmination of tutorial scenarios, use everything you've learned to overcome impossible odds. The odds are actually not that impossible, the scenario is deceptively easy.
010. Keep your secrets - 5/10, mostly a straight 1v1 with a focus on the commander snipe.
011. Steal Cortex's Tech - 5/10, a gimmick scenario place here to be between mostly straightforward missions.
012. One by One - 6/10, a straightforward ffa.
013. David vs Goliath - 7/10. No-build mission. Alternating macro and micro missions for variety.
014. Infantry Simulator - 7/10. The focus is building hordes of infantry. Alternating macro and micro missions for variety.
015. World War XXV - 8/10. A mostly straightforward team ffa mission where you don't actually have a team, but have enough free space and income to rival a full team.
016. New Beginning - 8/10. Gimmick fortress assault mission placed between straightforward missions for pacing.
017. Outsmart the Barbarians - 9/10. A straight 1v3. Alternating normal and gimmick missions for variety.
018. Tick Tock - 9/10. A speedmetal eco challenge. Alternating normal and gimmick missions for variety.
019. Catch these Rare Comets - 10/10. A straight 1v3 but harder map. Alternating normal and gimmick missions for variety.
020. Supremacy - 10/10. The hardest mission, rightfully last in the list