### PR TITLE
Address option panel erroring out when attempting to load bot configs

### DIFF
--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -737,7 +737,7 @@ function OptionpresetsPanel.ShowPresetPanel()
 	end
 
 
-	local currentAINames = battleLobby.battleAis
+	local currentAINames = lobby.battleAis
 	currentAITable = {}
 	for _, value in pairs(currentAINames) do
 		local aiStatus = battleLobby:GetUserBattleStatus(value)


### PR DESCRIPTION
This still isn't working quite right but at least it doesn't lock up