### PR TITLE
Fix `SecondsToTimeString` for single digit minutes while h>0

### DIFF
--- a/LuaMenu/widgets/gui_scenario_window.lua
+++ b/LuaMenu/widgets/gui_scenario_window.lua
@@ -54,16 +54,25 @@ local unitdefname_to_humanname = {} -- from en.lua, attached at the end of the f
 --------------------------------------------------------------------------------
 -- Utilities
 
+--- Format a number of seconds as a time string.
+-- The formatting differs depending on whether the duration is at least one hour.
+-- If there is a full hour: `h:mm:ss` and otherwise: `m:ss`
+-- Example outputs:
+-- - 10: `0:10`
+-- - 60: `1:00`
+-- - 3599: `59:59`
+-- - 7280: `2:01:20`
 local function SecondsToTimeString(s)
 	local hours = math.floor(s/3600)
 	s = math.fmod(s, 3600 )
 	local minutes = math.floor(s/60)
 	s = math.fmod(s,60)
-	result = ""
+
 	if hours>0 then
-		result = string.format("%d:",hours)
+		return string.format("%d:%02d:%02d",hours,minutes,s)
+	else
+		return string.format("%d:%02d",minutes,s)
 	end
-	return result .. string.format("%d:%02d",minutes,s)
 end
 
 local function MaybeDownloadMap(mapName)


### PR DESCRIPTION
I saw `SecondsToTimeString` outputting `1:4:00` as my personal best on a scenario, but I think that `1:04:00` would be more readable.

Changes:
- Change `SecondsToTimeString` to output `h:mm:ss` instead of `h:m:ss`
- Add doc string to `SecondsToTimeString`

I ran a few instances through a Lua interpreter to verify the output but did not build the whole lobby client.