### PR TITLE
Default boxes button with 1 team loads as if 2 teams

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -250,10 +250,13 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 
 				if selected == "Default Boxes" then
 					local function defaultBoxes()
+						Spring.Echo(battle.nbTeams.." here")
 						if battleLobby.name == "singleplayer" then
 							battleLobby:SelectMap(battle.mapName)
-						else
+						elseif battle.nbTeams and tonumber(battle.nbTeams) > 1 then
 							battleLobby:SayBattle("!loadboxes")
+						else
+							battleLobby:SayBattle("!loadboxes \""..battle.mapName.."\" 2 0")
 						end
 						UpdateBoxes()
 					end

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -250,10 +250,9 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 
 				if selected == "Default Boxes" then
 					local function defaultBoxes()
-						Spring.Echo(battle.nbTeams.." here")
 						if battleLobby.name == "singleplayer" then
 							battleLobby:SelectMap(battle.mapName)
-						elseif battle.nbTeams and tonumber(battle.nbTeams) > 1 then
+						elseif battle.nbTeams and tonumber(battle.nbTeams) > 1 then --Minimum 2 teams in multiplayer until PvE boxes are supported
 							battleLobby:SayBattle("!loadboxes")
 						else
 							battleLobby:SayBattle("!loadboxes \""..battle.mapName.."\" 2 0")


### PR DESCRIPTION
Maps don't have loadboxes defined for them for playing with only 1 team. There is no intended way to play with 1 team at all.

However, the "coop" preset sets the number of teams to 1 to force all the players into one team, and all the bots into the other.
This means that, while the players see 2 teams (one human and one AI), SPADS considers the number of teams to be 1 and loads (fails to load) the default boxes accordingly.

This PR forces the "Default Boxes" button to load the boxes for 2 teams if the number of teams is not greater than 1.