### PR TITLE
Prevent download handler error when spring-launcher doesn't exist

### DIFF
--- a/LuaMenu/widgets/gui_download_window.lua
+++ b/LuaMenu/widgets/gui_download_window.lua
@@ -25,7 +25,8 @@ local STATUS_PRIORITY = {
 	pending = 2,
 	cancelled = 3,
 	failed = 4,
-	success = 5,
+	unsupported = 5,
+	success = 6,
 }
 
 local NAME_MAP = {
@@ -34,6 +35,7 @@ local NAME_MAP = {
 	pending = "Queued",
 	cancel = "\255\255\255\0Cancelled",
 	fail = "\255\255\0\0Failed",
+	unsupported = "\255\255\0\0Require spring-launcher",
 	success = "\255\0\255\0Complete",
 }
 


### PR DESCRIPTION
When the game is run without spring-launcher, WG.Connector.enabled = false.

> [t=00:00:02.599880][f=-000001] [spring-launcher] Disabling spring-launcher due to missing connection detalis.

Then WG.WrapperLoopback is not initialized.

> [t=00:00:02.955802][f=-000001] [LuaMenu] Loading widget:      Spring-Launcher wrapper loopback interface  <sl_loopback.lua>
> [t=00:00:02.956712][f=-000001] [Chobby] spring-launcher doesn't exist.

DownloadQueueUpdate() falls back on VFS.DownloadArchive(), which is an error with type "resource".

> [t=00:00:04.046652][f=-000001] [LuaMenu] Error: In Update(): [string "LuaMenu/Widgets/api_download_handler.lua"]:142: Category must be one of: map, game, engine.
> [t=00:00:04.046671][f=-000001] [LuaMenu] Error: Removed widget: <Download Handler>

The problem is we can't download other types of ressources anymore.
This error was found on OpenBSD using a custom bin/sh launcher.

https://codeberg.org/OpenBSD/ports/src/branch/master/games/recoil-rts/files/beyond-all-reason

It's annoying as every day the download stops working because it tries to fetch player_skill_snapshot.csv.

https://github.com/beyond-all-reason/BYAR-Chobby/blob/b66be4f30afd3ddc2561ae81310a05d3b55fd7b5/LuaMenu/widgets/gui_open_skill_snapshot.lua#L31-L40

Please let me know what you think about these changes.