### PR TITLE
Fix not closing sockets and bad timeout error condition checks.

### DIFF
--- a/LuaMenu/widgets/api_analytics.lua
+++ b/LuaMenu/widgets/api_analytics.lua
@@ -658,9 +658,7 @@ local function LobbyInfo()
 		local client=socket.tcp()
 		local res, err = client:connect(host, port)
 		if not res and err ~= "timeout" then  Spring.Echo("Lobby:Info Error", res, err) else client:send(message) end
-		if client then
-			client:close()
-		end
+		client:close()
 	end
 end
 

--- a/LuaMenu/widgets/api_analytics.lua
+++ b/LuaMenu/widgets/api_analytics.lua
@@ -139,11 +139,17 @@ end
 
 
 local function SocketConnect(host, port)
+	if client then
+		client:close()
+		client = nil
+	end
 	client=socket.tcp()
 	client:settimeout(0)
 	res, err = client:connect(host, port)
-	if not res and not res=="timeout" then
+	if not res and err ~= "timeout" then
 		if PRINT_DEBUG then Spring.Echo("Error in connection to Analytics server: "..err) end
+		client:close()
+		client = nil
 		return false
 	end
 	if PRINT_DEBUG then Spring.Echo("Analytics connected") end
@@ -652,8 +658,10 @@ local function LobbyInfo()
 		local message = "c.telemetry.log_client_event lobby:info " .. Spring.Utilities.Base64Encode(Spring.Utilities.json.encode(t)).." ".. machineHash .. "\n"
 		local client=socket.tcp()
 		local res, err = client:connect(host, port)
-		if not res and not res=="timeout" then  Spring.Echo("Lobby:Info Error", res, err) else client:send(message) end
-		if client ~= nil then client:close() end
+		if not res and err ~= "timeout" then  Spring.Echo("Lobby:Info Error", res, err) else client:send(message) end
+		if client then
+			client:close()
+		end
 	end
 end
 
@@ -735,6 +743,7 @@ function widget:Initialize()
 		isConnected = true
 		if client ~= nil then
 			client:close()
+			client = nil
 		end
 		ACTIVE = false
 		-- disconnect

--- a/LuaMenu/widgets/api_analytics.lua
+++ b/LuaMenu/widgets/api_analytics.lua
@@ -141,7 +141,6 @@ end
 local function SocketConnect(host, port)
 	if client then
 		client:close()
-		client = nil
 	end
 	client=socket.tcp()
 	client:settimeout(0)

--- a/libs/liblobby/lobby/interface_shared.lua
+++ b/libs/liblobby/lobby/interface_shared.lua
@@ -56,6 +56,7 @@ function Interface:Disconnect(reason)
 	self.finishedConnecting = false
 	if self.client then
 		self.client:close()
+		self.client = nil
 	end
 	self:_OnDisconnected(reason, true)
 end

--- a/libs/spring-launcher/luaui/widgets/api_spring_launcher.lua
+++ b/libs/spring-launcher/luaui/widgets/api_spring_launcher.lua
@@ -89,10 +89,15 @@ local function explode(div,str)
 end
 
 function widget:SocketConnect()
+	if client then
+		client:close()
+	end
 	client = socket.tcp()
 	client:settimeout(0)
 	local res, err = client:connect(host, port)
-	if not res and not res == "timeout" then
+	if not res and err ~= "timeout" then
+		client:close()
+		client = nil
 		widgetHandler:RemoveWidget(self)
 		Spring.Log(LOG_SECTION, LOG.ERROR, "Error in connect launcher: " .. err)
 		return false


### PR DESCRIPTION
### Work done

* Fix not closing sockets consistently at api_analytics.lua and api_spring_launcher.lua.
* Also fixes some error condition checks on client:connect calls.
  * They would result in no error be treated as an error since lua doing `not res and not res == "timeout"` becomes `not res and (not res) == "timeout"` (never true) due to operator precedence.

### Related issues

* Fixes crashing (maybe on linux only) when launcher not available (see https://github.com/Spring-Chobby/Chobby/issues/548).
* https://github.com/beyond-all-reason/spring/issues/1786

### Remarks

* You might want to test this is fine on windows before merging
  * As far as I know the api should work similarly but anyways just in case
* At least on linux this was making spring **crash quite fast** after starting a game **when not run through the launcher**.
  * It was running out of descriptors due to not closing the sockets, so after not much, it would start failing to load images, sounds...
* The bad error condition checks probably didn't have much of an effect but it meant ignoring timeout wasn't always working as intended. This might have some unintended side effect tho.
* When connect returns `res, error`, when there's an error res should always be nil and error be set to some string, still I kept the `not res and err ~= "timeout"` pattern. I think conditions could be rationally changed to `err and err ~= "timeout"` but this way feels more solid, and also I think the original developer wanted to do it like this.
