### PR TITLE
Make `Disable Boss` send `!unboss USERNAME` instead of `!boss`.

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -1113,7 +1113,7 @@ local function GetUserControls(userName, opts)
 					elseif selectedName == "Make Boss" then
 						lobby:SayBattle("!boss "..userName)
 					elseif selectedName == "Disable Boss" then
-						lobby:SayBattle("!boss")
+						lobby:SayBattle("!unboss "..userName)
 					elseif selectedName == "Force Spectator" then
 						lobby:SayBattle("!spec "..userName)
 					elseif selectedName == "Report" and Configuration.gameConfig.link_reportPlayer ~= nil then


### PR DESCRIPTION
### Submitted as a Draft PR, pending the full deployment of https://github.com/beyond-all-reason/spads_config_bar/pull/170 (currently only merged to the Integration branch).

This patch updates the `Disable Boss` button (in the Lobby player- list's right-click menu) to send `!unboss USERNAME` in chat, instead of `!boss`.

An explanation of the benefits for a dedicated `!unboss` command is available in the PR which adds that command: https://github.com/beyond-all-reason/spads_config_bar/pull/170

Sometime after this PR is merged, I plan to disable the `!boss` command (without parameters) via https://github.com/beyond-all-reason/spads_config_bar/pull/171