### PR TITLE
Download prior engine versions on demand: Moose 

### DIFF
--- a/LuaMenu/widgets/api_download_handler.lua
+++ b/LuaMenu/widgets/api_download_handler.lua
@@ -176,7 +176,7 @@ local function GetDownloadIndexByName(downloadList, downloadName)
 	Spring.Utilities.TableEcho(downloadList)
 	for i = 1, #downloadList do
 		local data = downloadList[i]
-		if data.name == downloadName or data.resource and data.resource.destination:gsub("\\","\\\\"):gsub("/", "//") == downloadName then
+		if data.name == downloadName then
 			Spring.Echo("found index",  i)
 			return i
 		end
@@ -405,7 +405,7 @@ function wrapperFunctions.DownloadFinished(name, fileType, success, aborted)
 end
 
 function wrapperFunctions.DownloadFileProgress(name, progress, totalLength)
-	Spring.Echo("DownloadFileProgress", name, progress, totalLength)
+	Spring.Echo("DownloadFileProgress (name, progress, totalLength)", name, progress, totalLength)
 	local index = GetDownloadIndexByName(downloadQueue, name)
 	Spring.Echo("Index", index)
 	if not index then
@@ -414,6 +414,7 @@ function wrapperFunctions.DownloadFileProgress(name, progress, totalLength)
 	end
 
 	totalLength = (tonumber(totalLength or 0) or 0)/1023^2
+	Spring.Echo("DownloadFileProgress, call Listeners('DownloadProgress', downloadQueue[index].id, totalLength*math.min(1, (tonumber(progress or 0) or 0)/100), totalLength, downloadQueue[index].name)",downloadQueue[index].id, totalLength*math.min(1, (tonumber(progress or 0) or 0)/100), totalLength, downloadQueue[index].name)
 	CallListeners("DownloadProgress", downloadQueue[index].id, totalLength*math.min(1, (tonumber(progress or 0) or 0)/100), totalLength, downloadQueue[index].name)
 end
 
@@ -431,13 +432,15 @@ function widget:Update()
 end
 
 function widget:DownloadProgress(downloadID, downloaded, total)
-	Spring.Echo("DownloadHandler widget.DownloadProgress")
+	Spring.Echo("DownloadHandler:DownloadProgress")
 	local index = GetDownloadBySpringDownloadID(downloadQueue, downloadID)
 	if not index then
+		Spring.Echo("DownloadHandler:DownloadProgress not index")
 		return
 	end
 	downloaded = downloaded / 1024 / 1024
 	total = total / 1024 / 1024
+	Spring.Echo("DownloadHandler:DownloadProgress callingListeners(downloadQueue[index].id, downloaded, total, downloadQueue[index].name)", downloadQueue[index].id, downloaded, total, downloadQueue[index].name)
 	CallListeners("DownloadProgress", downloadQueue[index].id, downloaded, total, downloadQueue[index].name)
 end
 

--- a/LuaMenu/widgets/api_download_handler.lua
+++ b/LuaMenu/widgets/api_download_handler.lua
@@ -125,7 +125,6 @@ local function DownloadSortFunc(a, b)
 end
 
 local function DownloadQueueUpdate()
-	Spring.Echo("DownloadHandler:local DownloadQueueUpdate")
 	requestUpdate = false
 
 	if #downloadQueue == 0 then
@@ -134,10 +133,8 @@ local function DownloadQueueUpdate()
 	end
 	table.sort(downloadQueue, DownloadSortFunc)
 
-	Spring.Echo("front:")
 	local front = downloadQueue[1]
 	
-	Spring.Utilities.TableEcho(front)
 	if not front.active then
 		if USE_WRAPPER_DOWNLOAD and WG.WrapperLoopback and WG.WrapperLoopback.DownloadFile then
 			WG.WrapperLoopback.DownloadFile(front.name, typeMap[front.fileType], front.resource)
@@ -172,16 +169,12 @@ local function GetDownloadBySpringDownloadID(downloadList, springDownloadID)
 end
 
 local function GetDownloadIndexByName(downloadList, downloadName)
-	Spring.Echo("GetDownloadIndexByName", downloadName)
-	Spring.Utilities.TableEcho(downloadList)
 	for i = 1, #downloadList do
 		local data = downloadList[i]
 		if data.name == downloadName then
-			Spring.Echo("found index",  i)
 			return i
 		end
 	end
-	Spring.Echo("return nil")
 	return nil
 end
 
@@ -191,8 +184,6 @@ local function AssociatedSpringDownloadID(springDownloadID, name, fileType)
 		return false
 	end
 	downloadQueue[index].springDownloadID = springDownloadID
-	Spring.Echo("AssociatedSpringDownloadID downloadQueue")
-	Spring.Utilities.TableEcho(downloadQueue)
 end
 
 local function RemoveDownload(name, fileType, putInRemoveList, removalType)
@@ -201,16 +192,12 @@ local function RemoveDownload(name, fileType, putInRemoveList, removalType)
 	-- and retrying it up to retrycount times will succeed.
 	-- A game download will also return with failure often so we use VFS.ScanAllDirs() to check if we did actually
 	-- successfully download it: if we were truly unsuccessful, then we retry downloading it again.
-	Spring.Echo("RemoveDownload name, fileType, putInRemoveList,removalType",name, fileType, putInRemoveList,removalType)
 	local index = GetDownloadIndex(downloadQueue, name, fileType)
-	Spring.Echo("index=", index)
 	if not index then
-		Spring.Echo("not index")
 		return false
 	end
 
 	local downloadID = downloadQueue[index].id
-	Spring.Echo("downloadID=", downloadID)
 
 	if removalType == "success" then
 		CallListeners("DownloadFinished", downloadID, name, fileType)
@@ -285,8 +272,6 @@ function externalFunctions.QueueDownload(name, fileType, priority, retryCount, r
 		retryCount = retryCount or 0,
 		resource = resource,
 	}
-	Spring.Echo("DownloadHandler.external.QueueDownload downloadQueue:")
-	Spring.Utilities.TableEcho(downloadQueue)
 	requestUpdate = true
 	CallListeners("DownloadQueued", downloadCount, name, fileType, resource)
 end
@@ -351,28 +336,21 @@ end
 
 local function haveEngineDir(path)
 	local springExecutable = Platform.osFamily == "Windows" and "spring.exe" or "spring"
-	Spring.Echo("springExecutable", springExecutable)
-	Spring.Echo("haveEngineDir", VFS.FileExists(path .. "//" .. springExecutable))
 	return VFS.FileExists(path .. "//" .. springExecutable)
 end
 
 function externalFunctions.MaybeDownloadArchive(name, archiveType, priority, resource)
-	Spring.Echo("MaybeDownloadArchive", name, archiveType, priority, resource)
 	if archiveType == "resource" then
-		Spring.Echo("MaybeDownloadArchive resource")
 		local haveEngine = haveEngineDir(resource.destination)
-		Spring.Echo("MaybeDownloadArchive haveEngine", haveEngine)
 		if not haveEngine then
 			externalFunctions.QueueDownload(name, archiveType, priority, _, resource)
 		end
 		return
 
 	elseif not VFS.HasArchive(name) then
-		Spring.Echo("MaybeDownloadArchive not HasArchive")
 		externalFunctions.QueueDownload(name, archiveType, priority)
 		return
 	end
