### PR TITLE
Fix Option Presets not applying bonuses from saved AI profiles

### DIFF
--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -165,7 +165,7 @@ local function applyPreset(presetName)
 		-- AIs with their settings
 		local presetAi = presetObj["Bots"]
 		if presetAi ~= nil and enabledOptions["Bots"] then
-			local newAiNames = {}
+			local saidBattleExOnce = false
 
 			for key, _ in pairs(currentAITable) do
 				battleLobby:RemoveAi(key)
@@ -179,6 +179,15 @@ local function applyPreset(presetName)
 				battlestatusoptions.handicap = value.handicap
 				battleLobby:AddAi(key, value.aiLib, value.allyNumber, value.aiVersion, value.aiOptions,
 					battlestatusoptions)
+				if (multiplayer) and battlestatusoptions.handicap then
+					local isBoss = battle.bossed
+					if isBoss and isBoss == true then
+						battleLobby:SayBattle("!force "..key.." bonus ".. tostring(battlestatusoptions.handicap))
+					elseif saidBattleExOnce == false then
+							WG.Delay(function() battleLobby:SayBattleEx("tried to apply bonuses to AI, but was prevented due to not being boss") end, 1.5)
+							saidBattleExOnce = true
+					end
+				end
 			end
 		end
 

--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -176,6 +176,7 @@ local function applyPreset(presetName)
 				local battlestatusoptions = {}
 				battlestatusoptions.teamColor = value.teamColor
 				battlestatusoptions.side = value.side
+				battlestatusoptions.handicap = value.handicap
 				battleLobby:AddAi(key, value.aiLib, value.allyNumber, value.aiVersion, value.aiOptions,
 					battlestatusoptions)
 			end

--- a/libs/liblobby/lobby/interface_skirmish.lua
+++ b/libs/liblobby/lobby/interface_skirmish.lua
@@ -558,6 +558,7 @@ function InterfaceSkirmish:AddAi(aiName, aiLib, allyNumber, version, aiOptions, 
 		aiOptions = aiOptions,
 		teamColor = battleStatusOptions and battleStatusOptions.teamColor,
 		side = battleStatusOptions and battleStatusOptions.side,
+		handicap = battleStatusOptions and battleStatusOptions.handicap,
 	})
 end
 


### PR DESCRIPTION
Unfortunately this can trigger flood protection in multiplayer, so boss status is currently required to apply bonuses from the preset.