### PR TITLE
Add Support for Experimental King of the Hill Game Mode

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1773,10 +1773,10 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 
 						obj.oldSizes = {obj.x,obj.y, obj.width,obj.height}
 
-						local l = 200* obj.x / pw
-						local t = 200* obj.y / ph
-						local r = 200* obj.width / pw + l
-						local b = 200* obj.height / ph + t
+						local l = math.floor(200 * obj.x / pw + 0.5)
+						local t = math.floor(200 * obj.y / ph + 0.5)
+						local r = math.floor(200 * obj.width / pw + 0.5) + l
+						local b = math.floor(200 * obj.height / ph + 0.5) + t
 						--also do the fact that it should be red on change, and turn back black on successfull modification
 						--try to manage clicking on the startbox not changing it.
 						--TODO: problematic when resizing entire UI :/


### PR DESCRIPTION
See https://github.com/beyond-all-reason/Beyond-All-Reason/pull/6894

This PR adds a hill area selection box, identical to the start box selection, for the PR linked above.

<img width="445" height="651" alt="image" src="https://github.com/user-attachments/assets/27d0ff54-532e-49b6-a281-faada22ada9a" />
