### PR TITLE
Make minimum bonus 0 in all cases

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -1085,13 +1085,9 @@ local function GetUserControls(userName, opts)
 						if battleStatus.isSpectator then
 							return
 						end
-						local minbonus = 0
-						if isSingleplayer then
-							minbonus = -99
-						end
 						WG.IntegerSelectorWindow.CreateIntegerSelectorWindow({
 							defaultValue = 0,
-							minValue = minbonus,
+							minValue = 0,
 							maxValue = 100,
 							caption = "Add Bonus",
 							labelCaption = "Give "..userName.." an additional % resource bonus. 100% means that player produces double the normal resource amount. 0% is regular resource production. In single player games, a negative bonus will result in that player getting X% less resources",


### PR DESCRIPTION
The special -99 minimum value that the bonus selector gets in singleplayer would imply support for using bonus to debuff AI, but this value does not appear to do anything below 0. This PR sets this to 0 in all cases instead of multiplayer-only. 