### PR TITLE
Take 2: Simple Skirmish: Download needed maps and bump priority of map downloads based on gameType and map selection

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/singleplayerQuickSkirmish.lua
+++ b/LuaMenu/configs/gameConfig/byar/singleplayerQuickSkirmish.lua
@@ -77,7 +77,6 @@ local skirmishSetupData = {
 			tipText = "Click 'Advanced' for more maps and options.",
 			getDynamicOptions = function(pageChoices)
 				local selectedGameType = gameTypes[pageChoices.gameType or 1]
-				Spring.Echo("Selected game type string: " .. tostring(selectedGameType))
 				return mapsByGameType[selectedGameType]
 			end,
 		},
@@ -87,7 +86,7 @@ local skirmishSetupData = {
 function skirmishSetupData.ApplyFunction(battleLobby, pageChoices)
 	local difficulty = pageChoices.difficulty or 1
 	local gameType = pageChoices.gameType or 1
-	local map = pageChoices.map or 1
+	local map = pageChoices.map or 2
 
 	local pageConfig = skirmishSetupData.pages
 	local selectedGameType = pageConfig[1].options[gameType]

--- a/LuaMenu/configs/gameConfig/byar/skirmishDefault.lua
+++ b/LuaMenu/configs/gameConfig/byar/skirmishDefault.lua
@@ -1,6 +1,7 @@
 local randomSkirmishEnabled = Spring.GetConfigInt("randomSkirmishSetup", 1)
+local simpleSkirmishEnabled = Spring.GetConfigInt("simplifiedSkirmishSetup", 1)
 
-if randomSkirmishEnabled == 1 then
+if randomSkirmishEnabled == 1 and simpleSkirmishEnabled ~= 1 then
 	local listOfCertifiedMaps = VFS.Include("luamenu/configs/gameconfig/byar/mapdetails.lua")
 	local convertedListOfMaps = {}
 	for pickedMap, mapDetails in pairs(listOfCertifiedMaps) do
@@ -41,12 +42,11 @@ if randomSkirmishEnabled == 1 then
 				startboxes =  {[0] = {0, 160, 200, 200}, [1] = {0, 0, 200, 40}, }
 			end
 			skirmishTable = {map = map, enemyAI = enemyAI, friendlyAI = friendlyAI,startboxes = startboxes}
-			
 		end
 	end
 
 	return skirmishTable
 else
-	return { map = "Quicksilver Remake 1.24",}
+	return { map = "Avalanche 3.4",}
 end
 

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -226,6 +226,7 @@ return {
 		flushLogs_tooltip = "Immediately flush infolog.txt to disk for debuggging.",
 		keep_queues = "Stay in MM queues on launch",
 		simplifiedSkirmishSetup = "Simple skirmish setup",
+		simplifiedSkirmishSetup_tooltip = "Provides step-by-step instructions while setting up a singleplayer skirmish.",
 		debugMode = "Debug mode",
 		ShowhiddenModopions = "Show Hidden Modoptions",
 		ShowhiddenTooltip = "WARNING: Hidden options may not work. Rearranges Tabs",

--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -1067,7 +1067,7 @@ local function GetLobbyTabControls()
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("non_friend_notifications"), "nonFriendNotifications", true, nil,  i18n("non_friend_notifications_tooltip"))
 	--children[#children + 1], offset = AddCheckboxSetting(offset, i18n("notifyForAllChat"), "notifyForAllChat", false)
 	--children[#children + 1], offset = AddCheckboxSetting(offset, i18n("only_featured_maps"), "onlyShowFeaturedMaps", true)
-	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("simplifiedSkirmishSetup"), "simplifiedSkirmishSetup", true)
+	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("simplifiedSkirmishSetup"), "simplifiedSkirmishSetup", true, nil, i18n("simplifiedSkirmishSetup_tooltip"))
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("animate_lobby"), "animate_lobby", true, nil, i18n("animate_lobby_tooltip"))
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("drawFullSpeed"), "drawAtFullSpeed", false, nil, i18n("drawFullSpeed_tooltip"))
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("fixFlicker"), "fixFlicker", true, nil, i18n("fixFlicker_tooltip"))
@@ -1221,7 +1221,13 @@ local function GetLobbyTabControls()
 			else
 				Spring.SetConfigInt("randomSkirmishSetup", 0)
 			end
-			--Configuration:SetConfigValue("randomSkirmishSetup", value)
+		end
+		if key == "simplifiedSkirmishSetup" then
+			if value == true then
+				Spring.SetConfigInt("simplifiedSkirmishSetup", 1)
+			else
+				Spring.SetConfigInt("simplifiedSkirmishSetup", 0)
+			end
 		end
 
 		if key == "queueExitConfirmPromptDoNotAskAgain" and cbQueueExitConfirmPromptDoNotAskAgain.checked ~= value then


### PR DESCRIPTION
This time without breaking the actual launch sequence.

I changed the default offered map when random skirmish is disabled to Avalanche instead of Quicksilver, as it is already in the 1vs1 list. Random skirmish setup will now only engage is simple skirmish is not enabled, as it would trigger a superfluous map download.