### PR TITLE
Singleplayer bset: fix ghost(?) character

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -3171,7 +3171,7 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 				local modoptions = battleLobby:GetMyBattleModoptions()
 				for line in message:gmatch("[^\n]+") do
 					if line:starts("!bset ") then
-						local key, value = line:match("^!bset%s+([%a_][%w_]*)%s+(.+)%s*$")
+						local key, value = line:match("^!bset%s+([%a_][%w_]*)%s+(.*%S)%s*$")
 						if key and value then
 							modoptions[key] = value
 							cmdCounter = cmdCounter + 1


### PR DESCRIPTION
# Test Steps
Open singleplayer skirmish, and paste in the following into the chat:
```
!bset tweakdefs VW5pdERlZnMuY29yY29tID0gdGFibGUuY29weShVbml0RGVmcy5jb3JtbHMpClVuaXREZWZzLmxlZ2NvbSA9IHRhYmxlLmNvcHkoVW5pdERlZnMuY29yYWNhKQ
!bset experimentallegionfaction 1
```
before: the tweakdef would show up as 123 characters wrong, 1 extra that is invisible, would crash the game due to invalid start script.
now: the tweak shows up as 122 characters, the real character count of what the user thinks they entered