### PR TITLE
Fb computed lobby sizes

### DIFF
--- a/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
@@ -691,7 +691,7 @@ function BattleListWindow:MakeJoinBattle(battleID, battle)
 		align = "right",
 		valign = 'center',
 		objectOverrideFont = myFont2,
-		caption = lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams),
+		caption = lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)),
 		parent = parentButton,
 	}
 
@@ -1083,9 +1083,11 @@ function BattleListWindow:JoinedBattle(battleID)
 	local playersCaption = battleButton:GetChildByName("playersCaption")
 	if playersCaption then
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
-		if battleButton.previousPlayerCount ~= newPlayerCount then 
-			playersCaption:SetCaption(newPlayerCount .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
+		local newMaxPlayers = math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
+		if battleButton.previousPlayerCount ~= newPlayerCount or battleButton.previousMaxPlayers ~= newMaxPlayers then 
+			playersCaption:SetCaption(newPlayerCount .. "/" .. newMaxPlayers)
 			battleButton.previousPlayerCount = newPlayerCount
+			battleButton.previousMaxPlayers = newMaxPlayers
 		end
 	else
 		local playersOnMapCaption = battleButton:GetChildByName("playersOnMapCaption")
@@ -1114,9 +1116,11 @@ function BattleListWindow:LeftBattle(battleID)
 	local playersCaption = battleButton:GetChildByName("playersCaption")
 	if playersCaption then
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
-		if battleButton.previousPlayerCount ~= newPlayerCount then 
-			playersCaption:SetCaption(newPlayerCount .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
+		local newMaxPlayers = math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
+		if battleButton.previousPlayerCount ~= newPlayerCount or battleButton.previousMaxPlayers ~= newMaxPlayers then 
+			playersCaption:SetCaption(newPlayerCount .. "/" .. newMaxPlayers)
 			battleButton.previousPlayerCount = newPlayerCount
+			battleButton.previousMaxPlayers = newMaxPlayers
 		end
 	else
 		local playersOnMapCaption = battleButton:GetChildByName("playersOnMapCaption")
@@ -1193,10 +1197,12 @@ function BattleListWindow:OnUpdateBattleInfo(battleID)
 		-- local gameCaption = items.battleButton:GetChildByName("gameCaption")
 		-- gameCaption:SetCaption(self:_MakeGameCaption(battle))
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
-		if battleButton.previousPlayerCount ~= newPlayerCount then 
+		local newMaxPlayers = math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
+		if battleButton.previousPlayerCount ~= newPlayerCount or battleButton.previousMaxPlayers ~= newMaxPlayers then 
 			local playersCaption = battleButton:GetChildByName("playersCaption")
-			playersCaption:SetCaption(newPlayerCount .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
+			playersCaption:SetCaption(newPlayerCount .. "/" .. newMaxPlayers)
 			battleButton.previousPlayerCount = newPlayerCount
+			battleButton.previousMaxPlayers = newMaxPlayers
 		end
 
 	else

--- a/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
@@ -691,7 +691,7 @@ function BattleListWindow:MakeJoinBattle(battleID, battle)
 		align = "right",
 		valign = 'center',
 		objectOverrideFont = myFont2,
-		caption = lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers,
+		caption = lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams),
 		parent = parentButton,
 	}
 
@@ -1084,7 +1084,7 @@ function BattleListWindow:JoinedBattle(battleID)
 	if playersCaption then
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
 		if battleButton.previousPlayerCount ~= newPlayerCount then 
-			playersCaption:SetCaption(newPlayerCount .. "/" .. battle.maxPlayers)
+			playersCaption:SetCaption(newPlayerCount .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
 			battleButton.previousPlayerCount = newPlayerCount
 		end
 	else
@@ -1115,7 +1115,7 @@ function BattleListWindow:LeftBattle(battleID)
 	if playersCaption then
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
 		if battleButton.previousPlayerCount ~= newPlayerCount then 
-			playersCaption:SetCaption(newPlayerCount .. "/" .. battle.maxPlayers)
+			playersCaption:SetCaption(newPlayerCount .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
 			battleButton.previousPlayerCount = newPlayerCount
 		end
 	else
@@ -1195,7 +1195,7 @@ function BattleListWindow:OnUpdateBattleInfo(battleID)
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
 		if battleButton.previousPlayerCount ~= newPlayerCount then 
 			local playersCaption = battleButton:GetChildByName("playersCaption")
-			playersCaption:SetCaption(newPlayerCount .. "/" .. battle.maxPlayers)
+			playersCaption:SetCaption(newPlayerCount .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
 			battleButton.previousPlayerCount = newPlayerCount
 		end
 

--- a/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
@@ -691,9 +691,12 @@ function BattleListWindow:MakeJoinBattle(battleID, battle)
 		align = "right",
 		valign = 'center',
 		objectOverrideFont = myFont2,
-		caption = lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)),
+		caption = lobby:GetPlayerOccupancy(battleID),
 		parent = parentButton,
 	}
+
+	parentButton.previousMaxPlayers = lobby:GetBattleMaxPlayers(battleID)
+	parentButton.previousPlayerCount = lobby:GetBattlePlayerCount(battleID)
 
 	return parentButton
 end
@@ -1083,11 +1086,9 @@ function BattleListWindow:JoinedBattle(battleID)
 	local playersCaption = battleButton:GetChildByName("playersCaption")
 	if playersCaption then
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
-		local newMaxPlayers = math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
-		if battleButton.previousPlayerCount ~= newPlayerCount or battleButton.previousMaxPlayers ~= newMaxPlayers then 
-			playersCaption:SetCaption(newPlayerCount .. "/" .. newMaxPlayers)
+		if battleButton.previousPlayerCount ~= newPlayerCount then 
+			playersCaption:SetCaption(lobby:GetPlayerOccupancy(battleID))
 			battleButton.previousPlayerCount = newPlayerCount
-			battleButton.previousMaxPlayers = newMaxPlayers
 		end
 	else
 		local playersOnMapCaption = battleButton:GetChildByName("playersOnMapCaption")
@@ -1116,11 +1117,9 @@ function BattleListWindow:LeftBattle(battleID)
 	local playersCaption = battleButton:GetChildByName("playersCaption")
 	if playersCaption then
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
-		local newMaxPlayers = math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
-		if battleButton.previousPlayerCount ~= newPlayerCount or battleButton.previousMaxPlayers ~= newMaxPlayers then 
-			playersCaption:SetCaption(newPlayerCount .. "/" .. newMaxPlayers)
+		if battleButton.previousPlayerCount ~= newPlayerCount then 
+			playersCaption:SetCaption(lobby:GetPlayerOccupancy(battleID))
 			battleButton.previousPlayerCount = newPlayerCount
-			battleButton.previousMaxPlayers = newMaxPlayers
 		end
 	else
 		local playersOnMapCaption = battleButton:GetChildByName("playersOnMapCaption")
@@ -1197,10 +1196,10 @@ function BattleListWindow:OnUpdateBattleInfo(battleID)
 		-- local gameCaption = items.battleButton:GetChildByName("gameCaption")
 		-- gameCaption:SetCaption(self:_MakeGameCaption(battle))
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
-		local newMaxPlayers = math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
+		local newMaxPlayers = lobby:GetBattleMaxPlayers(battleID)
 		if battleButton.previousPlayerCount ~= newPlayerCount or battleButton.previousMaxPlayers ~= newMaxPlayers then 
 			local playersCaption = battleButton:GetChildByName("playersCaption")
-			playersCaption:SetCaption(newPlayerCount .. "/" .. newMaxPlayers)
+			playersCaption:SetCaption(lobby:GetPlayerOccupancy(battleID))
 			battleButton.previousPlayerCount = newPlayerCount
 			battleButton.previousMaxPlayers = newMaxPlayers
 		end

--- a/LuaMenu/widgets/gui_battle_status_panel.lua
+++ b/LuaMenu/widgets/gui_battle_status_panel.lua
@@ -88,7 +88,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		height = 20,
 		valign = 'top',
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-		caption = playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers,
+		caption = playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams),
 		parent = mainControl,
 	}
 
