### PR TITLE
Fix battle.locked status

### DIFF
--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -1343,10 +1343,8 @@ function Lobby:_OnUpdateBattleInfo(battleID, battleInfo)
 	battle.playerCount = battleInfo.playerCount or battle.playerCount
 	battle.spectatorCount = battleInfo.spectatorCount or battle.spectatorCount
 
-	if battleInfo.locked == true then -- Because (false or nil) == nil
-		battle.locked = true
-	else
-		battle.locked = false
+	if battleInfo.locked ~= nil then -- Because (false or nil) == nil
+		battle.locked = battleInfo.locked
 	end
 
 	if battleInfo.bossed ~= nil then

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -1343,7 +1343,7 @@ function Lobby:_OnUpdateBattleInfo(battleID, battleInfo)
 	battle.playerCount = battleInfo.playerCount or battle.playerCount
 	battle.spectatorCount = battleInfo.spectatorCount or battle.spectatorCount
 
-	if battleInfo.locked ~= nil then -- Because (false or nil) == nil
+	if battleInfo.locked ~= nil then
 		battle.locked = battleInfo.locked
 	end
 


### PR DESCRIPTION
The previous version of the query would always return false, regardless of lock status.

Closes https://github.com/beyond-all-reason/BYAR-Chobby/issues/829