### PR TITLE
Handle Invalid Base64 tweaks somewhat

### DIFF
--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -886,7 +886,12 @@ end
 				end
 				text = text .. tostring(name).. " = \255\255\255\255"
 				if (key:sub(1,10) == "tweakunits" or key:sub(1,9) == "tweakdefs") then
-					text = text .. tweakSummary(value)
+					local success, result = pcall(tweakSummary, value)
+					if success then
+						text = text .. result
+					else
+						text = text .. "\255\255\75\75".."Couldn't Parse\n".."\255\128\128\128"..shortenedValue(value)
+					end
 				else
 					text = text .. shortenedValue(value)
 				end

--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -459,6 +459,9 @@ local function ProcessStringOption(data, index)
 
 	local control
 	local oldText = localModoptions[data.key] or modoptionDefaults[data.key]
+
+	local textHidden = string.len(oldText) <= 1
+
 	local label = Label:New {
 		x = 5,
 		y = 0,
@@ -467,7 +470,7 @@ local function ProcessStringOption(data, index)
 		valign = "center",
 		align = "left",
 		caption = data.name,
-		objectOverrideFont = oldText == modoptionDefaults[data.key] and WG.Chobby.Configuration:GetFont(2) or WG.Chobby.Configuration:GetFont(2, "Changed2", {color = MARKED_AS_CHANGED_COLOR}),
+		objectOverrideFont = textHidden and WG.Chobby.Configuration:GetFont(2) or WG.Chobby.Configuration:GetFont(2, "Changed2", {color = MARKED_AS_CHANGED_COLOR}),
 		tooltip = data.desc,
 	}
 
@@ -477,10 +480,10 @@ local function ProcessStringOption(data, index)
 		y = 1,
 		width = 300,
 		height = 30,
-		text   = oldText,
+		text   = textHidden and "" or oldText,
 		useIME = false,
 		hint = data.hint,
-		objectOverrideFont = oldText == modoptionDefaults[data.key] and WG.Chobby.Configuration:GetFont(2) or WG.Chobby.Configuration:GetFont(2, "Changed2", {color = MARKED_AS_CHANGED_COLOR}),
+		objectOverrideFont = textHidden and WG.Chobby.Configuration:GetFont(2) or WG.Chobby.Configuration:GetFont(2, "Changed2", {color = MARKED_AS_CHANGED_COLOR}),
 		objectOverrideHintFont = WG.Chobby.Configuration:GetFont(11),
 		tooltip = data.desc,
 		OnFocusUpdate = {
@@ -488,13 +491,24 @@ local function ProcessStringOption(data, index)
 				if obj.focused then
 					return
 				end
-				localModoptions[data.key] = obj.text
-				if obj.text == modoptionDefaults[data.key] then
+
+				if string.len(obj.text) <= 1 then
+					if not textHidden then
+						localModoptions[data.key] = 0
+					end
+					obj.text = ""
+					textBox.font = WG.Chobby.Configuration:GetFont(2)
+					label.font = WG.Chobby.Configuration:GetFont(2)
+
+				else
+					localModoptions[data.key] = obj.text
+					if obj.text == modoptionDefaults[data.key] then
 						textBox.font = WG.Chobby.Configuration:GetFont(2)
 						label.font = WG.Chobby.Configuration:GetFont(2)
-				else
+					else
 						textBox.font = WG.Chobby.Configuration:GetFont(2, "Changed2", {color = MARKED_AS_CHANGED_COLOR})
 						label.font = WG.Chobby.Configuration:GetFont(2, "Changed2", {color = MARKED_AS_CHANGED_COLOR})
+					end
 				end
 			end
 		}
@@ -872,6 +886,10 @@ end
 					for i = 1, #option.unlock do
 						hidenOptions[option.unlock[i]] = true
 					end
+				end
+			elseif option.type == "string" then
+				if panelModoptions[option.key] and string.len(panelModoptions[option.key]) == 1 then
+					hidenOptions[option.key] = true
 				end
 			end
 		end


### PR DESCRIPTION
String Modoptions:
  Previosuly String modoptions couldn't be unset once set. This change makes it so that String modoptions set to a 1 character long option get hidden, and trying to set it to nothing sends through a single character to give the user an illusion of being able to unset the value. *Multiplyaer issue only

- trying to set it up to an empty string (not nil), now gets replaced with character `0` zero
- String Modoptions who's value is 1 character long now gets hidden, as the user was never able to unset

In addition the user gets warned when the base64 string for tweakdefs or tweakunits couldn't be parsed.

## Test steps:

Set either of the tweak fields to `a`
- Previously this would break the changed options panel, and maybe even crash the game on launch
- Now it will get hidden, (latter issue is game side issue)

Set either of the fields to `qqqqq`
- Now user will be warned that it couldn't be parsed

Set either of the fields to blank in multiplayer
- Previosuly a "`!bset tweaks/debug`" would go through, but have no effects due to no value being passed
- Now a value of 0 will be passed, hidden from the user giving a feeling of unsetting it, and hopefully somehow be handled by whatever processes the modoption

## Screenshots

![image](https://github.com/user-attachments/assets/35951f6b-5f4f-40e2-a71c-a6b9d512a337)