-	Spring.Echo("MaybeDownloadArchive HasArchive")
 end
 
 function externalFunctions.GetDownloadQueue()
@@ -384,8 +362,6 @@ end
 -- Wrapper Interface
 
 function wrapperFunctions.DownloadFinished(name, fileType, success, aborted)
-	Spring.Echo("wrapperFunctions DownloadFinished")
-	fileType = fileType and reverseTypeMap[fileType]
 	Spring.Echo("fileType=", fileType)
 	if fileType then
 		if (fileType == 'RAPID' or fileType == 'game') and SaveLobbyVersionGZPath then
@@ -405,16 +381,12 @@ function wrapperFunctions.DownloadFinished(name, fileType, success, aborted)
 end
 
 function wrapperFunctions.DownloadFileProgress(name, progress, totalLength)
-	Spring.Echo("DownloadFileProgress (name, progress, totalLength)", name, progress, totalLength)
 	local index = GetDownloadIndexByName(downloadQueue, name)
-	Spring.Echo("Index", index)
 	if not index then
-		Spring.Echo("not index")
 		return
 	end
 
 	totalLength = (tonumber(totalLength or 0) or 0)/1023^2
-	Spring.Echo("DownloadFileProgress, call Listeners('DownloadProgress', downloadQueue[index].id, totalLength*math.min(1, (tonumber(progress or 0) or 0)/100), totalLength, downloadQueue[index].name)",downloadQueue[index].id, totalLength*math.min(1, (tonumber(progress or 0) or 0)/100), totalLength, downloadQueue[index].name)
 	CallListeners("DownloadProgress", downloadQueue[index].id, totalLength*math.min(1, (tonumber(progress or 0) or 0)/100), totalLength, downloadQueue[index].name)
 end
 
@@ -432,15 +404,12 @@ function widget:Update()
 end
 
 function widget:DownloadProgress(downloadID, downloaded, total)
-	Spring.Echo("DownloadHandler:DownloadProgress")
 	local index = GetDownloadBySpringDownloadID(downloadQueue, downloadID)
 	if not index then
-		Spring.Echo("DownloadHandler:DownloadProgress not index")
 		return
 	end
 	downloaded = downloaded / 1024 / 1024
 	total = total / 1024 / 1024
-	Spring.Echo("DownloadHandler:DownloadProgress callingListeners(downloadQueue[index].id, downloaded, total, downloadQueue[index].name)", downloadQueue[index].id, downloaded, total, downloadQueue[index].name)
 	CallListeners("DownloadProgress", downloadQueue[index].id, downloaded, total, downloadQueue[index].name)
 end
 
@@ -455,7 +424,6 @@ function widget:DownloadStarted(downloadID)
 end
 
 function widget:DownloadFinished(downloadID)
-	Spring.Echo("DownloadHandler DownloadFinished")
 	local index = GetDownloadBySpringDownloadID(downloadQueue, downloadID)
 	if not index then
 		return

--- a/LuaMenu/widgets/api_download_handler.lua
+++ b/LuaMenu/widgets/api_download_handler.lua
@@ -362,6 +362,7 @@ end
 -- Wrapper Interface
 
 function wrapperFunctions.DownloadFinished(name, fileType, success, aborted)
+	fileType = fileType and reverseTypeMap[fileType]
 	if fileType then
 		if (fileType == 'RAPID' or fileType == 'game') and SaveLobbyVersionGZPath then
 			RestoreVersionGZ(SaveLobbyVersionGZPath)

--- a/LuaMenu/widgets/api_download_handler.lua
+++ b/LuaMenu/widgets/api_download_handler.lua
@@ -289,11 +289,8 @@ function externalFunctions.SetDownloadTopPriority(name, fileType)
 end
 
 function externalFunctions.CancelDownload(name, fileType, success)
-	Spring.Echo(name)
-	Spring.Echo(fileType)
 	local index = GetDownloadIndex(downloadQueue, name, fileType)
 	if not index then
-		Spring.Echo("not index")
 		return false
 	end
 

--- a/LuaMenu/widgets/api_download_handler.lua
+++ b/LuaMenu/widgets/api_download_handler.lua
@@ -134,7 +134,6 @@ local function DownloadQueueUpdate()
 	table.sort(downloadQueue, DownloadSortFunc)
 
 	local front = downloadQueue[1]
-	
 	if not front.active then
 		if USE_WRAPPER_DOWNLOAD and WG.WrapperLoopback and WG.WrapperLoopback.DownloadFile then
 			WG.WrapperLoopback.DownloadFile(front.name, typeMap[front.fileType], front.resource)
@@ -192,6 +191,7 @@ local function RemoveDownload(name, fileType, putInRemoveList, removalType)
 	-- and retrying it up to retrycount times will succeed.
 	-- A game download will also return with failure often so we use VFS.ScanAllDirs() to check if we did actually
 	-- successfully download it: if we were truly unsuccessful, then we retry downloading it again.
+
 	local index = GetDownloadIndex(downloadQueue, name, fileType)
 	if not index then
 		return false
@@ -362,7 +362,6 @@ end
 -- Wrapper Interface
 
 function wrapperFunctions.DownloadFinished(name, fileType, success, aborted)
-	Spring.Echo("fileType=", fileType)
 	if fileType then
 		if (fileType == 'RAPID' or fileType == 'game') and SaveLobbyVersionGZPath then
 			RestoreVersionGZ(SaveLobbyVersionGZPath)

--- a/LuaMenu/widgets/api_download_handler.lua
+++ b/LuaMenu/widgets/api_download_handler.lua
@@ -140,7 +140,7 @@ local function DownloadQueueUpdate()
 	Spring.Utilities.TableEcho(front)
 	if not front.active then
 		if USE_WRAPPER_DOWNLOAD and WG.WrapperLoopback and WG.WrapperLoopback.DownloadFile then
-			WG.WrapperLoopback.DownloadFile(front.name, typeMap[front.fileType], front.resource, "DownloadQueueUpdate")
+			WG.WrapperLoopback.DownloadFile(front.name, typeMap[front.fileType], front.resource)
 			CallListeners("DownloadStarted", front.id, front.name, front.fileType)
 		else
 			VFS.DownloadArchive(front.name, front.fileType)
@@ -490,7 +490,7 @@ end
 
 
 local function TestDownload()
