### PR TITLE
Fix instances of 'if not x == y'.

### DIFF
--- a/LuaMenu/widgets/chobby/components/friend_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/friend_list_window.lua
@@ -118,7 +118,7 @@ function FriendListWindow:OnAddUser(userName)
 end
 
 function FriendListWindow:OnRemoveUser(userName)
-	if (not lobby.status == "connected") then
+	if lobby.status ~= "connected" then
 		return
 	end
 	local userInfo = lobby:GetUser(userName)

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -4162,7 +4162,7 @@ end
 
 
 function BattleRoomWindow.SetTeams(numberOfTeams)
-	if not battleLobby.name == "singleplayer" then
+	if battleLobby.name ~= "singleplayer" then
 		-- command to set the teams
 		battleLobby:SayBattle(string.format("!nbteams %d", numberOfTeams))
 	end


### PR DESCRIPTION
While investigating #827 I noticed the lua antipattern of doing `if not x == y`, that results in `if (not x) == y` instead of `if x ~= y`.

They would result in the test always being skipped.

Fixing all those instances in the codebase (hopefully XD) except the ones included in #827.