### PR TITLE
Legion survey and new items pulse

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/welcomePanelItems.lua
+++ b/LuaMenu/configs/gameConfig/byar/welcomePanelItems.lua
@@ -13,6 +13,7 @@ local welcomePanelItems = {
     {
         Header = "Welcome to Beyond All Reason",
         Text = "Welcome back Commander. We hope you are ready for epic Singleplayer and Multiplayer battles. Check out our Discord and join the community!\n",
+        NoPulse = true,
     },
 
     {

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -85,6 +85,7 @@ function Configuration:init()
 	self.steamLinkComplete = false
 	self.alreadySeenFactionPopup4 = false
 	self.firstBattleStarted = false
+	self.seenWelcomeItems = {}
 	self.lobbyTimeoutTime = 60 -- Seconds
 
 	self.battleFilterPassworded2 = true
@@ -668,6 +669,7 @@ function Configuration:GetConfigData()
 		steamLinkComplete = self.steamLinkComplete,
 		alreadySeenFactionPopup4 = self.alreadySeenFactionPopup4,
 		firstBattleStarted = self.firstBattleStarted,
+		seenWelcomeItems = self.seenWelcomeItems,
 		battleFilterPassworded2 = self.battleFilterPassworded2,
 		battleFilterNonFriend = self.battleFilterNonFriend,
 		battleFilterRunning = self.battleFilterRunning,

--- a/LuaMenu/widgets/gui_community_window.lua
+++ b/LuaMenu/widgets/gui_community_window.lua
@@ -276,11 +276,9 @@ local function GetDateTimeDisplay(parentControl, xPosition, yPosition, timeStrin
 
 	return externalFunctions
 end
-
-
-local pulseStartTime = os.clock()
-local function UpdatePulse(controls, entryData)
-	if not controls.heading or not controls.heading.visible then
+				
+local function UpdatePulse(controls, entryData, pulseStartTime)
+	if not controls or not controls.visible then
 		return
 	end
 	
@@ -307,8 +305,8 @@ local function UpdatePulse(controls, entryData)
 		text = "\255\255\255\255" .. entryData.heading
 	end
 	
-	controls.heading:SetText(text)
-	WG.Delay(UpdatePulse, 0.05) -- 20 FPS updates
+	controls:SetText(text)
+	WG.Delay(function() UpdatePulse(controls, entryData, pulseStartTime) end, 0.05)
 end
 
 local headingFormats = {
@@ -419,7 +417,7 @@ local function GetNewsEntry(parentHolder, index, headingSize, timeAsTooltip, top
 			}
 
 			if isNewItem and not entryData.noPulse then
-				UpdatePulse(controls.heading, entryData)
+				UpdatePulse(controls.heading, entryData, os.clock())
 			end
 		else
 			controls.heading:SetText(entryData.heading)


### PR DESCRIPTION
makes it so that new items that haven't appeared before in your chobby have a subtle pulsing effect to grab your attention. After displaying once in this fashion, it's just plain white thereafter forevermore. Also allows for intentional exemptions to this pulse effect with the new `NoPulse` param