### PR TITLE
Actually prevent pressing Login button repeatedly from triggering flood protection

### DIFF
--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -453,6 +453,26 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	}
 	registerChildren[#registerChildren + 1] = self.txtErrorRegister
 
+	local function reenablebtnLogin()
+		self.btnLogin.tooltip = nil
+		self.btnLogin.suppressButtonReaction = false
+		self.btnLogin:SetEnabled(true)
+		self.btnLogin.OnClick = {
+			function()
+				btnLoginOnClick()
+			end
+		}
+	end
+
+	function btnLoginOnClick()
+		self.btnLogin.tooltip = "Please wait a moment before retrying login"
+		self.btnLogin.suppressButtonReaction = true
+		self.btnLogin:SetEnabled(false)
+		self.btnLogin.OnClick = {}
+		self:MayBeDisconnectBeforeTryLogin()
+		WG.Delay(reenablebtnLogin, 5)
+	end
+
 	self.btnLogin = Button:New {
 		right = 140,
 		width = 130,
@@ -461,10 +481,13 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 		caption = i18n("login_verb"),
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(3),
 		classname = "action_button",
+		tooltip = nil,
 		OnClick = {
 			function()
-				if lobby:GetConnectionStatus() ~= "connecting" then
-					self:MayBeDisconnectBeforeTryLogin()
+				if lobby:GetConnectionStatus() ~= "connected" then
+					btnLoginOnClick()
+				else
+					self.txtError:SetText(Configuration:GetErrorColor() .. "Already logged in")
 				end
 			end
 		},
@@ -554,7 +577,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.lblChangeUserName =  Label:New {
 		x = pad + formw * 0 ,
-		y = pad + formh * 2 ,
+		y = pad + formh * 1 ,
 		width =   formw * 1 ,
 		height =  formh * 1 ,
 		-- caption = i18n("register_long"),
@@ -879,7 +902,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.lblChangeEmailVerification =  Label:New {
 		x = pad + formw * 0 ,
-		y = pad + formh * 21 ,
+		y = pad + formh * 19 ,
 		width =   formw * 1 ,
 		height =  formh * 1 ,
 		-- caption = i18n("register_long"),

--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -1151,7 +1151,7 @@ function LoginWindow:MayBeDisconnectBeforeTryLogin()
 	self.onDisconnected = function(listener)
 		Spring.Echo("onDisconnected")
 		lobby:RemoveListener("OnDisconnected", self.onDisconnected)
-		WG.Delay(callTryLogin, 30) -- server returns error when connecting directly after disconnect
+		WG.Delay(callTryLogin, 3) -- server returns error when connecting directly after disconnect
 	end
 	lobby:AddListener("OnDisconnected", self.onDisconnected)
 
@@ -1191,7 +1191,7 @@ function LoginWindow:tryLogin()
 		local function FollowRedirect()
 			lobby:Connect(Configuration:GetServerAddress(), Configuration:GetServerPort(), username, password, 3, nil, GetLobbyName())
 		end
-
+			
 		self.onRedirect = function(listener, newaddress)
 			lobby:Disconnect()
 			Configuration:SetConfigValue("serverAddress", newaddress)

--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -1123,7 +1123,7 @@ function LoginWindow:MayBeDisconnectBeforeTryLogin()
 	local function callTryLogin() self:tryLogin() end
 	self.onDisconnected = function(listener)
 		lobby:RemoveListener("OnDisconnected", self.onDisconnected)
-		WG.Delay(callTryLogin, 3) -- server returns error when connecting directly after disconnect
+		WG.Delay(callTryLogin, 30) -- server returns error when connecting directly after disconnect
 	end
 	lobby:AddListener("OnDisconnected", self.onDisconnected)
 
@@ -1162,7 +1162,7 @@ function LoginWindow:tryLogin()
 		local function FollowRedirect()
 			lobby:Connect(Configuration:GetServerAddress(), Configuration:GetServerPort(), username, password, 3, nil, GetLobbyName())
 		end
-			
+
 		self.onRedirect = function(listener, newaddress)
 			lobby:Disconnect()
 			Configuration:SetConfigValue("serverAddress", newaddress)

--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -1143,13 +1143,8 @@ function LoginWindow:MayBeDisconnectBeforeTryLogin()
 	end
 
 	-- disconnect and cleanup before login to next account
-	local function callTryLogin()
-		Spring.Echo("Attempting reconnect")
-		self:tryLogin()
-	end
-
+	local function callTryLogin() self:tryLogin() end
 	self.onDisconnected = function(listener)
-		Spring.Echo("onDisconnected")
 		lobby:RemoveListener("OnDisconnected", self.onDisconnected)
 		WG.Delay(callTryLogin, 3) -- server returns error when connecting directly after disconnect
 	end
@@ -1160,7 +1155,6 @@ function LoginWindow:MayBeDisconnectBeforeTryLogin()
 end
 
 function LoginWindow:tryLogin()
-	Spring.Echo("LoginWindow:tryLogin")
 	self.txtError:SetText("")
 
 	local username = self.ebUsername.text

--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -1120,8 +1120,13 @@ function LoginWindow:MayBeDisconnectBeforeTryLogin()
 	end
 
 	-- disconnect and cleanup before login to next account
-	local function callTryLogin() self:tryLogin() end
+	local function callTryLogin()
+		Spring.Echo("Attempting reconnect")
+		self:tryLogin()
+	end
+
 	self.onDisconnected = function(listener)
+		Spring.Echo("onDisconnected")
 		lobby:RemoveListener("OnDisconnected", self.onDisconnected)
 		WG.Delay(callTryLogin, 30) -- server returns error when connecting directly after disconnect
 	end
@@ -1132,6 +1137,7 @@ function LoginWindow:MayBeDisconnectBeforeTryLogin()
 end
 
 function LoginWindow:tryLogin()
+	Spring.Echo("LoginWindow:tryLogin")
 	self.txtError:SetText("")
 
 	local username = self.ebUsername.text

--- a/LuaMenu/widgets/gui_login_window.lua
+++ b/LuaMenu/widgets/gui_login_window.lua
@@ -73,7 +73,6 @@ local function TrySimpleSteamLogin()
 	if (lobby:GetConnectionStatus() == "connected") then
 		lobby:Login(Configuration.userName, Configuration.password, 3, nil, "Chobby", true)
 	else
-		Spring.Echo("Trying Simple Steam Login")
 		lobby:Connect(Configuration:GetServerAddress(), Configuration:GetServerPort(), Configuration.userName, Configuration.password, 3, nil, "Chobby")
 	end
 	return true
@@ -84,7 +83,6 @@ local function TrySimpleLogin()
 	if (lobby:GetConnectionStatus() == "connected") then
 		lobby:Login(Configuration.userName, Configuration.password, 3, nil, "Chobby")
 	else
-		Spring.Echo("Trying Simple Login")
 		lobby:Connect(Configuration:GetServerAddress(), Configuration:GetServerPort(), Configuration.userName, Configuration.password, 3, nil, "Chobby")
 	end
 end
@@ -263,7 +261,6 @@ function LoginWindowHandler.TryLoginMultiplayer(name, password)
 end
 
 function LoginWindowHandler.TryLogin(newLoginAcceptedFunction)
-	Spring.Echo("LoginWindowHandler.TryLogin")
 	loginAcceptedFunction = newLoginAcceptedFunction
 	if not TrySimpleSteamLogin() then
 		local loginWindow = GetNewLoginWindow(nil, "LoginWindowHandler:TryLogin")

--- a/LuaMenu/widgets/gui_login_window.lua
+++ b/LuaMenu/widgets/gui_login_window.lua
@@ -73,6 +73,7 @@ local function TrySimpleSteamLogin()
 	if (lobby:GetConnectionStatus() == "connected") then
 		lobby:Login(Configuration.userName, Configuration.password, 3, nil, "Chobby", true)
 	else
+		Spring.Echo("Trying Simple Steam Login")
 		lobby:Connect(Configuration:GetServerAddress(), Configuration:GetServerPort(), Configuration.userName, Configuration.password, 3, nil, "Chobby")
 	end
 	return true
@@ -83,6 +84,7 @@ local function TrySimpleLogin()
 	if (lobby:GetConnectionStatus() == "connected") then
 		lobby:Login(Configuration.userName, Configuration.password, 3, nil, "Chobby")
 	else
+		Spring.Echo("Trying Simple Login")
 		lobby:Connect(Configuration:GetServerAddress(), Configuration:GetServerPort(), Configuration.userName, Configuration.password, 3, nil, "Chobby")
 	end
 end
@@ -261,6 +263,7 @@ function LoginWindowHandler.TryLoginMultiplayer(name, password)
 end
 
 function LoginWindowHandler.TryLogin(newLoginAcceptedFunction)
+	Spring.Echo("LoginWindowHandler.TryLogin")
 	loginAcceptedFunction = newLoginAcceptedFunction
 	if not TrySimpleSteamLogin() then
 		local loginWindow = GetNewLoginWindow(nil, "LoginWindowHandler:TryLogin")


### PR DESCRIPTION
Work done:

- Add a 5 second delay to the login button and prevent it from attempting to login again if already logged in. This is so we can be sure any more logs with the issue that come in aren't caused by people spam clicking login if facing flood protection. This could be improved further by detecting when flood protection has been triggered and increasing the wait to 20 seconds.
- Minor alignment fixes to 2 labels in the Recover menu of the Login panel
