### PR TITLE
Add support for BarManager updates with multiple bosses. (v2)

### DIFF
--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -1510,7 +1510,7 @@ end
 -- message = {"BattleStateChanged": {"locked": "locked", "autoBalance": "advanced", "teamSize": "8", "nbTeams": "2", "balanceMode": "clan;skill", "preset": "team", "boss": "Fireball"}}
 function Lobby:ParseBarManager(battleID, message)
 	local battleInfo = {}
-	local newBoss
+	local newBosses
 
 	local barManagerSettings = spJsonDecode(message)
 	if not barManagerSettings['BattleStateChanged'] then
@@ -1523,13 +1523,13 @@ function Lobby:ParseBarManager(battleID, message)
 				battleInfo["bossed"] = false
 			else
 				battleInfo["bossed"] = true
-				newBoss = v
+				newBosses = v
 			end
 		elseif WG.Chobby.Configuration.barMngSettings[k] then
 			battleInfo[k] = v
 		end
 	end
-	return battleInfo, newBoss
+	return battleInfo, newBosses
 end
 
 function Lobby:_OnSaidBattleEx(userName, message, sayTime)
@@ -1541,20 +1541,25 @@ function Lobby:_OnSaidBattleEx(userName, message, sayTime)
 			Spring.Log(LOG_SECTION, LOG_WARNING, "couldn't match barmanager message to any known battle", tostring(founder))
 			return
 		end
-		local battleInfo, newBoss = self:ParseBarManager(battleID, bmMessage)
+		local battleInfo, newBosses = self:ParseBarManager(battleID, bmMessage)
 		if next(battleInfo) then
 			self:super("_OnUpdateBattleInfo", battleID, battleInfo)
 
 			if battleInfo.bossed ~= nil then
-				if battleInfo.bossed then
-					self:_OnUpdateUserBattleStatus(newBoss, {isBoss = true})
-				else
-					local battleUsers = self.battles[battleID].users
-					for _, battleUserName in pairs(battleUsers) do
-						if self.userBattleStatus[battleUserName] and self.userBattleStatus[battleUserName].isBoss then
-							self:_OnUpdateUserBattleStatus(battleUserName, {isBoss = false})
-						end
+				local battleUsers = self.battles[battleID].users
+				local bossStates = {}
+				for _, battleUserName in pairs(battleUsers) do
+					if self.userBattleStatus[battleUserName] and self.userBattleStatus[battleUserName].isBoss then
+						bossStates[battleUserName] = false
 					end
+				end
+				if battleInfo.bossed then
+					for bossUsername in string.gmatch(newBosses, "([^,]+)") do
+						bossStates[bossUsername] = true
+					end
+				end
+				for battleUserName,bossState in pairs(bossStates) do
+					self:_OnUpdateUserBattleStatus(battleUserName, {isBoss = bossState})
 				end
 			end
 			


### PR DESCRIPTION
Currently, "boss" state is updated as follows:
- If the "boss" state is blank, mark all players as not-boss.
- If the "boss" state is a username, mark that player as boss. (Other players are left as-is).

That works well when there is only a single boss, but it quickly breaks down when more than one boss is present. For example, if a lobby has 2 bosses, a newly-joining player will only see a crown for a single boss.

The cleanest fix for this behavior is to have BarManager send all bosses to clients, rather than just the most-recent boss. This is a better match for how bosses are tracked by SPADS, but it requires an update to both BYAR-Chobby and BarManager.

This patch implements the BYAR-Chobby side of the above change. With this change, the "boss" state is updated as follows:
- If the boss state is blank, mark all *bosses* as not-boss
- If the boss state is one or more usernames (comma-separated), mark those players as boss and unmark any other bosses as not-boss.

This does introduce a small cosmetic issue for multi-boss lobbies running the current BarManager code; specifically, only one boss will have a crown at any single point in time. Since multi-boss lobbies are relatively rare, and this issue will no longer occur once BarManager has been updated, this should not have a significant impact to players.

(v2) Add a missing nil check for `self.userBattleStatus[battleUserName]`.