### PR TITLE
Fix Modoptions Reset Button not working in Multiplayer

### DIFF
--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -706,10 +706,10 @@ local function CreateModoptionWindow()
 	end
 
 	local function ResetFunc()
+		localModoptions = {}
 		for key, value in pairs(modoptionDefaults) do
 			UpdateControlValue(key, value)
 		end
-		localModoptions = {}
 	end
 
 	buttonReset = Button:New {


### PR DESCRIPTION
Emptying the local modoptions list didn't work in multiplayer as it is what gets itterated over to call bset commands.
I don't know if it needs to be emptied, as the follow up command will refill it with all the modoptions in their default values.