### PR TITLE
feat(Change Team): use drop down window

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -1054,10 +1054,9 @@ local function GetUserControls(userName, opts)
 						if battleStatus.isSpectator then
 							return
 						end
-						WG.IntegerSelectorWindow.CreateIntegerSelectorWindow({
-							defaultValue = (battleStatus.allyNumber or 1) + 1,
-							minValue = 1,
-							maxValue = 16,
+						WG.TeamChangeWindow.CreateTeamChangeWindow({
+							initialTeam = (battleStatus.allyNumber or 1) + 1,
+							maxTeams = 16,
 							caption = "Change Team",
 							labelCaption = "Change "..userName.." to Team: ",
 							OnAccepted = function(allyTeamID)

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -491,6 +491,7 @@ return {
 		customGames = "Spezielle Spiele",
 		playing = "Am Spielen",
 		pick_map = "Karte wechseln",
+		pick_team = "Team wechseln",
 		add_team = "Team hinzufügen",
 		players = "Spieler",
 		submit = "Abschicken",

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -184,6 +184,7 @@ return {
 		matchmaking = "Matchmaking",
 		customGames = "Custom Games",
 		pick_map = "Change Map",
+		pick_team = "Change Team",
 		add_team = "Add Team",
 		players = "Players",
 		submit = "Submit",

--- a/LuaMenu/widgets/gui_team_change_window.lua
+++ b/LuaMenu/widgets/gui_team_change_window.lua
@@ -20,7 +20,7 @@ local function CreateTeamChangeWindow(opts)
 	end
 
 	local teamChangeWindow = Window:New {
-		caption = "Change Team",
+		caption = i18n("pick_team"),
 		name = "teamChangeWindow",
 		parent = screen0,
 		width = 280,

--- a/LuaMenu/widgets/gui_team_change_window.lua
+++ b/LuaMenu/widgets/gui_team_change_window.lua
@@ -1,0 +1,114 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function widget:GetInfo()
+	return {
+		name      = "Team change window",
+		desc      = "Displays a team change window popup with a drop down list.",
+		author    = "oopsbagel",
+		date      = "2025-03-12",
+		license   = "GNU LGPL, v2.1 or later",
+		layer     = 0,
+		enabled   = true  --  loaded by default?
+	}
+end
+
+local function CreateTeamChangeWindow(opts)
+	opts = opts or {}
+	local Configuration = WG.Chobby.Configuration
+
+	local teamNumbers = {}
+	for i = 1, opts.maxTeams do
+		table.insert(teamNumbers, tostring(i))
+	end
+
+	local teamChangeWindow = Window:New {
+		caption = "Change Team",
+		name = "teamChangeWindow",
+		parent = screen0,
+		width = 280,
+		height = 200,
+		resizable = false,
+		draggable = false,
+		classname = "main_window",
+	}
+
+	local function ChangeAccepted()
+		if opts.OnAccepted then
+			opts.OnAccepted(opts.initialTeam)
+		end
+	end
+	local function CloseFunction()
+		teamChangeWindow:Dispose()
+		teamChangeWindow = nil
+	end
+
+	local lblTitle = TextBox:New {
+		x = 15,
+		y = 15,
+		width = teamChangeWindow.width - teamChangeWindow.padding[1] - teamChangeWindow.padding[3],
+		height = 35,
+		align = "center",
+		multiline = true,
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
+		text = opts.labelCaption,
+		parent = teamChangeWindow,
+		-- XXX handle longer strings gracefully
+	}
+
+	local btnOK = Button:New {
+		x = "10%",
+		width = "30%",
+		bottom = 1,
+		height = 40,
+		caption = i18n("ok"),
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
+		classname = "action_button",
+		OnClick = { CloseFunction, ChangeAccepted },
+		parent = teamChangeWindow,
+	}
+
+	local btnCancel = Button:New {
+		right = "10%",
+		width = "30%",
+		bottom = 1,
+		height = 40,
+		caption = i18n("cancel"),
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
+		classname = "negative_button",
+		OnClick = { CloseFunction },
+		parent = teamChangeWindow,
+	}
+
+	local cmbTeams = ComboBox:New {
+		x = "5%",
+		y = "40%",
+		width = "50%",
+		height = 35,
+		caption = "",
+		items = teamNumbers,
+		parent = teamChangeWindow,
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
+		itemHeight = 30,
+		selected = tostring(opts.initialTeam),
+		selectByName = true,
+		OnSelectName = {
+			function (obj, teamNumber)
+				if teamNumber == nil then
+					return
+				end
+				opts.initialTeam = tonumber(teamNumber)
+			end
+		},
+	}
+
+	WG.Chobby.PriorityPopup(teamChangeWindow, CloseFunction, CloseFunction, screen0)
+end
+
+function widget:Initialize()
+	VFS.Include(LUA_DIRNAME .. "widgets/chobby/headers/exports.lua", nil, VFS.RAW_FIRST)
+
+	WG.TeamChangeWindow = {
+		CreateTeamChangeWindow = CreateTeamChangeWindow
+	}
+end

--- a/LuaMenu/widgets/gui_team_change_window.lua
+++ b/LuaMenu/widgets/gui_team_change_window.lua
@@ -43,7 +43,7 @@ local function CreateTeamChangeWindow(opts)
 	local lblTitle = TextBox:New {
 		x = 15,
 		y = 15,
-		width = teamChangeWindow.width - teamChangeWindow.padding[1] - teamChangeWindow.padding[3],
+    width = "80%",
 		height = 35,
 		align = "center",
 		multiline = true,

--- a/LuaMenu/widgets/gui_team_change_window.lua
+++ b/LuaMenu/widgets/gui_team_change_window.lua
@@ -1,6 +1,3 @@
---------------------------------------------------------------------------------
---------------------------------------------------------------------------------
-
 function widget:GetInfo()
 	return {
 		name      = "Team change window",
@@ -53,7 +50,6 @@ local function CreateTeamChangeWindow(opts)
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
 		text = opts.labelCaption,
 		parent = teamChangeWindow,
-		-- XXX handle longer strings gracefully
 	}
 
 	local btnOK = Button:New {
@@ -81,7 +77,7 @@ local function CreateTeamChangeWindow(opts)
 	}
 
 	local cmbTeams = ComboBox:New {
-		x = "5%",
+		x = "25%",
 		y = "40%",
 		width = "50%",
 		height = 35,


### PR DESCRIPTION
Replace the integer selection window for changing teams (a slider) with a combobox (a drop down box) for selecting teams. This should feel more intuitive and be easier to click through. This also matches the SPADS configuration interface where the number of teams and team size are organised with a combobox.

# Screenshots
## Before
![change_team_old](https://github.com/user-attachments/assets/bbc70aa6-ac5d-42f6-ad44-4315dfe4cc8f)

## After
![change_team_new](https://github.com/user-attachments/assets/48581861-5d09-4bb1-87c0-f39b04c28678)
