### PR TITLE
Randomize player side selection in battle status updates

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/singleplayerQuickSkirmish.lua
+++ b/LuaMenu/configs/gameConfig/byar/singleplayerQuickSkirmish.lua
@@ -160,6 +160,7 @@ function skirmishSetupData.ApplyFunction(battleLobby, pageChoices)
 
 	battleLobby:SetBattleStatus({
 		allyNumber = 0,
+		side = math.random(0, 1),
 		isSpectator = false,
 	})
 

--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -1116,7 +1116,7 @@ local function GetUserControls(userName, opts)
 							return
 						end
 						WG.SideChangeWindow.CreateSideChangeWindow({
-							initialSide = battleStatus.side or 0,
+							initialSide = battleStatus.side or math.random(0, 1),
 							OnAccepted = function(sideId)
 								if userName == userControls.lobby:GetMyUserName() then
 									Configuration:SetConfigValue("lastFactionChoice", sideId)

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -748,7 +748,7 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 				battleLobby:SetBattleStatus({
 					isSpectator = false,
 					isReady = false,
-					side = (WG.Chobby.Configuration.lastFactionChoice or 0),
+					side = (WG.Chobby.Configuration.lastFactionChoice or math.random(0,1)),
 					teamNumber = unusedTeamID})
 
 				if battleLobby.name == "singleplayer" then
@@ -3991,7 +3991,7 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		battleLobby:SetBattleStatus({
 			isSpectator = wespecnow,
 			isReady = false,
-			side = (WG.Chobby.Configuration.lastFactionChoice or 0) ,
+			side = (WG.Chobby.Configuration.lastFactionChoice or math.random(0, 1)),
 			sync = (haveMapAndGame and 1) or 2, -- 0 = unknown, 1 = synced, 2 = unsynced
 			-- tamColor = PickRandomColor()
 			-- teamColor = {
@@ -4212,8 +4212,7 @@ function BattleRoomWindow.GetSingleplayerControl(setupData)
 					allyNumber = 0,
 					isSpectator = false,
 					sync = (haveMapAndGame and 1) or 2, -- 0 = unknown, 1 = synced, 2 = unsynced
-
-					side = 0, -- Our default side is Armada
+					side = (WG.Chobby.Configuration.lastFactionChoice or math.random(0, 1)),
 					teamColor = {0,.32,1},
 				})
 

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -308,7 +308,7 @@ local function UpdateAndCreateMerge(userData, status)
 		updated = updated or userData.side ~= status.side
 		battleStatus.side = status.side
 	else
-		battleStatus.side = userData.side or 0
+		battleStatus.side = userData.side or math.random(0, 1)
 	end
 
 	return battleStatus, updated
@@ -508,7 +508,7 @@ function Interface:AddAi(aiName, aiLib, allyNumber, version, aiOptions, battleSt
 		allyNumber = allyNumber,
 		playMode = true,
 		sync = 1, -- (0 = unknown, 1 = synced, 2 = unsynced)
-		side = 0,
+		side = math.random(0, 1),
 	}
 
 	local battleStatus, updated = UpdateAndCreateMerge(userData, battleStatusOptions or {})
@@ -1953,7 +1953,7 @@ function Interface:_OnRequestBattleStatus()
 	self:SetBattleStatus({
 		isSpectator = defaultSpec,
 		isReady = false,
-		side = (WG.Chobby.Configuration.lastFactionChoice or 0) ,
+		side = (WG.Chobby.Configuration.lastFactionChoice or math.random(0,1)) ,
 		sync = getSyncStatus(self:GetBattle(self:GetMyBattleID())),
 	})
 end

--- a/libs/liblobby/lobby/interface_skirmish.lua
+++ b/libs/liblobby/lobby/interface_skirmish.lua
@@ -91,7 +91,7 @@ function InterfaceSkirmish:_StartScript(gameName, mapName, playerName, friendLis
 			local sideData = WG.Chobby.Configuration:GetSideById(data.side)
 			if sideData and sideData.requiresModoption and
 			   (not self.modoptions or self.modoptions[sideData.requiresModoption] ~= "1") then
-				data.side = 0 -- Our default side is Armada
+				data.side = (WG.Chobby.Configuration.lastFactionChoice or math.random(0, 1))
 			end
 			players[playerCount] = {
 				Name = userName,


### PR DESCRIPTION
I play Armada much more often due to it being default everywhere. I'd like to play  Armada/Cortex equally. This PR tries to create a 50/50 chance of getting ARM/CORE.

TODO: 
- [ ] Test all code paths (in progress while I figure out the code paths)