@@ -166,7 +166,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		local text = StringUtilities.GetTruncatedStringWithDotDot(battle.title, lblTitle.font, smallMode and 150 or 180)
 		lblTitle:SetCaption(text)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers)
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
 	end
 
 	function externalFunctions.Update(newBattleID)
@@ -197,7 +197,7 @@ local function GetBattleInfoHolder(parent, battleID)
 
 		externalFunctions.Resize(currentSmallMode)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers)
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
 	end
 	lobby:AddListener("OnUpdateBattleInfo", OnUpdateBattleInfo)
 
@@ -223,13 +223,13 @@ local function GetBattleInfoHolder(parent, battleID)
 		if updatedBattleID ~= battleID then
 			return
 		end
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers)
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
 	end
 	lobby:AddListener("OnLeftBattle", PlayersUpdate)
 	lobby:AddListener("OnJoinedBattle", PlayersUpdate)
 
 	local function OnUpdateUserTeamStatus(listeners)
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers)
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
 	end
 	lobby:AddListener("OnUpdateUserTeamStatus", OnUpdateUserTeamStatus)
 

--- a/LuaMenu/widgets/gui_battle_status_panel.lua
+++ b/LuaMenu/widgets/gui_battle_status_panel.lua
@@ -88,7 +88,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		height = 20,
 		valign = 'top',
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-		caption = playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2),
+		caption = playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)),
 		parent = mainControl,
 	}
 
