### PR TITLE
Added checking for humanname if null, and loggging incorrect unitid

### DIFF
--- a/LuaMenu/widgets/gui_scenario_window.lua
+++ b/LuaMenu/widgets/gui_scenario_window.lua
@@ -249,12 +249,20 @@ local function CreateScenarioPanel(shortname, sPanel)
 	local numdisabledunits = 0
 	if scen.unitlimits then
 		for unitid, count in pairs(scen.unitlimits) do
-			additionalText = additionalText .. "\n  - " .. unitdefname_to_humanname[unitid] .. " (" ..unitid .. "): "
+			local humanName = unitdefname_to_humanname[unitid]
+			if not humanName then
+				Spring.Echo("Error: No human name for: " .. unitid)
+				humanName = "human name missing"
+			end
+	
+			additionalText = additionalText .. "\n  - " .. humanName .. " (" .. unitid .. "): "
+	
 			if count == 0 then
 				additionalText = additionalText .. "Disabled"
 			else
 				additionalText = additionalText .. tostring(count)
 			end
+	
 			numdisabledunits = numdisabledunits + 1
 		end
 	end


### PR DESCRIPTION
In laoding scenario in unit limits may be unitid that dont exist, and it crashes out. This checks if it is null, and if yes it wont crash but write hat name is null, and will echo wich unit type caused this.