### PR TITLE
Check if cols is nan and set to 0 if so 

### DIFF
--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -997,6 +997,10 @@ local function getReplayPlayerListTooltip(teamList)
 		table.sort(teamList, SortTeamsBySkill)
 	end
 
+	if (cols ~= cols) then
+		cols = 0
+	end
+
 	replayTooltip.mainStackPanel = Panel:New {
 			name = 'mainStackPanel',
 			x = 0,


### PR DESCRIPTION
Fixes interface breakage if a replay with no players is moused over
![Screenshot_Beyond All Reason_1](https://github.com/user-attachments/assets/86e0702c-c01e-4b8e-8a97-46f9bac7d0a7)
