### PR TITLE
Further refine modoption link styling.

### DIFF
--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -558,7 +558,6 @@ local function ProcessLinkButton(data, index)
 		tooltip = data.link,
 		padding = {2, 2, 2, 2},
 		backgroundColor	= {0.0, 0.0, 0.0, 0.0},
-		--focusColor		= {1.0, 1.0, 1.0, 1.0},
 		borderColor		= {0.0, 0.0, 0.0, 0.0},
 		OnMouseUp = {
 			function()
@@ -577,8 +576,6 @@ local function ProcessLinkButton(data, index)
 		y = 3,
 		width = 16,
 		height = 16,
-		--right = 0,
-		--bottom = 0,
 		keepAspect = true,
 		file = LUA_DIRNAME .. "images/external-website.png",
 		parent = button,


### PR DESCRIPTION
### Work Done
Hides the standard button ui,
Rescales the external website icon.

Unfortunately Button width is up to the modoption entry to adjust rather than automatic.

### Image

<img width="670" height="284" alt="image" src="https://github.com/user-attachments/assets/1c068183-8d24-48b0-8012-6e25239cb7b0" />
