### PR TITLE
20% darker background setting for new configs

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -303,7 +303,7 @@ function Configuration:init()
 	self.useSpringRestart = false
 	self.menuMusicVolume = 0.5
 	self.menuNotificationVolume = 0.8
-	self.menuBackgroundBrightness = 1
+	self.menuBackgroundBrightness = 0.8
 	self.gameOverlayOpacity = 0.5
 	self.coopConnectDelay = 5
 	self.showMatchMakerBattles = false


### PR DESCRIPTION
Because my config had `menuBackgroundBrightness = 0.79999995,` set somehow and I thought this was how it looked for everyone, but no, default was full brightness at 1.0. 