### PR TITLE
Reload Scenarios when changing game config

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -792,6 +792,9 @@ function Configuration:SetConfigValue(key, value)
 	end
 	if key == "gameConfigName" then
 		self:LoadGameConfig(LUA_DIRNAME .. "configs/gameConfig/" .. value .. "/mainConfig.lua")
+		if self.gameConfig and WG and WG.ScenarioHandler then
+			WG.ScenarioHandler.reloadGameVersion()
+		end
 	end
 	-- if key == "campaignConfigName" then
 	-- 	self.campaignPath = "campaign/" .. value

--- a/LuaMenu/widgets/gui_scenario_window.lua
+++ b/LuaMenu/widgets/gui_scenario_window.lua
@@ -1090,6 +1090,10 @@ function ScenarioHandler.GetControl()
 	return window
 end
 
+function ScenarioHandler.reloadGameVersion()
+	DownloadRequirements()
+end
+
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Widget Interface


### PR DESCRIPTION
##### Work Done

Made the scenarios panel refresh what game version it is using if the Game Config was changed so that we can switch between singleplayer normal and singleplayer dev in scenarios without needing to restart Chobby

##### Addresses Issue:

Contributor trying to play a scenario without dev mode but it still being on cause it didn't refresh when it was changed

##### Test Steps

1. Open Scenarios, pick any one and start it
2. run /gameinfo and read game name
3. Open Chobby Settings, Dev, Singleplayer and swap it to or from Beyond All Reason Dev
4. Start the Scenario again, check /gameinfo and see that it is a dinffrent game name / version

##### Disclamer

I am dyslexic and take no regards for my major spelling mistakes