### PR TITLE
Add rejoin battle button

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -415,7 +415,10 @@ function Configuration:init()
 	-- remember if new default of showSkill was applied
 	self.tempChangedShowSkill = false
 	self.supperAnnouncementKey = "nil"
+
+	self.rejoinID = "nil"
 end
+
 
 ---------------------------------------------------------------------------------
 -- Settings
@@ -756,7 +759,8 @@ function Configuration:GetConfigData()
 		useLastGameSpectatorState = self.useLastGameSpectatorState,
 		friendsFilterOnline = self.friendsFilterOnline,
 		queueExitConfirmPromptDoNotAskAgain = self.queueExitConfirmPromptDoNotAskAgain,
-		supperAnnouncementKey = self.supperAnnouncementKey
+		supperAnnouncementKey = self.supperAnnouncementKey,
+		rejoinID = self.rejoinID
 	}
 end
 

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -760,7 +760,7 @@ function Configuration:GetConfigData()
 		friendsFilterOnline = self.friendsFilterOnline,
 		queueExitConfirmPromptDoNotAskAgain = self.queueExitConfirmPromptDoNotAskAgain,
 		supperAnnouncementKey = self.supperAnnouncementKey,
-		rejoinID = self.rejoinID
+		rejoinBattleID = self.rejoinBattleID
 	}
 end
 

--- a/LuaMenu/widgets/chobby/components/interface_root.lua
+++ b/LuaMenu/widgets/chobby/components/interface_root.lua
@@ -385,6 +385,7 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 	-- Exit button
 	local function ExitSpring()
 		Spring.Echo("Quitting...")
+		WG.Chobby.Configuration:SetConfigValue("rejoinBattleID", nil)
 		Spring.Quit()
 	end
 

--- a/LuaMenu/widgets/gui_battle_rejoin.lua
+++ b/LuaMenu/widgets/gui_battle_rejoin.lua
@@ -14,38 +14,48 @@ end
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+local lobby, battleList
+
+local function LoginRejoinOption(listener, battleID)
+	-- Check if a battle ID has been stored for rejoining.
+	if not WG.Chobby.Configuration.rejoinBattleID then
+		return
+	end
+	-- Spring.Echo("Saved BattleID: "..WG.Chobby.Configuration.rejoinID)
+
+	local battle = lobby:GetBattle(WG.Chobby.Configuration.rejoinBattleID) -- Battle Object
+	if battle == nil then
+		return
+	end
+	
+	local function doJoinBattle()
+		battleList:JoinBattle(battle)
+	end
+	
+	WG.Chobby.ConfirmationPopup(doJoinBattle, i18n("rejoinBattlePopup"), nil, 315, 200, i18n("rejoin"), i18n("abandon"))
+end
+
+local function OnJoinedBattle(listener, battleID, userName)
+	if userName ~= lobby:GetMyUserName() then
+		return
+	end
+
+	-- Spring.Echo('Saving Lobby ID: '..battleID)
+	WG.Chobby.Configuration:SetConfigValue("rejoinBattleID", battleID)
+end
+
+local function OnLeftBattle(listener, battleID, userName)
+	if userName ~= lobby:GetMyUserName() then
+		return
+	end
+
+	-- Spring.Echo('Removing Lobby ID: ' .. battleID)
+	WG.Chobby.Configuration:SetConfigValue("rejoinBattleID", nil)
+end
+
 local function DelayedInitialize()
