### PR TITLE
Remove s.battle.teams message logging of received base64 data

### DIFF
--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -2365,7 +2365,6 @@ Interface.commandPattern["s.battle.extra_data"] = "(%S+)%s+(.*)"
 
 -- Handle s.battle.teams messages
 function Interface:_OnBattleTeams(data)
-	Spring.Log(LOG_SECTION, LOG.NOTICE, "Received s.battle.teams message with data: " .. tostring(data))
 	local teamsData = Json.decode(Spring.Utilities.Base64Decode(data))
 	if not teamsData then
 		Spring.Log(LOG_SECTION, LOG.ERROR, "Failed to parse s.battle.teams data: " .. tostring(data))


### PR DESCRIPTION
<img width="851" height="125" alt="Screenshot_20240703" src="https://github.com/user-attachments/assets/dc85b1cc-8cc5-4a45-9f12-90a4e39ff823" />

Some of these base64 messages can be very long, and are unnecessarily bloating logs. A log entry is still created if parsing fails.