### PR TITLE
More login echoes

### DIFF
--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -1120,8 +1120,13 @@ function LoginWindow:MayBeDisconnectBeforeTryLogin()
 	end
 
 	-- disconnect and cleanup before login to next account
-	local function callTryLogin() self:tryLogin() end
+	local function callTryLogin()
+		Spring.Echo("Attempting reconnect")
+		self:tryLogin()
+	end
+
 	self.onDisconnected = function(listener)
+		Spring.Echo("onDisconnected")
 		lobby:RemoveListener("OnDisconnected", self.onDisconnected)
 		WG.Delay(callTryLogin, 3) -- server returns error when connecting directly after disconnect
 	end
@@ -1132,6 +1137,7 @@ function LoginWindow:MayBeDisconnectBeforeTryLogin()
 end
 
 function LoginWindow:tryLogin()
+	Spring.Echo("LoginWindow:tryLogin")
 	self.txtError:SetText("")
 
 	local username = self.ebUsername.text

--- a/LuaMenu/widgets/gui_login_window.lua
+++ b/LuaMenu/widgets/gui_login_window.lua
@@ -73,6 +73,7 @@ local function TrySimpleSteamLogin()
 	if (lobby:GetConnectionStatus() == "connected") then
 		lobby:Login(Configuration.userName, Configuration.password, 3, nil, "Chobby", true)
 	else
+		Spring.Echo("Trying Simple Steam Login")
 		lobby:Connect(Configuration:GetServerAddress(), Configuration:GetServerPort(), Configuration.userName, Configuration.password, 3, nil, "Chobby")
 	end
 	return true
@@ -83,6 +84,7 @@ local function TrySimpleLogin()
 	if (lobby:GetConnectionStatus() == "connected") then
 		lobby:Login(Configuration.userName, Configuration.password, 3, nil, "Chobby")
 	else
+		Spring.Echo("Trying Simple Login")
 		lobby:Connect(Configuration:GetServerAddress(), Configuration:GetServerPort(), Configuration.userName, Configuration.password, 3, nil, "Chobby")
 	end
 end
@@ -261,6 +263,7 @@ function LoginWindowHandler.TryLoginMultiplayer(name, password)
 end
 
 function LoginWindowHandler.TryLogin(newLoginAcceptedFunction)
+	Spring.Echo("LoginWindowHandler.TryLogin")
 	loginAcceptedFunction = newLoginAcceptedFunction
 	if not TrySimpleSteamLogin() then
 		local loginWindow = GetNewLoginWindow(nil, "LoginWindowHandler:TryLogin")


### PR DESCRIPTION
Add 6 new echoes. Currently logs that show login spam only have `OnConnected` and `Disconnected, reason:, nil, true` over and over. We need more info about the login path that is being taken when this login spam is occurring to fix appropriately.

Related log:
[spring-launcher-20241114T083304.log](https://github.com/user-attachments/files/17781265/spring-launcher-20241114T083304.log)
