### PR TITLE
Make public BARb custom profiles

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/aiCustomData.lua
+++ b/LuaMenu/configs/gameConfig/byar/aiCustomData.lua
@@ -1,5 +1,5 @@
 local customProfiles = {
-	['BARb stable'] = {
+	['BARb'] = {
 		{
 			key  = 'hard_aggressive',  -- must conform to directory name
 			name = 'Hard | Aggressive',  -- human readable name displayed in a list
@@ -9,7 +9,7 @@ local customProfiles = {
 }
 
 local blacklistProfiles = {
--- 	['BARb stable'] = {
+-- 	['BARb'] = {
 -- 		dev = true,
 -- 		hard = true,
 -- 	},

--- a/LuaMenu/widgets/chobby/components/ai_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/ai_list_window.lua
@@ -121,7 +121,7 @@ function AiListWindow:MakeAiOptionsButton(displayName, tooltip, shortName, versi
 					self:AddAi(displayName, shortName, version, aioptions)
 					self:HideWindow()
 				end
-				WG.Chobby.AiOptionsWindow(displayName, path, successFunc)
+				WG.Chobby.AiOptionsWindow(displayName, shortName, path, successFunc)
 			end
 		},
 	}

--- a/LuaMenu/widgets/chobby/components/aioptions_window.lua
+++ b/LuaMenu/widgets/chobby/components/aioptions_window.lua
@@ -1,6 +1,6 @@
 AiOptionsWindow = ListWindow:extends{}
 
-function AiOptionsWindow:init(displayName, optionsPath, successFunc)
+function AiOptionsWindow:init(displayName, shortName, optionsPath, successFunc)
 	self:super('init', lobbyInterfaceHolder, displayName.." Options", false, "main_window", nil, {6, 7, 7, 4})
 	self.window:SetPos(nil, nil, 650, 700)
 	WG.Chobby.PriorityPopup(self.window, nil, nil, nil, true)
@@ -26,7 +26,7 @@ function AiOptionsWindow:init(displayName, optionsPath, successFunc)
 
 	-- AIOptions
 	local options = VFS.Include(optionsPath)
-	self:CustomizeProfiles(displayName, options)
+	self:CustomizeProfiles(shortName, options)
 	for i = #options, 1, -1 do
 		self:AddEntry(options[i], i)
 	end
@@ -225,10 +225,10 @@ function AiOptionsWindow:MakeString(data)
 	}
 end
 
-function AiOptionsWindow:CustomizeProfiles(displayName, options)
+function AiOptionsWindow:CustomizeProfiles(shortName, options)
 	for _, data in ipairs(options) do
 		if data.type == "list" and data.key == "profile" then
-			WG.Chobby.Configuration.gameConfig.CustomAiProfiles(displayName, data.items)  -- in place
+			WG.Chobby.Configuration.gameConfig.CustomAiProfiles(shortName, data.items)  -- in place
 			return
 		end
 	end


### PR DESCRIPTION
Fix for custom profile being hidden behind `Simplified AI list` unticked option.
It supposed to be public.