### PR TITLE
Fix `Error: [string "LuaMenu/Widgets/gui_battle_room_window.lua"]:3960: malformed pattern (missing ']')`

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -3957,7 +3957,7 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 			return 
 		end
 		local myUserName = battleLobby:GetMyUserName()
-		local iAmMentioned = myUserName and userName ~= myUserName and string.find(message, myUserName)
+		local iAmMentioned = myUserName and userName ~= myUserName and string.find(message, myUserName, 1, true)
 		local chatColour = (iAmMentioned and CHAT_MENTION) or CHAT_ME
 		battleRoomConsole:AddMessage(message, userName, false, chatColour, true)
 	end


### PR DESCRIPTION
<img width="393" height="79" alt="Screenshot_20240701" src="https://github.com/user-attachments/assets/ddca3d0c-85ea-4df6-856a-72cd8fba1114" />

This PR enables the argument for `string.find` to treat input here as plaintext so that it doesn't error upon mentioning usernames with lua pattern characters in them.