### PR TITLE
Switch to the "Login" tab after successful registration.

### DIFF
--- a/LuaMenu/widgets/gui_login_window.lua
+++ b/LuaMenu/widgets/gui_login_window.lua
@@ -123,6 +123,9 @@ local function InitializeListeners()
 			registerRecieved = true
 			WG.Delay(ResetRegisterRecieved, 0.8)
 			currentLoginWindow.txtError:SetText(Configuration:GetSuccessColor() .. "Registered!")
+			if currentLoginWindow.tabPanel then
+				currentLoginWindow.tabPanel:ChangeTab("login")
+			end
 		end
 	end
 


### PR DESCRIPTION
Consider the following user-story:
1. Attempt to register a new account
2. Receive confirmation that the registration was successful.
3. Display the EULA / verification code widget
4. Accept and send code
5. Receive a rejection from the server, with error message

Currently, the error message from step 5 is displayed on the "Login" tab; however, the Login Window widget remains on the previously-active "Register" tab. As a result, it may appear that the registration silently failed.

This patch makes the "Login" tab active immediately after a successful registration. This makes any verification-code-related error messages that the server may send afterwards clearly visible.