### PR TITLE
Make maxPlayers and playerCount more resistant to being nil

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -3215,8 +3215,8 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		-- Buttons Play and Spec
 
 		local battleID = battleLobby:GetMyBattleID()
-		local maxPlayers = battleLobby.battles[battleID].maxPlayers or 0
-		local playerCount = battleLobby:GetBattlePlayerCount(battleID)
+		local maxPlayers = (battleLobby and battleLobby.battles and battleLobby.battles[battleID].maxPlayers) or 0
+		local playerCount = (battleLobby and battleLobby:GetBattlePlayerCount(battleID)) or 0
 		local myBs = battleLobby:GetUserBattleStatus(battleLobby.myUserName) or {}
 		local iAmPlayer = myBs.isSpectator ~= nil and myBs.isSpectator == false
 		local iAmQueued = myBs.queuePos and myBs.queuePos > 0


### PR DESCRIPTION
To prevent this, for example:
```
[t=00:00:16.227727][f=-000001] [liblobby] Warning: Can't update user's battle status, user is not in our battle:  , TetrisCo
[t=00:00:16.364914][f=-000001] [liblobby] Error: [string "LuaMenu/Widgets/gui_battle_room_window.lua"]:3218: attempt to index field '?' (a nil value)
[t=00:00:16.365007][f=-000001] [liblobby] Error: [string "LuaMenu/Widgets/gui_battle_room_window.lua"]:3218: attempt to index field '?' (a nil value)
```