### PR TITLE
Computed lobby sizes

### DIFF
--- a/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
@@ -691,9 +691,12 @@ function BattleListWindow:MakeJoinBattle(battleID, battle)
 		align = "right",
 		valign = 'center',
 		objectOverrideFont = myFont2,
-		caption = lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers,
+		caption = lobby:GetPlayerOccupancy(battleID),
 		parent = parentButton,
 	}
+
+	parentButton.previousMaxPlayers = lobby:GetBattleMaxPlayers(battleID)
+	parentButton.previousPlayerCount = lobby:GetBattlePlayerCount(battleID)
 
 	return parentButton
 end
@@ -1084,7 +1087,7 @@ function BattleListWindow:JoinedBattle(battleID)
 	if playersCaption then
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
 		if battleButton.previousPlayerCount ~= newPlayerCount then 
-			playersCaption:SetCaption(newPlayerCount .. "/" .. battle.maxPlayers)
+			playersCaption:SetCaption(lobby:GetPlayerOccupancy(battleID))
 			battleButton.previousPlayerCount = newPlayerCount
 		end
 	else
@@ -1115,7 +1118,7 @@ function BattleListWindow:LeftBattle(battleID)
 	if playersCaption then
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
 		if battleButton.previousPlayerCount ~= newPlayerCount then 
-			playersCaption:SetCaption(newPlayerCount .. "/" .. battle.maxPlayers)
+			playersCaption:SetCaption(lobby:GetPlayerOccupancy(battleID))
 			battleButton.previousPlayerCount = newPlayerCount
 		end
 	else
@@ -1193,10 +1196,12 @@ function BattleListWindow:OnUpdateBattleInfo(battleID)
 		-- local gameCaption = items.battleButton:GetChildByName("gameCaption")
 		-- gameCaption:SetCaption(self:_MakeGameCaption(battle))
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
-		if battleButton.previousPlayerCount ~= newPlayerCount then 
+		local newMaxPlayers = lobby:GetBattleMaxPlayers(battleID)
+		if battleButton.previousPlayerCount ~= newPlayerCount or battleButton.previousMaxPlayers ~= newMaxPlayers then 
 			local playersCaption = battleButton:GetChildByName("playersCaption")
-			playersCaption:SetCaption(newPlayerCount .. "/" .. battle.maxPlayers)
+			playersCaption:SetCaption(lobby:GetPlayerOccupancy(battleID))
 			battleButton.previousPlayerCount = newPlayerCount
+			battleButton.previousMaxPlayers = newMaxPlayers
 		end
 
 	else

--- a/LuaMenu/widgets/gui_battle_status_panel.lua
+++ b/LuaMenu/widgets/gui_battle_status_panel.lua
@@ -88,7 +88,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		height = 20,
 		valign = 'top',
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-		caption = playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers,
+		caption = playersPrefix .. lobby:GetPlayerOccupancy(battleID),
 		parent = mainControl,
 	}
 
@@ -166,7 +166,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		local text = StringUtilities.GetTruncatedStringWithDotDot(battle.title, lblTitle.font, smallMode and 150 or 180)
 		lblTitle:SetCaption(text)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers)
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 
 	function externalFunctions.Update(newBattleID)
@@ -197,7 +197,7 @@ local function GetBattleInfoHolder(parent, battleID)
 
 		externalFunctions.Resize(currentSmallMode)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers)
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 	lobby:AddListener("OnUpdateBattleInfo", OnUpdateBattleInfo)
 
@@ -223,13 +223,13 @@ local function GetBattleInfoHolder(parent, battleID)
 		if updatedBattleID ~= battleID then
 			return
 		end
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers)
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 	lobby:AddListener("OnLeftBattle", PlayersUpdate)
 	lobby:AddListener("OnJoinedBattle", PlayersUpdate)
 
 	local function OnUpdateUserTeamStatus(listeners)
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers)
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 	lobby:AddListener("OnUpdateUserTeamStatus", OnUpdateUserTeamStatus)
 

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -341,7 +341,7 @@ local function GetBattleTooltip(battleID, battle, showMapName)
 		if not battleTooltip.playerCount then
 			battleTooltip.playerCount = GetTooltipLine(battleTooltip.mainControl)
 		end
-		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers)
+		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetPlayerOccupancy(battleID))
 
 		if not battleTooltip.spectatorCount then
 			battleTooltip.spectatorCount = GetTooltipLine(battleTooltip.mainControl, nil, nil, 130)

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -2352,6 +2352,29 @@ end
 Interface.commands["s.battle.extra_data"] = Interface._OnBattleExtraData
 Interface.commandPattern["s.battle.extra_data"] = "(%S+)%s+(.*)"
 
+-- Handle s.battle.teams messages
+function Interface:_OnBattleTeams(data)
+	Spring.Log(LOG_SECTION, LOG.NOTICE, "Received s.battle.teams message with data: " .. tostring(data))
+	local teamsData = Spring.Utilities.json.decode(Spring.Utilities.Base64Decode(data))
+	if not teamsData then
+		Spring.Log(LOG_SECTION, LOG.ERROR, "Failed to parse s.battle.teams data: " .. tostring(data))
+		return
+	end
+	
+	-- Update each battle with its team data
+	for battleID, teamInfo in pairs(teamsData) do
+		battleID = tonumber(battleID)
+		if battleID then
+			self:super("_OnUpdateBattleInfo", battleID, {
+				teamSize = teamInfo.teamSize,
+				nbTeams = teamInfo.nbTeams
+			})
+		end
+	end
+end
+Interface.commands["s.battle.teams"] = Interface._OnBattleTeams
+Interface.commandPattern["s.battle.teams"] = "(.+)"
+
 function Interface:_OnS_Client_Errorlog()
 	self:_CallListeners("OnS_Client_Errorlog")
 end

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -2285,6 +2285,20 @@ function Lobby:GetBattlePlayerCount(battleID)
 	end
 end
 
+function Lobby:GetBattleMaxPlayers(battleID)
+	local battle = self:GetBattle(battleID)
+	if not battle then
+		return 0
+	end
+
+	-- fall back to maxPlayers, if nbTeams or teamSize is unknown
+	return (battle.teamSize and battle.nbTeams) and (battle.teamSize * battle.nbTeams) or battle.maxPlayers
+end
+
+function Lobby:GetPlayerOccupancy(battleID)
+	return self:GetBattlePlayerCount(battleID) .. "/" .. self:GetBattleMaxPlayers(battleID)
+end
+
 function Lobby:GetBattleFoundedBy(userName)
 	-- TODO, improve data structures to make this search nice
 	for battleID, battleData in pairs(self.battles) do


### PR DESCRIPTION
Hi all, first contribution.  Hoping I'm doing it right.

This change alters the lobby size text to show a computed value of how many players the lobby can support based on battle.teamSize * battle.nbTeams.

The value is clamped to maxPlayers to avoid having a player set a lobby larger than 16 (8 teams of 4 or something), but still allows for developers to set a much larger lobby than the regular 16 and have it still display correctly.

Example:
<img width="1204" height="43" alt="image" src="https://github.com/user-attachments/assets/0a91e5bf-760d-44d1-b6c9-773a49287ab9" />