-	WG.WrapperLoopback.DownloadFile("Sands of Time v1.0", "MAP", "TestDownload")
+	WG.WrapperLoopback.DownloadFile("Sands of Time v1.0", "MAP")
 	Spring.Echo("TestDownload")
 	Chotify:Post({
 		title = "Download Failed",

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -1069,6 +1069,12 @@ function Configuration:SanitizeEngineVersion(engineVersion)
 		end
 	end
 
+	local format = "(%d%d%d)%.(%d)%.(%d)%-(%d+)%-g([%x][%x][%x][%x][%x][%x][%x])%s"
+    if not ret:match(format) then
+        Spring.Echo("Invalid engine version format: " .. engineVersion)
+		ret = ""
+    end
+
 	return ret
 end
 

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -1045,9 +1045,9 @@ end
 
 function Configuration:IsValidEngineVersion(engineVersion)
 	local validengine = (engineVersion == Spring.Utilities.GetEngineVersion() or engineVersion == self:GetTruncatedEngineVersion())
-	--Spring.Echo(" Configuration:IsValidEngineVersion(engineVersion)",engineVersion, validengine)
-	--Spring.Echo(" Spring.Utilities.GetEngineVersion() ",Spring.Utilities.GetEngineVersion() )
-	--Spring.Echo(" self:GetTruncatedEngineVersion()",self:GetTruncatedEngineVersion())
+	Spring.Echo(" Configuration:IsValidEngineVersion(engineVersion)",engineVersion, validengine)
+	Spring.Echo(" Spring.Utilities.GetEngineVersion() ",Spring.Utilities.GetEngineVersion() )
+	Spring.Echo(" self:GetTruncatedEngineVersion()",self:GetTruncatedEngineVersion())
 	return validengine
 end
 

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -1045,9 +1045,9 @@ end
 
 function Configuration:IsValidEngineVersion(engineVersion)
 	local validengine = (engineVersion == Spring.Utilities.GetEngineVersion() or engineVersion == self:GetTruncatedEngineVersion())
-	Spring.Echo(" Configuration:IsValidEngineVersion(engineVersion)",engineVersion, validengine)
-	Spring.Echo(" Spring.Utilities.GetEngineVersion() ",Spring.Utilities.GetEngineVersion() )
-	Spring.Echo(" self:GetTruncatedEngineVersion()",self:GetTruncatedEngineVersion())
+	--Spring.Echo(" Configuration:IsValidEngineVersion(engineVersion)",engineVersion, validengine)
+	--Spring.Echo(" Spring.Utilities.GetEngineVersion() ",Spring.Utilities.GetEngineVersion() )
+	--Spring.Echo(" self:GetTruncatedEngineVersion()",self:GetTruncatedEngineVersion())
 	return validengine
 end
 

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -379,6 +379,14 @@ function Configuration:init()
 		self.saneCharacters[saneCharacterList[i]] = true
 	end
 
+	local engineSaneCharacterList = {
+		"-", ".", " ",
+	}
+	self.engineSaneCharacters = {}
+	for i = 1, #engineSaneCharacterList do
+		self.engineSaneCharacters[engineSaneCharacterList[i]] = true
+	end
+
 	self.barMngSettings = {
 		autoBalance = true,
 		teamSize = true,
@@ -1049,6 +1057,19 @@ function Configuration:IsValidEngineVersion(engineVersion)
 	--Spring.Echo(" Spring.Utilities.GetEngineVersion() ",Spring.Utilities.GetEngineVersion() )
 	--Spring.Echo(" self:GetTruncatedEngineVersion()",self:GetTruncatedEngineVersion())
 	return validengine
+end
+
+function Configuration:SanitizeEngineVersion(engineVersion)
+	local ret = ""
+	local length = string.len(engineVersion)
+	for i = 1, length do
+		local c = string.sub(engineVersion, i, i)
+		if self.saneCharacters[c] or self.engineSaneCharacters[c] then
+			ret = ret .. c
+		end
+	end
+
+	return ret
 end
 
 function Configuration:SanitizeName(name, usedNames)

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -1069,7 +1069,7 @@ function Configuration:SanitizeEngineVersion(engineVersion)
 		end
 	end
 
-	local format = "(%d%d%d)%.(%d)%.(%d)%-(%d+)%-g([%x][%x][%x][%x][%x][%x][%x])%s"
+	local format = "(%d+)%.(%d+)%.(%d+)%-(%d+)%-g([%x][%x][%x][%x][%x][%x][%x])%s"
     if not ret:match(format) then
         Spring.Echo("Invalid engine version format: " .. engineVersion)
 		ret = ""

--- a/LuaMenu/widgets/chobby/components/downloader.lua
+++ b/LuaMenu/widgets/chobby/components/downloader.lua
@@ -196,7 +196,6 @@ function round2(num, idp)
 end
 
 function Downloader:DownloadProgress(listener, downloadID, downloaded, total)
-	Spring.Echo("Downloader:DownloadProgress")
 	if not self.downloads[downloadID] then
 		return
 	end

--- a/LuaMenu/widgets/chobby/components/downloader.lua
+++ b/LuaMenu/widgets/chobby/components/downloader.lua
@@ -240,7 +240,7 @@ function Downloader:DownloadFinished(listener, downloadID)
 
 	if self.duplicateDownloads[self.downloads[downloadID].archiveName] then
 		if WG.WrapperLoopback and WG.WrapperLoopback.DownloadFile then
-			WG.WrapperLoopback.DownloadFile(self.downloads[downloadID].archiveName, ((self.downloads[downloadID].archiveType == "map") and "MAP") or "RAPID", "DownloadFinished")
+			WG.WrapperLoopback.DownloadFile(self.downloads[downloadID].archiveName, ((self.downloads[downloadID].archiveType == "map") and "MAP") or "RAPID")
 			Chotify:Post({
 				title = "Download Failed",
 				body = "Starting backup download for " .. (self.downloads[downloadID].archiveName or "???"),
@@ -272,7 +272,7 @@ function Downloader:DownloadFailed(listener, downloadID, errorID)
 	end
 
 	if self.wrapperAsFallback and WG.WrapperLoopback and WG.WrapperLoopback.DownloadFile then
-		WG.WrapperLoopback.DownloadFile(self.downloads[downloadID].archiveName, ((self.downloads[downloadID].archiveType == "map") and "MAP") or "RAPID", "DownloadFailed")
+		WG.WrapperLoopback.DownloadFile(self.downloads[downloadID].archiveName, ((self.downloads[downloadID].archiveType == "map") and "MAP") or "RAPID")
 		Chotify:Post({
 			title = "Download Failed",
 			body = "Starting backup download for " .. (self.downloads[downloadID].archiveName or "???"),
@@ -298,7 +298,5 @@ function Downloader:DownloadQueued(listener, downloadID, archiveName, archiveTyp
 		archiveType = archiveType,
 		resource = resource,
 		startTime = os.clock() }
-	Spring.Echo("DownloadQueued")
-	Spring.Utilities.TableEcho(self.downloads)
 	self:UpdateQueue()
 end

--- a/LuaMenu/widgets/chobby/components/downloader.lua
+++ b/LuaMenu/widgets/chobby/components/downloader.lua
@@ -240,7 +240,7 @@ function Downloader:DownloadFinished(listener, downloadID)
 
 	if self.duplicateDownloads[self.downloads[downloadID].archiveName] then
 		if WG.WrapperLoopback and WG.WrapperLoopback.DownloadFile then
-			WG.WrapperLoopback.DownloadFile(self.downloads[downloadID].archiveName, ((self.downloads[downloadID].archiveType == "map") and "MAP") or "RAPID")
+			WG.WrapperLoopback.DownloadFile(self.downloads[downloadID].archiveName, ((self.downloads[downloadID].archiveType == "map") and "MAP") or "RAPID", "DownloadFinished")
 			Chotify:Post({
 				title = "Download Failed",
 				body = "Starting backup download for " .. (self.downloads[downloadID].archiveName or "???"),
@@ -272,7 +272,7 @@ function Downloader:DownloadFailed(listener, downloadID, errorID)
 	end
 
 	if self.wrapperAsFallback and WG.WrapperLoopback and WG.WrapperLoopback.DownloadFile then
-		WG.WrapperLoopback.DownloadFile(self.downloads[downloadID].archiveName, ((self.downloads[downloadID].archiveType == "map") and "MAP") or "RAPID")
+		WG.WrapperLoopback.DownloadFile(self.downloads[downloadID].archiveName, ((self.downloads[downloadID].archiveType == "map") and "MAP") or "RAPID", "DownloadFailed")
 		Chotify:Post({
 			title = "Download Failed",
 			body = "Starting backup download for " .. (self.downloads[downloadID].archiveName or "???"),
@@ -292,7 +292,13 @@ function Downloader:DownloadFailed(listener, downloadID, errorID)
 	self:UpdateQueue()
 end
 
-function Downloader:DownloadQueued(listener, downloadID, archiveName, archiveType)
-	self.downloads[downloadID] = { archiveName = archiveName, archiveType = archiveType, startTime = os.clock() }
+function Downloader:DownloadQueued(listener, downloadID, archiveName, archiveType, resource)
+	self.downloads[downloadID] = {
+		archiveName = archiveName,
+		archiveType = archiveType,
+		resource = resource,
+		startTime = os.clock() }
+	Spring.Echo("DownloadQueued")
+	Spring.Utilities.TableEcho(self.downloads)
 	self:UpdateQueue()
 end

--- a/LuaMenu/widgets/chobby/components/downloader.lua
+++ b/LuaMenu/widgets/chobby/components/downloader.lua
@@ -196,6 +196,7 @@ function round2(num, idp)
 end
 
 function Downloader:DownloadProgress(listener, downloadID, downloaded, total)
+	Spring.Echo("Downloader:DownloadProgress")
 	if not self.downloads[downloadID] then
 		return
 	end

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -204,6 +204,7 @@ return {
 			other = "%{count} items left to download.",
 		},
 		downloads_completed = "All downloads completed.",
+		download_failed = "Download Failed",
 		wip_challenges = "WiP Challenges",
 		["scenarios"] = "Scenarios",
 		-- Settings

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -76,7 +76,7 @@ return {
 		delete_confirm = "Are you sure you want to delete this saved game?",
 		load_confirm = "Loading will lose any unsaved progress. Are you sure?",
 		replay_not_found = "Replay file not found, refresh the list!",
-		replay_different_version = "This replay requires a different engine version (FIXME download automatically if necessary)",
+		replay_different_version = "This replay requires a different engine version (will be downloaded automatically if necessary)",
 		--
 		start_download = 'Start download',
 		download_noun = 'Download',

--- a/LuaMenu/widgets/gui_download_window.lua
+++ b/LuaMenu/widgets/gui_download_window.lua
@@ -192,6 +192,7 @@ local function CreateDownloadEntry(downloadData)
 	local externalFunctions = {}
 
 	function externalFunctions.SetProgress(sizeCurrent, sizeTotal)
+		Spring.Echo("DownloadWindow:SetProgress(of downloadentry) (sizeCurrent, sizeTotal)", sizeCurrent, sizeTotal)
 		if sizeCurrent == 0 then
 			return
 		end
@@ -359,8 +360,13 @@ local function InitializeControls(window)
 	WG.DownloadHandler.AddListener("DownloadQueueUpdate", DownloadQueueUpdate)
 
 	local function DownloadProgress(_, _, sizeCurrent, sizeTotal, name)
+		Spring.Echo("DownloadWindow:DownloadProgressListener downloads= ...")
+		Spring.Utilities.TableEcho(downloads)
 		if downloads[name] then
+			Spring.Echo("DownloadWindow:DownloadProgressListener found, call SetProgress")
 			downloads[name].SetProgress(sizeCurrent, sizeTotal)
+		else
+			Spring.Echo("DownloadWindow:DownloadProgressListener not found")
 		end
 	end
 

--- a/LuaMenu/widgets/gui_download_window.lua
+++ b/LuaMenu/widgets/gui_download_window.lua
@@ -359,11 +359,10 @@ local function InitializeControls(window)
 	WG.DownloadHandler.AddListener("DownloadQueueUpdate", DownloadQueueUpdate)
 
 	local function DownloadProgress(_, _, sizeCurrent, sizeTotal, name)
-		Spring.Utilities.TableEcho(downloads)
 		if downloads[name] then
 			downloads[name].SetProgress(sizeCurrent, sizeTotal)
 		else
-			Spring.Echo("DownloadWindow:DownloadProgressListener not found")
+			Spring.Log(LOG_SECTION, LOG.ERROR, "DownloadWindow:DownloadProgressListener not found")
 		end
 	end
 

--- a/LuaMenu/widgets/gui_download_window.lua
+++ b/LuaMenu/widgets/gui_download_window.lua
@@ -192,7 +192,6 @@ local function CreateDownloadEntry(downloadData)
 	local externalFunctions = {}
 
 	function externalFunctions.SetProgress(sizeCurrent, sizeTotal)
-		Spring.Echo("DownloadWindow:SetProgress(of downloadentry) (sizeCurrent, sizeTotal)", sizeCurrent, sizeTotal)
 		if sizeCurrent == 0 then
 			return
 		end
@@ -360,10 +359,8 @@ local function InitializeControls(window)
 	WG.DownloadHandler.AddListener("DownloadQueueUpdate", DownloadQueueUpdate)
 
 	local function DownloadProgress(_, _, sizeCurrent, sizeTotal, name)
-		Spring.Echo("DownloadWindow:DownloadProgressListener downloads= ...")
 		Spring.Utilities.TableEcho(downloads)
 		if downloads[name] then
-			Spring.Echo("DownloadWindow:DownloadProgressListener found, call SetProgress")
 			downloads[name].SetProgress(sizeCurrent, sizeTotal)
 		else
 			Spring.Echo("DownloadWindow:DownloadProgressListener not found")

--- a/LuaMenu/widgets/gui_replay_handler.lua
+++ b/LuaMenu/widgets/gui_replay_handler.lua
@@ -169,6 +169,7 @@ end
 local function CreateReplayEntry(
 	replayPath, engineName, gameName, mapName, players, time, winningAllyTeamIds
 )
+	Spring.Echo("CreateReplayEntry", replayPath, engineName, gameName, mapName, players, time, winningAllyTeamIds)
 
 	local Configuration = WG.Chobby.Configuration
 	local mapNameTruncated = StringUtilities.GetTruncatedStringWithDotDot(mapName, Configuration:GetFont(8), 180)
@@ -474,6 +475,7 @@ local function CreateReplayEntry(
 					"replay", gameName,
 					mapName, nil, nil, replayPath, offEngine and engineName
 				)
+
 			end
 		},
 		parent = replayPanel,
@@ -791,6 +793,7 @@ function ReplayHandler.GetControl()
 end
 
 function ReplayHandler.ReadReplayInfoDone(path, engine, game, map, players, time, winningAllyTeamIds)
+	Spring.Echo("ReadReplayInfoDone", path, engine, game, map, players, time, winningAllyTeamIds)
 	if not replayListWindow then
 		return
 	end

--- a/LuaMenu/widgets/gui_replay_handler.lua
+++ b/LuaMenu/widgets/gui_replay_handler.lua
@@ -169,7 +169,6 @@ end
 local function CreateReplayEntry(
 	replayPath, engineName, gameName, mapName, players, time, winningAllyTeamIds
 )
-	Spring.Echo("CreateReplayEntry", replayPath, engineName, gameName, mapName, players, time, winningAllyTeamIds)
 
 	local Configuration = WG.Chobby.Configuration
 	local mapNameTruncated = StringUtilities.GetTruncatedStringWithDotDot(mapName, Configuration:GetFont(8), 180)
@@ -475,7 +474,6 @@ local function CreateReplayEntry(
 					"replay", gameName,
 					mapName, nil, nil, replayPath, offEngine and engineName
 				)
-
 			end
 		},
 		parent = replayPanel,
@@ -793,7 +791,6 @@ function ReplayHandler.GetControl()
 end
 
 function ReplayHandler.ReadReplayInfoDone(path, engine, game, map, players, time, winningAllyTeamIds)
-	Spring.Echo("ReadReplayInfoDone", path, engine, game, map, players, time, winningAllyTeamIds)
 	if not replayListWindow then
 		return
 	end

--- a/LuaMenu/widgets/gui_steam_coop_handler.lua
+++ b/LuaMenu/widgets/gui_steam_coop_handler.lua
@@ -171,7 +171,8 @@ end
 
 -- outcome example: https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D105.1.1-1354-g72b2d55/spring_bar_.BAR105.105.1.1-1354-g72b2d55_windows-64-minimal-portable.7z
 local function GetEngineDownloadUrl(engineVersion)
-	local pureVersion = engineVersion:gsub(" BAR105", "")
+	local sanitizedEngineVersion = WG.Chobby.Configuration:SanitizeEngineVersion(engineVersion)
+	local pureVersion = sanitizedEngineVersion:gsub(" BAR105", "")
 	local baseUrl = "https://github.com/beyond-all-reason/spring/releases/download/"
 	local versionDir = "spring_bar_%7BBAR105%7D" .. pureVersion .. "/"
 	local platform64 = Platform.osFamily:lower() .. "-64"
@@ -268,7 +269,7 @@ local function CheckDownloads(gameName, mapName, DoneFunc, gameList, engineVersi
 	end
 
 	downloading.dlString = dlString
-	MakeExclusivePopup(string.format(dlString, unpack(downloading.progress)), "Cancel", CancelFunc, "negative_button", (gameList and (180 + (#gameList)*40)))
+	MakeExclusivePopup(string.format(dlString, unpack(downloading.progress)), "Cancel", CancelFunc, "negative_button", (gameList and (220 + (#gameList)*40)))
 end
 
 

--- a/LuaMenu/widgets/gui_steam_coop_handler.lua
+++ b/LuaMenu/widgets/gui_steam_coop_handler.lua
@@ -61,7 +61,7 @@ local function MakeExclusivePopup(text, buttonText, ClickFunc, buttonClass, heig
 	if replacablePopup then
 		replacablePopup:Close()
 	end
-	replacablePopup = WG.Chobby.InformationPopup(text, {caption = buttonText, closeFunc = ClickFunc, buttonClass = buttonClass, height = height, width = 500})
+	replacablePopup = WG.Chobby.InformationPopup(text, {caption = buttonText, closeFunc = ClickFunc, buttonClass = buttonClass, height = height, width = 540})
 end
 
 local function CloseExclusivePopup()

--- a/LuaMenu/widgets/gui_steam_coop_handler.lua
+++ b/LuaMenu/widgets/gui_steam_coop_handler.lua
@@ -172,11 +172,12 @@ end
 -- outcome example: https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D105.1.1-1354-g72b2d55/spring_bar_.BAR105.105.1.1-1354-g72b2d55_windows-64-minimal-portable.7z
 local function GetEngineDownloadUrl(engineVersion)
 	local sanitizedEngineVersion = WG.Chobby.Configuration:SanitizeEngineVersion(engineVersion)
-	local pureVersion = sanitizedEngineVersion:gsub(" BAR105", "")
+	local branch = sanitizedEngineVersion:match("%s([%w-]*)") or ""
+	local pureVersion = sanitizedEngineVersion:gsub(" " .. branch, "")
 	local baseUrl = "https://github.com/beyond-all-reason/spring/releases/download/"
-	local versionDir = "spring_bar_%7BBAR105%7D" .. pureVersion .. "/"
+	local versionDir = "spring_bar_%7B" .. branch .. "%7D" .. pureVersion .. "/"
 	local platform64 = Platform.osFamily:lower() .. "-64"
-	local fileName = "spring_bar_.BAR105." .. pureVersion .. "_" .. platform64 .. "-minimal-portable.7z"
+	local fileName = "spring_bar_." .. branch .. "." .. pureVersion .. "_" .. platform64 .. "-minimal-portable.7z"
 	return baseUrl .. versionDir .. fileName
 end
 

--- a/LuaMenu/widgets/gui_steam_coop_handler.lua
+++ b/LuaMenu/widgets/gui_steam_coop_handler.lua
@@ -172,7 +172,7 @@ end
 -- outcome example: https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D105.1.1-1354-g72b2d55/spring_bar_.BAR105.105.1.1-1354-g72b2d55_windows-64-minimal-portable.7z
 local function GetEngineDownloadUrl(engineVersion)
 	local sanitizedEngineVersion = WG.Chobby.Configuration:SanitizeEngineVersion(engineVersion)
-	local branch = sanitizedEngineVersion:match("%s([%w-]*)") or ""
+	local branch = sanitizedEngineVersion:match("%s([%w-.]*)") or ""
 	local pureVersion = sanitizedEngineVersion:gsub(" " .. branch, "")
 	local baseUrl = "https://github.com/beyond-all-reason/spring/releases/download/"
 	local versionDir = "spring_bar_%7B" .. branch .. "%7D" .. pureVersion .. "/"

--- a/LuaMenu/widgets/gui_steam_coop_handler.lua
+++ b/LuaMenu/widgets/gui_steam_coop_handler.lua
@@ -209,8 +209,8 @@ local function CheckDownloads(gameName, mapName, DoneFunc, gameList, engineVersi
 		end
 	end
 
-	local haveEngine = not engineVersion and haveEngineVersion(engineVersion)
-	Spring.Echo("haveEngine", haveEngine)
+	local haveEngine = not engineVersion or haveEngineVersion(engineVersion)
+	Spring.Echo("haveEngine", haveEngine, not engineVersion)
 	if not haveEngine then
 		if oneTimeResourceDl then
 			Spring.Echo("oneTimeResourceDl = true")

--- a/LuaMenu/widgets/gui_steam_coop_handler.lua
+++ b/LuaMenu/widgets/gui_steam_coop_handler.lua
@@ -382,7 +382,7 @@ end
 -- External functions: Widget <-> Widget
 
 function SteamCoopHandler.AttemptGameStart(gameType, gameName, mapName, scriptTable, newFriendsReplaceAI, newReplayFile, newEngineVersion)
-	if coopClient then -- false
+	if coopClient then -- ZK only, always false 
 		local statusAndInvitesPanel = WG.Chobby.interfaceRoot.GetStatusAndInvitesPanel()
 		if statusAndInvitesPanel and statusAndInvitesPanel.GetChildByName("coopPanel") then
 			WG.Chobby.InformationPopup("Only the host of the coop party can launch games.")

--- a/LuaMenu/widgets/gui_steam_coop_handler.lua
+++ b/LuaMenu/widgets/gui_steam_coop_handler.lua
@@ -161,14 +161,11 @@ end
 
 -- outcome example: "105.1.1-1354-g72b2d55 BAR105" -> "engine/105.1.1-1354-g72b2d55 bar"
 local function GetEnginePath(engineVersion)
-	Spring.Echo("GetEnginePath", ("engine/" .. engineVersion:gsub(" BAR105", " bar")):lower())
 	return ("engine/" .. engineVersion:gsub(" BAR105", " bar")):lower() -- maybe there are more special cases to take in mind here for very old demos or future ones!
 end
 
 local function haveEngineVersion(engineVersion)
 	local springExecutable = Platform.osFamily == "Windows" and "spring.exe" or "spring"
-	Spring.Echo("springExecutable", springExecutable)
-	Spring.Echo("haveEngineVersion", VFS.FileExists(GetEnginePath(engineVersion) .. "//" .. springExecutable))
 	return VFS.FileExists(GetEnginePath(engineVersion) .. "//" .. springExecutable)
 end
 
@@ -185,18 +182,13 @@ end
 -- gameList = nil
 -- local oneTimeResourceDl = false
 local function CheckDownloads(gameName, mapName, DoneFunc, gameList, engineVersion)
-	Spring.Echo("CheckDownloads",gameName, mapName, DoneFunc, gameList, engineVersion)
 	local haveGame = (not gameName) or WG.Package.ArchiveExists(gameName)
-	Spring.Echo("haveGame", haveGame, not gameName)
 	if not haveGame then
-		Spring.Echo("not haveGame")
 		WG.DownloadHandler.MaybeDownloadArchive(gameName, "game", -1)
 	end
 
 	local haveMap = (not mapName) or VFS.HasArchive(mapName)
-	Spring.Echo("haveMap", haveMap, not mapName)
 	if not haveMap then
-		Spring.Echo("not haveMap")
 		WG.DownloadHandler.MaybeDownloadArchive(mapName, "map", -1)
 	end
 
@@ -210,32 +202,20 @@ local function CheckDownloads(gameName, mapName, DoneFunc, gameList, engineVersi
 	end
 
 	local haveEngine = not engineVersion or haveEngineVersion(engineVersion)
-	Spring.Echo("haveEngine", haveEngine, not engineVersion)
 	if not haveEngine then
-		--if oneTimeResourceDl then
-		--	Spring.Echo("oneTimeResourceDl = true")
-		--	return
-		--end
-		Spring.Echo("Url", GetEngineDownloadUrl(engineVersion))
-		Spring.Echo("destination", GetEnginePath(engineVersion))
-		Spring.Echo("Engine ", engineVersion, " not existing, attempt to download...")
 		WG.DownloadHandler.MaybeDownloadArchive(engineVersion, "resource", -1,{ -- FB 2023-05-14: Use resource download until engine-download is supported by launcher
 			url = GetEngineDownloadUrl(engineVersion),
 			destination = GetEnginePath(engineVersion),
 			extract = true,
 		})
-		oneTimeResourceDl = true
 	end
 
 	if haveGame and haveMap and haveEngine then
-		Spring.Echo("haveGame and haveMap and haveEngine")
 		return true
 	end
 
 	local function Update()
-		Spring.Echo("DownloadUpdateFunction")
 		if ((not gameName) or WG.Package.ArchiveExists(gameName)) and ((not mapName) or VFS.HasArchive(mapName)) and ((not engineVersion) or haveEngineVersion(engineVersion)) then
-			Spring.Echo("DownloadUpdateFunction all available")
 			if gameList then
 				for i = 1, #gameList do
 					if not WG.Package.ArchiveExists(gameList[i]) then
@@ -244,7 +224,6 @@ local function CheckDownloads(gameName, mapName, DoneFunc, gameList, engineVersi
 				end
 			end
 			DoneFunc()
-			Spring.Echo("DownloadUpdateFunction doneFunc done")
 			DownloadUpdateFunction = nil
 		end
 	end
@@ -403,19 +382,6 @@ end
 -- External functions: Widget <-> Widget
 
 function SteamCoopHandler.AttemptGameStart(gameType, gameName, mapName, scriptTable, newFriendsReplaceAI, newReplayFile, newEngineVersion)
-	-- Spring.Echo("AttemptGameStart coopClient", coopClient)
-	
-	--local newEngineName = string.gsub(string.gsub(string.gsub(newEngineVersion, " maintenance", ""), " develop", "")," BAR105", " bar")
-	--newEngineName = newEngineVersion
-	Spring.Echo("AttemptGameStart", gameType, gameName, mapName, scriptTable, newFriendsReplaceAI, newReplayFile, newEngineVersion)
-	-- gameType = replay
-	-- gameName = Beyond All Reason test-21542-7b3b45d
-	-- mapName = Koom Valley 3 3.1
-	-- scriptTable = nil
-	-- newFriendsReplaceAI = nil
-	-- newReplayFile = demos\20221201_233009_Koom Valley 3 3_105.1.1-1354-g72b2d55 BAR105.sdfz
-	-- newEngineVersion = 105.1.1-1354-g72b2d55 BAR105
-
 	if coopClient then -- false
 		local statusAndInvitesPanel = WG.Chobby.interfaceRoot.GetStatusAndInvitesPanel()
 		if statusAndInvitesPanel and statusAndInvitesPanel.GetChildByName("coopPanel") then
@@ -440,8 +406,6 @@ function SteamCoopHandler.AttemptGameStart(gameType, gameName, mapName, scriptTa
 		startReplayFile = newReplayFile
 		startEngineVersion = newEngineVersion
 
-		Spring.Echo("DownloadsComplete", gameType, scriptTable, newFriendsReplaceAI, newReplayFile, newEngineVersion)
-
 		CloseExclusivePopup()
 
 		local Configuration = WG.Chobby.Configuration
@@ -462,16 +426,12 @@ function SteamCoopHandler.AttemptGameStart(gameType, gameName, mapName, scriptTa
 			lastStart.newEngineVersion    = currentStart.newEngineVersion
 
 			if startEngineVersion then
-				Spring.Echo("startEngineVersion")
 				-- Only replay so far.
 				if not WG.WrapperLoopback then
-					Spring.Echo("Wrapper is required to watch replays with old engine versions.")
 					MakeExclusivePopup("Wrapper is required to watch replays with old engine versions.")
 					return
 				end
-				-- local engine = string.gsub(string.gsub(startEngineVersion, " maintenance", ""), " develop", "") -- useless line, we write var engine from scratch in next line
 				local engine = string.gsub(startEngineVersion, "BAR105", "bar") -- because this is the path we use
-				Spring.Echo("engine:", engine, startReplayFile, engine, WG.SettingsWindow.GetSettingsString())
 				local params = {
 					StartDemoName = startReplayFile, -- dont remove the 'demos/' string from it now
 					Engine = engine,
@@ -538,8 +498,6 @@ function SteamCoopHandler.AttemptGameStart(gameType, gameName, mapName, scriptTa
 		WG.WrapperLoopback.SteamHostGameRequest(args)
 	end
 
-	-- gameName = Beyond All Reason test-21542-7b3b45d
-	-- mapName = Koom Valley 3 3.1
 	if CheckDownloads(gameName, mapName, DownloadsComplete, _, newEngineVersion) then
 		DownloadsComplete()
 	end
@@ -555,13 +513,9 @@ end
 --------------------------------------------------------------------------------
 -- Widget Interface
 function DelayedInitialize()
-	Spring.Echo("DelayedInitialize")
 	local function downloadFinished(_, name)
-		Spring.Echo("DelayedInitialize name", name)
 		if DownloadUpdateFunction then
-			Spring.Echo("DelayedInitialize DownloadUpdateFunction = true")
 			DownloadUpdateFunction()
-			Spring.Echo("DelayedInitialize DownloadUpdateFunction done")
 
 			local index = downloading and downloading.downloads[name]
 			if not index then

--- a/LuaMenu/widgets/gui_steam_coop_handler.lua
+++ b/LuaMenu/widgets/gui_steam_coop_handler.lua
@@ -463,7 +463,6 @@ function SteamCoopHandler.AttemptGameStart(gameType, gameName, mapName, scriptTa
 
 			if startEngineVersion then
 				Spring.Echo("startEngineVersion")
-				if true then return end
 				-- Only replay so far.
 				if not WG.WrapperLoopback then
 					Spring.Echo("Wrapper is required to watch replays with old engine versions.")

--- a/LuaMenu/widgets/gui_steam_coop_handler.lua
+++ b/LuaMenu/widgets/gui_steam_coop_handler.lua
@@ -159,10 +159,10 @@ end
 --------------------------------------------------------------------------------
 -- Downloading
 
--- outcome example: "105.1.1-1354-g72b2d55 BAR105" -> "engine//105.1.1-1354-g72b2d55 bar"
+-- outcome example: "105.1.1-1354-g72b2d55 BAR105" -> "engine/105.1.1-1354-g72b2d55 bar"
 local function GetEnginePath(engineVersion)
-	Spring.Echo("GetEnginePath", ("engine//" .. engineVersion:gsub(" BAR105", " bar")):lower())
-	return ("engine//" .. engineVersion:gsub(" BAR105", " bar")):lower() -- maybe there are more special cases to take in mind here
+	Spring.Echo("GetEnginePath", ("engine/" .. engineVersion:gsub(" BAR105", " bar")):lower())
+	return ("engine/" .. engineVersion:gsub(" BAR105", " bar")):lower() -- maybe there are more special cases to take in mind here for very old demos or future ones!
 end
 
 local function haveEngineVersion(engineVersion)
@@ -183,7 +183,7 @@ local function GetEngineDownloadUrl(engineVersion)
 end
 
 -- gameList = nil
-local oneTimeResourceDl = false
+-- local oneTimeResourceDl = false
 local function CheckDownloads(gameName, mapName, DoneFunc, gameList, engineVersion)
 	Spring.Echo("CheckDownloads",gameName, mapName, DoneFunc, gameList, engineVersion)
 	local haveGame = (not gameName) or WG.Package.ArchiveExists(gameName)
@@ -212,10 +212,10 @@ local function CheckDownloads(gameName, mapName, DoneFunc, gameList, engineVersi
 	local haveEngine = not engineVersion or haveEngineVersion(engineVersion)
 	Spring.Echo("haveEngine", haveEngine, not engineVersion)
 	if not haveEngine then
-		if oneTimeResourceDl then
-			Spring.Echo("oneTimeResourceDl = true")
-			return
-		end
+		--if oneTimeResourceDl then
+		--	Spring.Echo("oneTimeResourceDl = true")
+		--	return
+		--end
 		Spring.Echo("Url", GetEngineDownloadUrl(engineVersion))
 		Spring.Echo("destination", GetEnginePath(engineVersion))
 		Spring.Echo("Engine ", engineVersion, " not existing, attempt to download...")

--- a/LuaMenu/widgets/sl_loopback.lua
+++ b/LuaMenu/widgets/sl_loopback.lua
@@ -116,7 +116,8 @@ end
 -- Replace all minutes (-) by (%-) so that it´s not used by string.find as special char
 -- example: "engine/105.1.1-1354-g72b2d55 bar" -> "engine/105.1.1%-1354%-g72b2d55 bar"
 local function EscapeMinusPattern(text)
-    return text:gsub("([%-])", "%%%1")
+	local txt = text:gsub("([%-])", "%%%1")
+	return txt
 end
 
 -- FB 2023-05-19: "resource"-downloads currently return no name in first DownloadFinished-command

--- a/LuaMenu/widgets/sl_loopback.lua
+++ b/LuaMenu/widgets/sl_loopback.lua
@@ -54,45 +54,119 @@ function WrapperLoopback.ParseMiniMap(mapPath, destination, miniMapSize)
 	})
 end
 
-local downloads = {}
+local downloads2 = {} -- index table
 
--- downloads a file, type can be any of RAPID, MAP, MISSION, DEMO, ENGINE, NOTKNOWN
-function WrapperLoopback.DownloadFile(name, type)
-	downloads[name] = type
-
-	type = type:lower()
-	if type == "rapid" then
-		type = "game"
+-- FB 2023-05-14 outdated ?: downloads a file, type can be any of RAPID, MAP, MISSION, DEMO, ENGINE, NOTKNOWN
+-- FB 2023-05-14 downloads a file, type can be any of game, map, engine, resource
+function WrapperLoopback.DownloadFile(name, type, resource, debug_wherewecomefrom)
+	Spring.Echo("WrapperLoopback DownloadFile")
+	if type:lower() == "resource" and not resource then
+		Spring.Echo("DownloadFile called with type resource, but no resouce infos given")
+		-- ToDo: Call Finished
+		return false
 	end
+
+	table.insert(downloads2, {
+		nameSent = type:lower() == "resource" and resource.destination or name, -- FB 2023-05-14: Workaround for now: With "resource" DownloadProgress & DownloadFinished return destination as name
+		name     = name,
+		type     = type,
+		typeSent = type:lower() == "rapid" and "game" or type:lower(),
+		resource = resource -- {url, destination, extract}
+	})
+	Spring.Echo("sent download")
+	Spring.Utilities.TableEcho(downloads2)
+
 	WG.Connector.Send("Download", {
-		name = name,
-		type = type
+		name     = downloads2[#downloads2].nameSent,
+		type     = downloads2[#downloads2].typeSent,
+		resource = downloads2[#downloads2].resource,
 	})
 end
 
 -- Starts a new spring instance, generally to play replays.
 function WrapperLoopback.StartNewSpring(args)
+	Spring.Echo("StartNewSpring")
+	Spring.Utilities.TableEcho(args)
+	Spring.Echo("StartNewSpring end")
 	WG.Connector.Send("StartNewSpring", args)
 end
 
+local function GetDownloadByName(name)
+	for i, download in ipairs(downloads2) do
+		if download.name == name then
+			return download, i
+		end
+	end
+	return false, nil
+end
+
+local function GetDownloadByNameSent(nameSent)
+	Spring.Echo("GetDownloadByNameSent")
+	Spring.Utilities.TableEcho(downloads2)
+	for i, download in ipairs(downloads2) do
+		Spring.Echo("i, download.nameSent", i, download.nameSent)
+		if download.nameSent == nameSent then
+			return download, i
+		end
+	end
+	return false, nil
+end
+
 function WrapperLoopback.AbortDownload(name, type)
+	Spring.Echo("WrapperLoopback.AbortDownload(name,type)", name, type)
+	local download = GetDownloadByName(name)
+	if not download then
+		Spring.Echo("AbortDownload, no download found with name:", name)
+		-- ToDo: Handle this, e.g. set download = finished or aborted or failed or whatever
+		return false
+	end
+	Spring.Echo("AbortDownload, download found:")
+	Spring.Utilities.TableEcho(download)
 	WG.Connector.Send("AbortDownload", {
-		name = name,
-		type = type
+		name = download.sentName,
+		type = download.sentType
 	})
 end
 
-
 -- reports that download has ended/was aborted
 local function DownloadFinished(command)
-	local type = downloads[command.name]
-	WG.DownloadWrapperInterface.DownloadFinished(command.name, type, command.isSuccess, command.isAborted)
-	downloads[command.name] = nil
+	Spring.Echo("WrapperLoopback:local DownloadFinished")	
+	Spring.Utilities.TableEcho(command)
+	if not command.name then
+		Spring.Echo("DownloadFinished without name")
+		return false
+	end
+
+	local download, i = GetDownloadByNameSent(command.name)
+	if not download then
+		Spring.Echo("DownloadFinished, no download found with name", command.name) -- ERROR
+		return false
+	end
+	Spring.Echo("AbortDownload, download found:")
+	Spring.Utilities.TableEcho(download)
+	
+	WG.DownloadWrapperInterface.DownloadFinished(download.name, download.type, command.isSuccess, command.isAborted)
+	table.remove(downloads2, i)
 end
 
 -- reports download progress. 100 might not indicate complation, wait for downloadfiledone
 local function DownloadProgress(command)
-	WG.DownloadWrapperInterface.DownloadFileProgress(command.name, command.progress * 100, command.total)
+	Spring.Echo("WrapperLoopback:local DownloadProgress")
+	Spring.Utilities.TableEcho(command)
+	if not command.name then
+		Spring.Echo("DownloadProgress without name")
+		return false
+	end
+
+	local download, i = GetDownloadByNameSent(command.name)
+	if not download then
+		Spring.Echo("DownloadProgress, no download found with name", command.name) -- ERROR
+		Spring.Utilities.TableEcho(download)
+		return false
+	end
+	Spring.Echo("DownloadProgress, download found:")
+	Spring.Utilities.TableEcho(download)
+	WG.DownloadWrapperInterface.DownloadFileProgress(download.name, command.progress * 100, command.total)
 end
 
 local function ParseMiniMapFinished(command)

--- a/LuaMenu/widgets/sl_loopback.lua
+++ b/LuaMenu/widgets/sl_loopback.lua
@@ -141,14 +141,14 @@ local function DownloadFinished(command)
 		return false
 	end
 
-	download, dlIndex = FindNameReceivedInDownloads(command.name)		
+	download, dlIndex = FindNameReceivedInDownloads(command.name)
 	if not download then
 		Spring.Log(LOG_SECTION, LOG.ERROR, "Received command.name couldn't be matched to any known download:", command.name)
 		return false
 	end
-	
+
 	WG.DownloadWrapperInterface.DownloadFinished(download.name, download.type, command.isSuccess, command.isAborted)
-	table.remove(downloads, i)
+	table.remove(downloads, dlIndex)
 end
 
 -- reports download progress. 100 might not indicate completion, wait for DownloadFinished

--- a/LuaMenu/widgets/sl_loopback.lua
+++ b/LuaMenu/widgets/sl_loopback.lua
@@ -59,9 +59,14 @@ local downloads = {} -- index table
 -- FB 2023-05-14 downloads a file, type can be any of game, map, resource
 -- engine not supported yet by launcher, though using resource here for engine downloads with workarounds!
 function WrapperLoopback.DownloadFile(name, type, resource)
+	LOG_SECTION = "downloader"
+
 	if type:lower() == "resource" and not resource then
-		Spring.Log(LOG_SECTION, LOG.ERROR, "DownloadFile called with type resource, but no resouce infos given")
-		-- ToDo: Call Finished
+
+		Spring.Log(LOG_SECTION, LOG.ERROR, "DownloadFile called with type resource, but no resource infos given")
+
+		WG.DownloadHandler.CancelDownload(name, type:lower(), "fail")
+
 		return false
 	end
 
@@ -117,18 +122,6 @@ local function FindNameReceivedInDownloads(nameReceived)
 		end
 	end
 	return false, nil
-end
-
-function WrapperLoopback.AbortDownload(name, type)
-	local download = GetDownloadByName(name)
-	if not download then
-		-- ToDo: Handle this, e.g. set download = finished or aborted or failed or whatever
-		return false
-	end
-	WG.Connector.Send("AbortDownload", {
-		name = download.sentName,
-		type = download.sentType
-	})
 end
 
 local function startsWith(targetstring, pattern) 

--- a/LuaMenu/widgets/sl_loopback.lua
+++ b/LuaMenu/widgets/sl_loopback.lua
@@ -58,7 +58,7 @@ local downloads = {} -- index table
 
 -- FB 2023-05-14 downloads a file, type can be any of game, map
 -- {resource,engine} not fully supported yet by launcher, though using resource here for engine downloads with workarounds!
-function WrapperLoopback.DownloadFile(name, type, resource, debug_wherewecomefrom)
+function WrapperLoopback.DownloadFile(name, type, resource)
 	Spring.Echo("WrapperLoopback DownloadFile")
 	if type:lower() == "resource" and not resource then
 		Spring.Echo("DownloadFile called with type resource, but no resouce infos given")

--- a/LuaMenu/widgets/sl_loopback.lua
+++ b/LuaMenu/widgets/sl_loopback.lua
@@ -103,7 +103,7 @@ local function GetDownloadByNameSent(nameSent)
 	return false, nil
 end
 
--- Replace all minutes (-) by (%-) so that it´s not used by string.find as special char
+-- Replace all minutes (-) by (%-) so that it's not used by string.find as special char
 -- example: "engine/105.1.1-1354-g72b2d55 bar" -> "engine/105.1.1%-1354%-g72b2d55 bar"
 local function EscapeMinusPattern(text)
 	local txt = text:gsub("([%-])", "%%%1")
@@ -112,7 +112,7 @@ end
 
 local function FindNameReceivedInDownloads(nameReceived)
 	for i, download in ipairs(downloads) do
-		if nameReceived:gsub("\\", "/"):find(EscapeMinusPattern(download.nameSent)) then -- replace backslashes(windows) with slashes, because that´s how we generated it in CoopHandler:local GetEnginePath()
+		if nameReceived:gsub("\\", "/"):find(EscapeMinusPattern(download.nameSent)) then -- replace backslashes(windows) with slashes, because that's how we generated it in CoopHandler:local GetEnginePath()
 			return download, i
 		end
 	end


### PR DESCRIPTION
Closes #453 (Does not require merging of original PR)

This is an expansion of @FIr3baL's PR that attempts to act upon feedback from @p2004a in regards to security and found bugs.

The engine version requested for download is now sanitized by a list of sane characters already built into chobby for username check, and adds a few more that are found in the engine label. The sanitized version is pattern-checked.

Failed download of a required engine version to run the replay is handled a bit more gracefully, the interface still isn't great as the user is requested to check the status of the download themselves and act accordingly. There is room for improvement here but things should basically work.

There is now a small notification which appears in the bottom right corner if any download fails, a small band-aid to address the lacking interface above. 