### PR TITLE
Feature/remember password option

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -76,6 +76,7 @@ function Configuration:init()
 	self.suggestedNameFromSteam = false
 	self.password = false
 	self.autoLogin = true
+	self.rememberPassword = false
 	self.uploadLogPrompt = 'Prompt'
 	self.firstLoginEver = true
 	self.canAuthenticateWithSteam = false

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -636,6 +636,10 @@ function Configuration:SetConfigData(data)
 end
 
 function Configuration:GetConfigData()
+	local rememberedPassword = false
+	if self.rememberPassword then
+		rememberedPassword = self.password
+	end
 	return {
 		tempChangedShowSkill = self.tempChangedShowSkill, -- should be removed at 1.1.2024
 		autoLaunchAsSpectator = self.autoLaunchAsSpectator,
@@ -644,9 +648,9 @@ function Configuration:GetConfigData()
 		userName = self.userName,
 		suggestedNameFromSteam = self.suggestedNameFromSteam,
 		uiScalesForScreenSizes = self.uiScalesForScreenSizes,
-		password = self.password,
-		autoLogin = self.autoLogin,
 		rememberPassword = self.rememberPassword,
+		password = rememberedPassword,
+		autoLogin = self.autoLogin,
 		uploadLogPrompt = self.uploadLogPrompt,
 		firstLoginEver = self.firstLoginEver,
 		wantAuthenticateWithSteam = self.wantAuthenticateWithSteam,

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -76,7 +76,7 @@ function Configuration:init()
 	self.suggestedNameFromSteam = false
 	self.password = false
 	self.autoLogin = true
-	self.rememberPassword = false
+	self.rememberPassword = true
 	self.uploadLogPrompt = 'Prompt'
 	self.firstLoginEver = true
 	self.canAuthenticateWithSteam = false

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -646,6 +646,7 @@ function Configuration:GetConfigData()
 		uiScalesForScreenSizes = self.uiScalesForScreenSizes,
 		password = self.password,
 		autoLogin = self.autoLogin,
+		rememberPassword = self.rememberPassword,
 		uploadLogPrompt = self.uploadLogPrompt,
 		firstLoginEver = self.firstLoginEver,
 		wantAuthenticateWithSteam = self.wantAuthenticateWithSteam,

--- a/LuaMenu/widgets/chobby/components/interface_root.lua
+++ b/LuaMenu/widgets/chobby/components/interface_root.lua
@@ -387,6 +387,9 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 
 	-- Exit button
 	local function ExitSpring()
+		if not Configuration.rememberPassword then
+			Configuration.password = ""
+		end
 		Spring.Echo("Quitting...")
 		Spring.Quit()
 	end

--- a/LuaMenu/widgets/chobby/components/interface_root.lua
+++ b/LuaMenu/widgets/chobby/components/interface_root.lua
@@ -387,9 +387,6 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 
 	-- Exit button
 	local function ExitSpring()
-		if not Configuration.rememberPassword then
-			Configuration.password = ""
-		end
 		Spring.Echo("Quitting...")
 		Spring.Quit()
 	end

--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -399,7 +399,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	self.cbRememberPassword = Checkbox:New {
 		x = 15,
 		width = 215,
-		y = self.windowHeight - 145,
+		y = self.windowHeight - 215,
 		height = 35,
 		boxalign = "right",
 		boxsize = 15,
@@ -415,7 +415,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	self.cbRememberPasswordRegister = Checkbox:New {
 		x = 15,
 		width = 215,
-		y = self.windowHeight - 145,
+		y = self.windowHeight - 215,
 		height = 35,
 		boxalign = "right",
 		boxsize = 15,

--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -396,6 +396,38 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	}
 	registerChildren[#registerChildren + 1] = self.cbAutoLoginRegister
 
+	self.cbRememberPassword = Checkbox:New {
+		x = 15,
+		width = 215,
+		y = self.windowHeight - 145,
+		height = 35,
+		boxalign = "right",
+		boxsize = 15,
+		caption = i18n("rememberPassword"),
+		checked = Configuration.rememberPassword,
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
+		OnClick = {function (obj)
+			Configuration:SetConfigValue("rememberPassword", obj.checked)
+		end},
+	}
+	loginChildren[#loginChildren+1] = self.cbRememberPassword
+
+	self.cbRememberPasswordRegister = Checkbox:New {
+		x = 15,
+		width = 215,
+		y = self.windowHeight - 145,
+		height = 35,
+		boxalign = "right",
+		boxsize = 15,
+		caption = i18n("rememberPassword"),
+		checked = Configuration.rememberPassword,
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
+		OnClick = {function (obj)
+			Configuration:SetConfigValue("rememberPassword", obj.checked)
+		end},
+	}
+	registerChildren[#registerChildren + 1] = self.cbRememberPasswordRegister
+
 	self.txtError = TextBox:New {
 		x = 15,
 		right = 15,

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -42,6 +42,7 @@ return {
 		alt_acknowledgement = 'By pressing Register, you acknowledge the\nrules concerning alt accounts.',
 		register_steam_long = "Enter a username for multiplayer",
 		autoLogin = "Login automatically",
+		rememberPassword = "Remember password",
 		authenticateSteam = "Authenticate with Steam",
 		play_offline = "Play offline",
 		keys = "Keys",
@@ -367,6 +368,7 @@ return {
 		register_long = "Account erstellen",
 		register_steam_long = "Benutzername für den Mehrspieler-Modus wählen",
 		autoLogin = "Automatisch einloggen",
+		rememberPassword = "Passwort merken",
 		authenticateSteam = "Mit Steam authentifizieren",
 		play_offline = "Offline spielen",
 		-- gui_battle_status_panel

--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -993,6 +993,25 @@ local function GetLobbyTabControls()
 	children[#children + 1] = autoLogin
 	offset = offset + ITEM_OFFSET
 
+	local rememberPassword = Checkbox:New {
+		x = 20,
+		width = CHECK_WIDTH,
+		y = offset,
+		height = 30,
+		boxalign = "right",
+		boxsize = 20,
+		caption = i18n("rememberPassword"),
+		checked = Configuration.rememberPassword or false,
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
+		OnChange = {function (obj, newState)
+			freezeSettings = true
+			Configuration:SetConfigValue("rememberPassword", newState)
+			freezeSettings = false
+		end},
+	}
+	children[#children + 1] = rememberPassword
+	offset = offset + ITEM_OFFSET
+
 	local cbQueueExitConfirmPromptDoNotAskAgain
 	cbQueueExitConfirmPromptDoNotAskAgain, offset = AddCheckboxSetting(offset, i18n("queueExitConfirmPromptDoNotAskAgain"), "queueExitConfirmPromptDoNotAskAgain", true, nil , i18n("queueExitConfirmPromptDoNotAskAgain_tooltip"))
 	children[#children + 1] = cbQueueExitConfirmPromptDoNotAskAgain
@@ -1192,6 +1211,9 @@ local function GetLobbyTabControls()
 		end
 		if key == "autoLogin" then
 			autoLogin:SetToggle(value)
+		end
+		if key == "rememberPassword" then
+			rememberPassword:SetToggle(value)
 		end
 		if key == "randomSkirmishSetup" then
 			if value == true then


### PR DESCRIPTION
I wanted an option to not remember my password between sessions, partly to stop my son from connecting to multiplayer games, but also discovered the password is stored in plain text in the config file which isn't great.

Added checkbox to the register, login and settings screen to "Remember password" and added code to clear password on exit if this is not checked.