### PR TITLE
Fix Scenario Personal Records: show correct best time / resources

### DIFF
--- a/LuaMenu/widgets/gui_scenario_window.lua
+++ b/LuaMenu/widgets/gui_scenario_window.lua
@@ -627,7 +627,15 @@ local function CreateScenarioPanel(shortname, sPanel)
 		for i, diff in pairs(scen.difficulties) do
 			if diff.name == newdifficultyname then mydifficulty = diff end
 		end
-		lbldifflevelpersonal:SetCaption("Difficulty level: "..tostring(mydifficulty.name))
+		lbldifflevelpersonal:SetCaption("Difficulty: "..tostring(mydifficulty.name))
+    
+    myscores = GetBestScores(scen.scenarioid, scen.version, mydifficulty.name)
+    if myscores == nil then
+      myscores = {time = "0", resources = "0"}
+    end
+    
+    mytime:SetCaption(SecondsToTimeString(myscores.time))
+    myresources:SetCaption(string.format( "%.2fK metal",myscores.resources/1000.0))
 	end
 
 	local difficultCombo = ComboBox:New{


### PR DESCRIPTION
The scenarios keep track of the player's best time / resources for EACH difficulty, but there wasn't a way to see any of them other than "Normal" difficulty. With this patch, it will now show the personal record of the difficulty selected.