### PR TITLE
Changes random skirmish AI to choose random faction

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -270,7 +270,7 @@ local function ApplySingleplayerSkirmishSetup(singleplayerDefault)
 		end
 
 		battleLobby:AddAi(aiDisplayName, shortName, allyTeam, nil, aiOptions, {
-			side = math.random(0, 1),
+			side = 2, -- random faction
 			teamColor = color,
 		})
 		aiCounter = aiCounter + 1


### PR DESCRIPTION
Changes faction chosen by AI to random when using the random skirmish button.

Allows for legion to spawn when "Legion Faction = 1"

 
<img width="914" height="967" alt="image" src="https://github.com/user-attachments/assets/1875a906-58f3-41c0-a1f9-d164dee5187b" />
