### PR TITLE
OS displays on lobby preview

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -98,7 +98,7 @@ local openSkillLoaded = false
 local openSkillLoadFailed = false
 local openSkillLoadCo = nil
 local openSkillLoading = false
-local OPEN_SKILL_LINES_PER_STEP = 500 -- per frame parse
+local OPEN_SKILL_LINES_PER_STEP = 750 -- per frame parse
 local openSkillPendingUpdates = {}
 
 local IMAGE_CLAN_PATH    = "LuaUI/Configs/Clans/"
@@ -769,7 +769,7 @@ local function UpdateUserActivitySingleList(userList, userName, status)
 		end
 
 		if status and (status["skill"] or status["skillUncertainty"]) and userControls.showSkill then
-			local displaySkill = userControls.showSkillAlways or ((userControls.isPlaying or userControls.replayUserInfo) and WG.Chobby.Configuration.showSkillOpt > 1)
+			local displaySkill = userControls.showSkillAlways or ((userControls.isPlaying or userControls.replayUserInfo or userControls.useSnapshotSkill) and WG.Chobby.Configuration.showSkillOpt > 1)
 			if displaySkill then
 				local skill, skillColorFont = GetUserSkillFont(userName, userControls)
 				userControls.tbSkill:SetText(skill)
@@ -986,7 +986,7 @@ local function UpdateUserBattleStatus(listener, userName, battleStatusDiff)
 
 					-- Skill: show only in battlelist (limited by spring lobby protocol, skill not available for users outside of own battle)
 					if userControls.showSkill then
-						local displaySkill = userControls.showSkillAlways or (userControls.isPlaying and Configuration.showSkillOpt > 1)
+						local displaySkill = userControls.showSkillAlways or ((userControls.isPlaying or userControls.useSnapshotSkill) and Configuration.showSkillOpt > 1)
 						userControls.tbSkill:SetVisibility(displaySkill)
 						if displaySkill then
 							offset = offset + 2
@@ -2026,7 +2026,7 @@ function userHandler.GetBattleUser(userName, isSingleplayer)
 end
 
 function userHandler.GetTooltipUser(userName)
-	return _GetUser(tooltipUsers, userName, {
+	local control = _GetUser(tooltipUsers, userName, {
 		isInBattle         = true,
 		suppressSync       = true,
 		showModerator      = true,
@@ -2034,12 +2034,14 @@ function userHandler.GetTooltipUser(userName)
 		showCountry        = true,
 		showRank           = true,
 		showSkill          = true,
-		showSkillAlways    = true,
+		showSkillAlways    = false,
 		useSnapshotSkill   = true,
 		tooltipBattle      = userHandler._tooltipBattle,
 		disableInteraction = true,
 		colorizeFriends    = true,
 	})
+	UpdateUserBattleStatus(_, userName)
+	return control
 end
 
 function userHandler.GetReplayTooltipUser(replayUserInfo, maxNameLength)

--- a/LuaMenu/widgets/gui_open_skill_snapshot.lua
+++ b/LuaMenu/widgets/gui_open_skill_snapshot.lua
@@ -13,9 +13,17 @@ end
 -- if download fails, current local csv is used and if there is no local file then snapshot cache is empty. Does not block UI startup
 local SNAPSHOT_URL = "https://data-marts.beyondallreason.dev/player_skill_snapshot.csv"
 local SNAPSHOT_PATH = "data-processing-main/data-processing-main/data_export/player_skill_snapshot.csv"
+local SNAPSHOT_FETCH_INTERVAL = 24 * 60 * 60
+local SNAPSHOT_FETCH_CONFIG_KEY = "OpenSkillSnapshotLastFetch"
 
 local function download_snapshot()
 	if not (WG.DownloadHandler and WG.DownloadHandler.MaybeDownloadArchive) then
+		return
+	end
+-- skips download if last fetch was within 24 hours
+	local now = os.time()
+	local lastFetch = Spring.GetConfigInt(SNAPSHOT_FETCH_CONFIG_KEY, 0)
+	if lastFetch > 0 and (now - lastFetch) < SNAPSHOT_FETCH_INTERVAL then
 		return
 	end
 
@@ -30,6 +38,7 @@ local function download_snapshot()
 			extract = false,
 		}
 	)
+	Spring.SetConfigInt(SNAPSHOT_FETCH_CONFIG_KEY, now)
 end
 
 function widget:Initialize()

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -353,8 +353,9 @@ local function GetBattleTooltip(battleID, battle, showMapName)
 		battleTooltip.playerCount.Hide()
 	end
 
-	-- Avg OpenSkill
-	if battle.users and WG.UserHandler and WG.UserHandler.GetSnapshotSkillValue then
+	-- Avg OpenSkill, disabled if showOS is turned off
+	local showOS = Configuration.showSkillOpt and Configuration.showSkillOpt > 1
+	if showOS and battle.users and WG.UserHandler and WG.UserHandler.GetSnapshotSkillValue then
 		local total = 0
 		local count = 0
 		for i = 1, #battle.users do


### PR DESCRIPTION
Edited the original PR, teiserver changes are no longer required. This PR utilizes recent additions to the BAR data processing repository. References this file which is updated twice a week:  https://data-marts.beyondallreason.dev/player_skill_snapshot.csv

Feature is ready to merge.

Work Done

- Loads OpenSkill snapshot CSV, loads 750 lines a frame to limit stutters
- Update snapshot cache in‑memory using live lobby skill values, when a player joins a new lobby. Values found during game session are shown when possible
- Openskill values are calculated from the CSV using skill − uncertainty for the corresponding gamemode
- ``gui_open_skill_snapshot.lua`` OpenSkill snapshot downloader widget, receives a download path from BAR data dump. This runs on startup of chobby. If update fails current previous csv values this Does not stall UI startup. 
- Added an average OS value for a lobby
- If player is not listed within data dump or does not have OS values for that gamemode, the field is left blank until populated by joining the lobby


- This does handle case where lobby changes game type

Future Improvement if approved:

- list players from high to low OS 
- Not sure how possible this is, but if the frequency of BAR data dump can be increased, it would improve the quality of this feature by having more up to date OS previews



<img width="319" height="377" alt="image" src="https://github.com/user-attachments/assets/c15fe83d-609e-406b-abd4-7a908bf1dd29" />


Feature showcase video: https://discord.com/channels/549281623154229250/549282587487502347/1462653510884659211