@@ -166,7 +166,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		local text = StringUtilities.GetTruncatedStringWithDotDot(battle.title, lblTitle.font, smallMode and 150 or 180)
 		lblTitle:SetCaption(text)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
 	end
 
 	function externalFunctions.Update(newBattleID)
@@ -197,7 +197,7 @@ local function GetBattleInfoHolder(parent, battleID)
 
 		externalFunctions.Resize(currentSmallMode)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
 	end
 	lobby:AddListener("OnUpdateBattleInfo", OnUpdateBattleInfo)
 
@@ -223,13 +223,13 @@ local function GetBattleInfoHolder(parent, battleID)
 		if updatedBattleID ~= battleID then
 			return
 		end
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
 	end
 	lobby:AddListener("OnLeftBattle", PlayersUpdate)
 	lobby:AddListener("OnJoinedBattle", PlayersUpdate)
 
 	local function OnUpdateUserTeamStatus(listeners)
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
 	end
 	lobby:AddListener("OnUpdateUserTeamStatus", OnUpdateUserTeamStatus)
 

--- a/LuaMenu/widgets/gui_battle_status_panel.lua
+++ b/LuaMenu/widgets/gui_battle_status_panel.lua
@@ -88,7 +88,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		height = 20,
 		valign = 'top',
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-		caption = playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams),
+		caption = playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2),
 		parent = mainControl,
 	}
 
@@ -166,7 +166,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		local text = StringUtilities.GetTruncatedStringWithDotDot(battle.title, lblTitle.font, smallMode and 150 or 180)
 		lblTitle:SetCaption(text)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
 	end
 
 	function externalFunctions.Update(newBattleID)
@@ -197,7 +197,7 @@ local function GetBattleInfoHolder(parent, battleID)
 
 		externalFunctions.Resize(currentSmallMode)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
 	end
 	lobby:AddListener("OnUpdateBattleInfo", OnUpdateBattleInfo)
 
@@ -223,13 +223,13 @@ local function GetBattleInfoHolder(parent, battleID)
 		if updatedBattleID ~= battleID then
 			return
 		end
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
 	end
 	lobby:AddListener("OnLeftBattle", PlayersUpdate)
 	lobby:AddListener("OnJoinedBattle", PlayersUpdate)
 
 	local function OnUpdateUserTeamStatus(listeners)
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
 	end
 	lobby:AddListener("OnUpdateUserTeamStatus", OnUpdateUserTeamStatus)
 

--- a/LuaMenu/widgets/gui_battle_status_panel.lua
+++ b/LuaMenu/widgets/gui_battle_status_panel.lua
@@ -88,7 +88,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		height = 20,
 		valign = 'top',
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-		caption = playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)),
+		caption = playersPrefix .. lobby:GetPlayerOccupancy(battleID),
 		parent = mainControl,
 	}
 
@@ -166,7 +166,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		local text = StringUtilities.GetTruncatedStringWithDotDot(battle.title, lblTitle.font, smallMode and 150 or 180)
 		lblTitle:SetCaption(text)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 
 	function externalFunctions.Update(newBattleID)
@@ -197,7 +197,7 @@ local function GetBattleInfoHolder(parent, battleID)
 
 		externalFunctions.Resize(currentSmallMode)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 	lobby:AddListener("OnUpdateBattleInfo", OnUpdateBattleInfo)
 
@@ -223,13 +223,13 @@ local function GetBattleInfoHolder(parent, battleID)
 		if updatedBattleID ~= battleID then
 			return
 		end
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 	lobby:AddListener("OnLeftBattle", PlayersUpdate)
 	lobby:AddListener("OnJoinedBattle", PlayersUpdate)
 
 	local function OnUpdateUserTeamStatus(listeners)
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 	lobby:AddListener("OnUpdateUserTeamStatus", OnUpdateUserTeamStatus)
 

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -341,7 +341,7 @@ local function GetBattleTooltip(battleID, battle, showMapName)
 		if not battleTooltip.playerCount then
 			battleTooltip.playerCount = GetTooltipLine(battleTooltip.mainControl)
 		end
