### PR TITLE
Remove spring-chobby dev directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ git clone https://github.com/beyond-all-reason/Beyond-All-Reason.git BAR.sdd
 
 1. Use Zerobrane Studio dev env, open up any chobby Beyond-All-Reason\data\*.lua file with Zerobrane studio, then set Project->Project Directory->From current file
 2. This allows you to ctrl+shift+f to find any text in all of chobby, useful
-3. Do NOT try to edit anything in Chobby.sdd! If you want to edit something in Chobby.sdd that is not overwritten by the mutator BYAR-Chobby (e.g. does not exist in BYAR-Chobby.sdd), then copy it over to BYAR-Chobby.sdd first and commit it (so we have a baseline).
-4. Open infolog.txt in notepad++ or anything to grep for errors.
+3. Open infolog.txt in notepad++ or anything to grep for errors.
 
 ## How to make new launcher releases:
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,6 @@ This should result in the following directory being present: `/path/to/install/d
 
 4. Choose the `Dev Lobby` config from the launcher's top right dropdown menu which will run the lobby version on your PC. You can now develop and test any BYAR specific lobby functionality.
 
-5. If you want to develop Chobby itself, clone it in the `games` directory similar to step 3:
-
-```
-git clone https://github.com/Spring-Chobby/Chobby.git Chobby.sdd
-```
-
-You must also change the `depend` table in `BYAR-Chobby.sdd/modinfo.lua` to use `Chobby $VERSION` instead of `rapid://chobby:test`.
-
 To enable debugmode, make an empty `devmode.txt` in the already used game install directory (`/data/`), and then the `Settings/Developer` tab will appear in the lobby. All debug messages are visible in th Debug chat panel.
 
 # Developing the Game


### PR DESCRIPTION
This step has not been needed since base chobby was merged.