### PR TITLE
Don't notify for coordinator lines full of "#"

### DIFF
--- a/LuaMenu/widgets/chobby/components/chat_windows.lua
+++ b/LuaMenu/widgets/chobby/components/chat_windows.lua
@@ -104,21 +104,19 @@ function ChatWindows:init()
 	)
 	lobby:AddListener("OnSaidPrivate",
 		function(listener, userName, message, msgDate)
-			if userName == 'Nightwatch' then
-				local chanName, userName, msgDate, message = message:match('.-|(.+)|(.+)|(.+)|(.*)')
-				local channelConsole = self:GetChannelConsole(chanName)
-				if channelConsole ~= nil then
-					channelConsole:AddMessage(message, userName, msgDate)
-				end
-			else
-				local chanName = userName .. " messages"
-				local privateChatConsole = self:GetPrivateChatConsole(userName)
-				if self:IsChannelSelected(chanName) and self.activeUnreadMessages and self.activeUnreadMessages ~= 0 then
-					self.activeUnreadMessages = self.activeUnreadMessages + 1
-				end
-				privateChatConsole:AddMessage(message, userName, msgDate)
-				self:_NotifyTab(chanName, userName, "Private", true, message, "sounds/beep4.wav", 15)
+			local chanName = userName .. " messages"
+			local privateChatConsole = self:GetPrivateChatConsole(userName)
+			if self:IsChannelSelected(chanName) and self.activeUnreadMessages and self.activeUnreadMessages ~= 0 then
+				self.activeUnreadMessages = self.activeUnreadMessages + 1
 			end
+			privateChatConsole:AddMessage(message, userName, msgDate)
+			if userName == 'Coordinator' then
+				message = message and message:gsub("#", "")
+				if message == "" or nil then
+					return
+				end
+			end
+			self:_NotifyTab(chanName, userName, "Private", true, message, "sounds/beep4.wav", 15)
 		end
 	)
 	lobby:AddListener("OnSaidPrivateEx",


### PR DESCRIPTION
"#" is commonly used for line space before and after join messages from Coordinator, skip those characters in notifications and just show the message.