-		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
+		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
 
 		if not battleTooltip.spectatorCount then
 			battleTooltip.spectatorCount = GetTooltipLine(battleTooltip.mainControl, nil, nil, 130)

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -341,7 +341,7 @@ local function GetBattleTooltip(battleID, battle, showMapName)
 		if not battleTooltip.playerCount then
 			battleTooltip.playerCount = GetTooltipLine(battleTooltip.mainControl)
 		end
-		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
+		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetPlayerOccupancy(battleID))
 
 		if not battleTooltip.spectatorCount then
 			battleTooltip.spectatorCount = GetTooltipLine(battleTooltip.mainControl, nil, nil, 130)

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -341,7 +341,7 @@ local function GetBattleTooltip(battleID, battle, showMapName)
 		if not battleTooltip.playerCount then
 			battleTooltip.playerCount = GetTooltipLine(battleTooltip.mainControl)
 		end
-		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetBattlePlayerCount(battleID) .. "/" .. battle.maxPlayers)
+		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, battle.teamSize * battle.nbTeams))
 
 		if not battleTooltip.spectatorCount then
 			battleTooltip.spectatorCount = GetTooltipLine(battleTooltip.mainControl, nil, nil, 130)

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -341,7 +341,7 @@ local function GetBattleTooltip(battleID, battle, showMapName)
 		if not battleTooltip.playerCount then
 			battleTooltip.playerCount = GetTooltipLine(battleTooltip.mainControl)
 		end
-		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
+		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
 
 		if not battleTooltip.spectatorCount then
 			battleTooltip.spectatorCount = GetTooltipLine(battleTooltip.mainControl, nil, nil, 130)

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -2352,6 +2352,52 @@ end
 Interface.commands["s.battle.extra_data"] = Interface._OnBattleExtraData
 Interface.commandPattern["s.battle.extra_data"] = "(%S+)%s+(.*)"
 
+-- Handle s.battle.teams batch message (sent on login)
+function Interface:_OnBattleTeams(data)
+	Spring.Log(LOG_SECTION, LOG.NOTICE, "Received s.battle.teams message with data: " .. tostring(data))
+	local teamsData = Spring.Utilities.json.decode(Spring.Utilities.Base64Decode(data))
+	if not teamsData then
+		Spring.Log(LOG_SECTION, LOG.ERROR, "Failed to parse s.battle.teams data: " .. tostring(data))
+		return
+	end
+	
+	Spring.Log(LOG_SECTION, LOG.NOTICE, "Parsed teams data: " .. Spring.Utilities.json.encode(teamsData))
+	
+	-- Update each battle with its team data
+	for battleID, teamInfo in pairs(teamsData) do
+		battleID = tonumber(battleID)
+		if battleID then
+			Spring.Log(LOG_SECTION, LOG.NOTICE, "Updating battle " .. battleID .. " with teamSize=" .. tostring(teamInfo.teamSize) .. ", nbTeams=" .. tostring(teamInfo.nbTeams))
+			self:super("_OnUpdateBattleInfo", battleID, {
+				teamSize = teamInfo.teamSize,
+				nbTeams = teamInfo.nbTeams
+			})
+		end
+	end
+end
+Interface.commands["s.battle.teams"] = Interface._OnBattleTeams
+Interface.commandPattern["s.battle.teams"] = "(.+)"
+
+-- Handle s.battle.teams_update individual update message
+function Interface:_OnBattleTeamsUpdate(battleID, data)
+	Spring.Log(LOG_SECTION, LOG.NOTICE, "Received s.battle.teams_update message for battle " .. battleID .. " with data: " .. tostring(data))
+	battleID = tonumber(battleID)
+	local teamData = Spring.Utilities.json.decode(Spring.Utilities.Base64Decode(data))
+	if not teamData then
+		Spring.Log(LOG_SECTION, LOG.ERROR, "Failed to parse s.battle.teams_update data: " .. tostring(data))
+		return
+	end
+	
+	Spring.Log(LOG_SECTION, LOG.NOTICE, "Updating battle " .. battleID .. " with teamSize=" .. tostring(teamData.teamSize) .. ", nbTeams=" .. tostring(teamData.nbTeams))
+	self:super("_OnUpdateBattleInfo", battleID, {
+		teamSize = teamData.teamSize,
+		nbTeams = teamData.nbTeams
+	})
+end
+Interface.commands["s.battle.teams_update"] = Interface._OnBattleTeamsUpdate
+Interface.commandPattern["s.battle.teams_update"] = "([^\t]+)\t(.+)"
+
+
 function Interface:_OnS_Client_Errorlog()
 	self:_CallListeners("OnS_Client_Errorlog")
 end

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -2379,25 +2379,6 @@ Interface.commands["s.battle.teams"] = Interface._OnBattleTeams
 Interface.commandPattern["s.battle.teams"] = "(.+)"
 
 -- Handle s.battle.teams_update individual update message
