### PR TITLE
Increase callTryLogin delay to 30

### DIFF
--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -1123,7 +1123,7 @@ function LoginWindow:MayBeDisconnectBeforeTryLogin()
 	local function callTryLogin() self:tryLogin() end
 	self.onDisconnected = function(listener)
 		lobby:RemoveListener("OnDisconnected", self.onDisconnected)
-		WG.Delay(callTryLogin, 3) -- server returns error when connecting directly after disconnect
+		WG.Delay(callTryLogin, 30) -- server returns error when connecting directly after disconnect
 	end
 	lobby:AddListener("OnDisconnected", self.onDisconnected)
 


### PR DESCRIPTION
This is an attempt to mitigate chobby is spamming login requests after disconnecting mid-match, triggering flood protection. There is one function I found that seemed to be set to try reconnecting if disconnected every 3 seconds, and it isn't anywhere in Zero-K chobby code so I am suspicious of it. 

This PR increases the delay mentioned above to 30.

Related log:
[spring-launcher-20241114T083304.log](https://github.com/user-attachments/files/17780997/spring-launcher-20241114T083304.log)