-	local lobby = WG.LibLobby.lobby
-	local battleList = WG.Chobby.BattleListWindow()
-
-	--Spring.Echo("Saved BattleID: "..WG.Chobby.Configuration.rejoinID)
-
-	local function LoginRejoinOption(listener, battleID)
-		-- if no ID is present then there is no server to rejoin
-		if not WG.Chobby.Configuration.rejoinID or WG.Chobby.Configuration.rejoinID == 'nil' then
-			return
-		end
-
-		local battle = lobby:GetBattle(WG.Chobby.Configuration.rejoinID) -- Battle Object
-		if battle == nil or battle == 'nil' then return end
-		WG.Chobby.ConfirmationPopup(function() battleList:JoinBattle(battle) end,
-			"You were connected to a previous lobby last time you were online. Would you like to rejoin it?", nil, 315,
-			200, "rejoin", "abandon")
-	end
-
-	local function OnJoinedBattle(listener, battleID, userName)
-		if userName ~= lobby:GetMyUserName() then return end
-
-		--Spring.Echo('Saving Lobby ID: '..battleID)
-		WG.Chobby.Configuration:SetConfigValue("rejoinID", battleID)
-	end
-
-	local function OnLeftBattle(listener, battleID, userName)
-		if userName ~= lobby:GetMyUserName() then return end
-
-		--Spring.Echo('Removing Lobby ID: '..battleID)
-		WG.Chobby.Configuration:SetConfigValue("rejoinID", nil)
-	end
+	lobby = WG.LibLobby.lobby
+	battleList = WG.Chobby.BattleListWindow()
 
 	lobby:AddListener("OnLoginInfoEnd", LoginRejoinOption)
 	lobby:AddListener("OnJoinedBattle", OnJoinedBattle)

--- a/LuaMenu/widgets/gui_battle_rejoin.lua
+++ b/LuaMenu/widgets/gui_battle_rejoin.lua
@@ -1,0 +1,62 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+function widget:GetInfo()
+	return {
+		name    = "Battle Rejoin",
+		desc    = "Prompts the user to rejoin a previous battle on login.",
+		author  = "Rogshotz",
+		date    = "13 July 2025",
+		license = "GNU LGPL, v2.1 or later",
+		layer   = 0,
+		enabled = true
+	}
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+local function DelayedInitialize()
+	local lobby = WG.LibLobby.lobby
+	local battleList = WG.Chobby.BattleListWindow()
+
+	--Spring.Echo("Saved BattleID: "..WG.Chobby.Configuration.rejoinID)
+
+	local function LoginRejoinOption(listener, battleID)
+		-- if no ID is present then there is no server to rejoin
+		if not WG.Chobby.Configuration.rejoinID or WG.Chobby.Configuration.rejoinID == 'nil' then
+			return
+		end
+
+		local battle = lobby:GetBattle(WG.Chobby.Configuration.rejoinID) -- Battle Object
+		if battle == nil or battle == 'nil' then return end
+		WG.Chobby.ConfirmationPopup(function() battleList:JoinBattle(battle) end,
+			"You were connected to a previous lobby last time you were online. Would you like to rejoin it?", nil, 315,
+			200, "rejoin", "abandon")
+	end
+
+	local function OnJoinedBattle(listener, battleID, userName)
+		if userName ~= lobby:GetMyUserName() then return end
+
+		--Spring.Echo('Saving Lobby ID: '..battleID)
+		WG.Chobby.Configuration:SetConfigValue("rejoinID", battleID)
+	end
+
+	local function OnLeftBattle(listener, battleID, userName)
+		if userName ~= lobby:GetMyUserName() then return end
+
+		--Spring.Echo('Removing Lobby ID: '..battleID)
+		WG.Chobby.Configuration:SetConfigValue("rejoinID", nil)
+	end
+
+	lobby:AddListener("OnLoginInfoEnd", LoginRejoinOption)
+	lobby:AddListener("OnJoinedBattle", OnJoinedBattle)
+	lobby:AddListener("OnLeftBattle", OnLeftBattle)
+end
+
+function widget:Initialize()
+	CHOBBY_DIR = LUA_DIRNAME .. "widgets/chobby/"
+	VFS.Include(LUA_DIRNAME .. "widgets/chobby/headers/exports.lua", nil, VFS.RAW_FIRST)
+	WG.Delay(DelayedInitialize, 1)
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------


### PR DESCRIPTION
Add a button that allows users to rejoin a battle if they did not properly leave a battle, i.e. press leave battle, or leave lobby.

This allows users to reconnect to lobbies that are open after a break or to allow users to rejoin a server in the event of a crash. No longer do people have to keep a mental note of what game they were in.

To note, a known bug exists wherein if a BattleLobby opens up with the same the same ID as the last BattleLobby when it was closed, the user will connect to that 'random' lobby. This bug ultimately is very small though.