-function Interface:_OnBattleTeamsUpdate(battleID, data)
-	Spring.Log(LOG_SECTION, LOG.NOTICE, "Received s.battle.teams_update message for battle " .. battleID .. " with data: " .. tostring(data))
-	battleID = tonumber(battleID)
-	local teamData = Spring.Utilities.json.decode(Spring.Utilities.Base64Decode(data))
-	if not teamData then
-		Spring.Log(LOG_SECTION, LOG.ERROR, "Failed to parse s.battle.teams_update data: " .. tostring(data))
-		return
-	end
-	
-	Spring.Log(LOG_SECTION, LOG.NOTICE, "Updating battle " .. battleID .. " with teamSize=" .. tostring(teamData.teamSize) .. ", nbTeams=" .. tostring(teamData.nbTeams))
-	self:super("_OnUpdateBattleInfo", battleID, {
-		teamSize = teamData.teamSize,
-		nbTeams = teamData.nbTeams
-	})
-end
-Interface.commands["s.battle.teams_update"] = Interface._OnBattleTeamsUpdate
-Interface.commandPattern["s.battle.teams_update"] = "([^\t]+)\t(.+)"
-
-
 function Interface:_OnS_Client_Errorlog()
 	self:_CallListeners("OnS_Client_Errorlog")
 end

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -2352,7 +2352,7 @@ end
 Interface.commands["s.battle.extra_data"] = Interface._OnBattleExtraData
 Interface.commandPattern["s.battle.extra_data"] = "(%S+)%s+(.*)"
 
--- Handle s.battle.teams batch message (sent on login)
+-- Handle s.battle.teams messages
 function Interface:_OnBattleTeams(data)
 	Spring.Log(LOG_SECTION, LOG.NOTICE, "Received s.battle.teams message with data: " .. tostring(data))
 	local teamsData = Spring.Utilities.json.decode(Spring.Utilities.Base64Decode(data))
@@ -2361,13 +2361,10 @@ function Interface:_OnBattleTeams(data)
 		return
 	end
 	
-	Spring.Log(LOG_SECTION, LOG.NOTICE, "Parsed teams data: " .. Spring.Utilities.json.encode(teamsData))
-	
 	-- Update each battle with its team data
 	for battleID, teamInfo in pairs(teamsData) do
 		battleID = tonumber(battleID)
 		if battleID then
-			Spring.Log(LOG_SECTION, LOG.NOTICE, "Updating battle " .. battleID .. " with teamSize=" .. tostring(teamInfo.teamSize) .. ", nbTeams=" .. tostring(teamInfo.nbTeams))
 			self:super("_OnUpdateBattleInfo", battleID, {
 				teamSize = teamInfo.teamSize,
 				nbTeams = teamInfo.nbTeams
@@ -2378,7 +2375,6 @@ end
 Interface.commands["s.battle.teams"] = Interface._OnBattleTeams
 Interface.commandPattern["s.battle.teams"] = "(.+)"
 
--- Handle s.battle.teams_update individual update message
 function Interface:_OnS_Client_Errorlog()
 	self:_CallListeners("OnS_Client_Errorlog")
 end

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -2285,6 +2285,20 @@ function Lobby:GetBattlePlayerCount(battleID)
 	end
 end
 
+function Lobby:GetBattleMaxPlayers(battleID)
+	local battle = self:GetBattle(battleID)
+	if not battle then
+		return 0
+	end
+
+	-- fall back to maxPlayers, if nbTeams or teamSize is unknown
+	return (battle.teamSize and battle.nbTeams) and (battle.teamSize * battle.nbTeams) or battle.maxPlayers
+end
+
+function Lobby:GetPlayerOccupancy(battleID)
+	return self:GetBattlePlayerCount(battleID) .. "/" .. self:GetBattleMaxPlayers(battleID)
+end
+
 function Lobby:GetBattleFoundedBy(userName)
 	-- TODO, improve data structures to make this search nice
 	for battleID, battleData in pairs(self.battles) do


### PR DESCRIPTION
1. Refactor: extract repeated logic into function to avoid duplication for
GetBattleMaxPlayers and
GetPlayerOccupancy

2. Initialize previousMaxPlayers.previousPlayerCount and battleButton.previousMaxPlayers on button creation
and revert checking for previousMaxPlayers on JoinedBattle and LeftBattle, where no change to it occurs
