### PR TITLE
BARb: Reorganize profile list

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/aiCustomData.lua
+++ b/LuaMenu/configs/gameConfig/byar/aiCustomData.lua
@@ -5,14 +5,36 @@ local customProfiles = {
 			name = 'Hard | Aggressive',  -- human readable name displayed in a list
 			desc = 'Difficulty: Hard | Playstyle: Aggressive | Made by Flaka, tweaked by Corosus',
 		},
+		{
+			key  = 'hard',
+			name = 'Hard | Balanced',
+			desc = 'Difficulty: Hard |Playstyle: Balanced |Made by Flaka',
+		},
+		{
+			key  = 'medium',
+			name = 'Medium | Lazy',
+			desc = 'Difficulty: Medium |Playstyle: Learning mechanics',
+		},
+		{
+			key  = 'easy',
+			name = 'Easy | Slow',
+			desc = 'Difficulty: Easy |Playstyle: First launch',
+		},
+		{
+			key  = 'dev',
+			name = 'Testing AI',
+			desc = 'Testing config',
+		},
 	},
 }
 
 local blacklistProfiles = {
--- 	['BARb'] = {
--- 		dev = true,
--- 		hard = true,
--- 	},
+	['BARb'] = {
+		dev = true,
+		hard = true,
+		medium = true,
+		easy = true,
+	},
 }
 
 local function ArrayRemove(t, fnKeep)


### PR DESCRIPTION
In `Engine test` profiles that aren't in AI repository were removed from the list: https://github.com/rlcevg/CircuitAI/blob/barbarian/data/AIOptions.lua#L79-L93
Profiles re-added through [aiCustomData.lua](https://github.com/beyond-all-reason/BYAR-Chobby/compare/master...rlcevg:barb_profile_list1?expand=1#diff-c5cde79c1e16a9c2502a4e6a8f666465ac660e9f8cdeffe07d0089a138ed9318)

Usage of `blacklistProfiles` makes this PR usable now (blacklisting `hard, medium, easy` will be redundant after `Engine test` adaptation).