### PR TITLE
Hide Newbie OS

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -284,7 +284,7 @@ local function GetUserSkillFont(userName, userControl)
 
 		skill = tostring(skill)
 
-		if userInfo.skillUncertainty and tonumber(userInfo.skillUncertainty) > 6 then
+		if userInfo.skillUncertainty and tonumber(userInfo.skillUncertainty) > 6.65 then
 			skill = "??"
 		end
 	end

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1749,10 +1749,10 @@ local function SortPlayersBySkill(a, b)
 	local sB = battleLobby:GetUser(b.name)
 	local joinA = tonumber((sA and sA.skill) or 0)
 	local joinB = tonumber((sB and sB.skill) or 0)
-	if tonumber((sA and sA.skillUncertainty) or 0) > 6 then
+	if tonumber((sA and sA.skillUncertainty) or 0) > 6.65 then
 		joinA = 0
 	end
-	if tonumber((sB and sB.skillUncertainty) or 0) > 6 then
+	if tonumber((sB and sB.skillUncertainty) or 0) > 6.65 then
 		joinB = 0
 	end
 	return joinA > joinB

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -696,7 +696,7 @@ local function GetUserTooltip(userName, userInfo, userBattleInfo, inBattleroom)
 		elseif userBattleInfo.aiLib then
 			text = "AI: " .. userBattleInfo.aiLib
 		elseif Configuration.showSkillOpt and Configuration.showSkillOpt > 1 and userInfo.skill and userInfo.skillUncertainty then
-			if tonumber(userInfo.skillUncertainty) > 6 then
+			if tonumber(userInfo.skillUncertainty) > 6.65 then
 				text = "OpenSkill: " .. "??"
 			else
 				text = "OpenSkill: " .. userInfo.skill


### PR DESCRIPTION
Hides OS of players above 6 sigma (uncertainty)
Sorts players in a way that the unknown ones are at the bottom.
<img width="403" height="434" alt="obraz" src="https://github.com/user-attachments/assets/0e5728eb-6779-4b36-9935-af03700e29e1" />
<img width="518" height="135" alt="obraz" src="https://github.com/user-attachments/assets/521e9503-efc8-401f-9bf8-ba2e86de533f" />

BAR side PR: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5925
