### PR TITLE
Fix unsafe socket usage (v2)

### DIFF
--- a/LuaMenu/widgets/api_analytics.lua
+++ b/LuaMenu/widgets/api_analytics.lua
@@ -108,7 +108,7 @@ local infologDirectory = "log/"
 function SendBARAnalytics(cmdName,args,isEvent)
 	if PRINT_DEBUG then Spring.Log("Chobby", LOG.WARNING, "Analytics Event", cmdName, args, isEvent, client, "C/A",isConnected, ACTIVE) end
 
-	if client == nil then
+	if not isConnected and client == nil then
 		return
 	end
 	cmdName = string.gsub(cmdName, " ", "_") -- remove spaces from event names

--- a/LuaMenu/widgets/api_analytics.lua
+++ b/LuaMenu/widgets/api_analytics.lua
@@ -139,11 +139,16 @@ end
 
 
 local function SocketConnect(host, port)
+	if client then
+		client:close()
+	end
 	client=socket.tcp()
 	client:settimeout(0)
 	res, err = client:connect(host, port)
-	if not res and not res=="timeout" then
+	if not res and err ~= "timeout" then
 		if PRINT_DEBUG then Spring.Echo("Error in connection to Analytics server: "..err) end
+		client:close()
+		client = nil
 		return false
 	end
 	if PRINT_DEBUG then Spring.Echo("Analytics connected") end
@@ -652,8 +657,8 @@ local function LobbyInfo()
 		local message = "c.telemetry.log_client_event lobby:info " .. Spring.Utilities.Base64Encode(Spring.Utilities.json.encode(t)).." ".. machineHash .. "\n"
 		local client=socket.tcp()
 		local res, err = client:connect(host, port)
-		if not res and not res=="timeout" then  Spring.Echo("Lobby:Info Error", res, err) else client:send(message) end
-		if client ~= nil then client:close() end
+		if not res and err ~= "timeout" then  Spring.Echo("Lobby:Info Error", res, err) else client:send(message) end
+		client:close()
 	end
 end
 
@@ -735,6 +740,7 @@ function widget:Initialize()
 		isConnected = true
 		if client ~= nil then
 			client:close()
+			client = nil
 		end
 		ACTIVE = false
 		-- disconnect

--- a/libs/liblobby/lobby/interface_shared.lua
+++ b/libs/liblobby/lobby/interface_shared.lua
@@ -56,6 +56,7 @@ function Interface:Disconnect(reason)
 	self.finishedConnecting = false
 	if self.client then
 		self.client:close()
+		self.client = nil
 	end
 	self:_OnDisconnected(reason, true)
 end

--- a/libs/spring-launcher/luaui/widgets/api_spring_launcher.lua
+++ b/libs/spring-launcher/luaui/widgets/api_spring_launcher.lua
@@ -89,10 +89,15 @@ local function explode(div,str)
 end
 
 function widget:SocketConnect()
+	if client then
+		client:close()
+	end
 	client = socket.tcp()
 	client:settimeout(0)
 	local res, err = client:connect(host, port)
-	if not res and not res == "timeout" then
+	if not res and err ~= "timeout" then
+		client:close()
+		client = nil
 		widgetHandler:RemoveWidget(self)
 		Spring.Log(LOG_SECTION, LOG.ERROR, "Error in connect launcher: " .. err)
 		return false


### PR DESCRIPTION
### Work done

- New fix for sockets (see below for more information).
- Fixed version of https://github.com/beyond-all-reason/BYAR-Chobby/pull/827 that was merged and then reverted because of api_analytics issue affecting the join queue.
- Pbbly good idea to test online by devs before deploying to all users.
  - I tested and queue works well now, also could join a game as spec.

### Explanation about regression with previous fix

(note the same fix applied to base Chobby and zk Chobby didn't have this problem since they don't have the api_analytics module)

Turns out analytics is doing more than expected (not the module I'd have expected to produce actual lobby issues).

Due to a logic error, when the initial socket is disposed of (and now set to nil), once lobby is connected it would stop sending information, and apparently that's what makes the queue status show ok.

Seems analytics is sending one way when lobby is not connected, and when it's connected it sends in a different way.

For those curious, this is the fix for the issue: https://github.com/beyond-all-reason/BYAR-Chobby/pull/837/commits/c5d87c1030ccde766642586e20d2b914cdf4ced6

### More info the socket fixes:

* Fix not closing sockets consistently at api_analytics.lua, api_spring_launcher.lua and interface_shared.lua.
* Also fixes some error condition checks on client:connect calls.
  * They would result in no error be treated as an error since lua doing `not res and not res == "timeout"` becomes `not res and (not res) == "timeout"` (never true) due to operator precedence.
  * Also it was checking for the error at `res`, when it's actually at `err` when doing: `res, err = client.connect(...)`

### Related issues

* Fixes crashing (maybe on linux only) when launcher not available (see https://github.com/Spring-Chobby/Chobby/issues/548).
* https://github.com/beyond-all-reason/spring/issues/1786
