### PR TITLE
Fix main menu not initializing if campaignConfigName is nil

### DIFF
--- a/LuaMenu/widgets/chobby/components/interface_root.lua
+++ b/LuaMenu/widgets/chobby/components/interface_root.lua
@@ -1226,15 +1226,8 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 			heading_image.file = Configuration:GetHeadingImage(doublePanelMode, mainWindowHandler.GetSubheadingName())
 			heading_image:Invalidate()
 
-			local replacementTabs = Configuration.gameConfig.singleplayerConfig
-			--local replacementHelpTabs = Configuration.gameConfig.helpSubmenuConfig
-
 			WG.BattleRoomWindow.LeaveBattle(false, true)
 
-			mainWindowHandler.OpenSubmenu(1)
-
-			--mainWindowHandler.ReplaceSubmenu(SINGLEPLAYER_INDEX, replacementTabs)
-			--mainWindowHandler.ReplaceSubmenu(HELP_INDEX, replacementHelpTabs)
 		end
 	end
 	Configuration:AddListener("OnConfigurationChange", onConfigurationChange)
@@ -1265,6 +1258,8 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 	-- Initialization
 	-------------------------------------------------------------------
 	local screenWidth, screenHeight = Spring.GetViewSizes()
+
+	mainWindowHandler.OpenSubmenu(1)
 
 	battleStatusPanelHandler.Rescale(2, 70)
 	rightPanelHandler.Rescale(2, 70)

--- a/LuaMenu/widgets/gui_login_window.lua
+++ b/LuaMenu/widgets/gui_login_window.lua
@@ -35,10 +35,6 @@ local function ResetRegisterRecieved()
 	registerRecieved = false
 end
 
-local function LoadMainMenu()
-	WG.Chobby.interfaceRoot.GetMainWindowHandler().OpenSubmenu(1)
-end
-
 local wantLoginStatus = {
 	["offline"] = true,
 	["closed"] = true,
@@ -109,7 +105,6 @@ local function CheckFirstTimeRegister()
 	end
 	local Configuration = WG.Chobby.Configuration
 	if Configuration.firstLoginEver then
-		LoadMainMenu()
 		LoginWindowHandler.TryLogin()
 	end
 end


### PR DESCRIPTION
https://discord.com/channels/549281623154229250/1313757882621104148

So, turns out initial loading of the flattened main menu wasn't done right, it relied upon listening to either a `gameconfigname` or `campaignconfigname` change. old function checking `campaignconfigname` for "dev" or "sample" was the only reason this was happening on startup. 

Main menu was flattened 6 months ago https://github.com/beyond-all-reason/BYAR-Chobby/pull/699 by Beherith but writing of the `campaignconfigname` config setting was disabled a half year before by Fireball in https://github.com/beyond-all-reason/BYAR-Chobby/pull/500. Those who've been around for longer would still have it in configuration, and would not perceive this issue in testing.

