### PR TITLE
fix(presets): can load very large presets via batching (20k chars every 4 seconds)

### DIFF
--- a/LuaMenu/widgets/chobby/utilities/stringUtilities.lua
+++ b/LuaMenu/widgets/chobby/utilities/stringUtilities.lua
@@ -48,10 +48,6 @@ function StringUtilities.TruncateStringIfRequiredAndDotDot(myString, myFont, max
 	return StringUtilities.GetTruncatedStringWithDotDot(myString, myFont, maxLength)
 end
 
--- Pure character-based middle truncation: keeps the first headLength and last
--- tailLength characters joined by "..." when value exceeds threshold.
--- Useful for display-side rendering of long values in chat / logs where font
--- metrics are not relevant.
 function StringUtilities.TruncateMiddle(value, threshold, headLength, tailLength)
 	threshold = threshold or 20
 	headLength = headLength or 8

--- a/LuaMenu/widgets/chobby/utilities/stringUtilities.lua
+++ b/LuaMenu/widgets/chobby/utilities/stringUtilities.lua
@@ -48,6 +48,21 @@ function StringUtilities.TruncateStringIfRequiredAndDotDot(myString, myFont, max
 	return StringUtilities.GetTruncatedStringWithDotDot(myString, myFont, maxLength)
 end
 
+-- Pure character-based middle truncation: keeps the first headLength and last
+-- tailLength characters joined by "..." when value exceeds threshold.
+-- Useful for display-side rendering of long values in chat / logs where font
+-- metrics are not relevant.
+function StringUtilities.TruncateMiddle(value, threshold, headLength, tailLength)
+	threshold = threshold or 20
+	headLength = headLength or 8
+	tailLength = tailLength or 8
+	local s = tostring(value or "")
+	if #s <= threshold then
+		return s
+	end
+	return s:sub(1, headLength) .. "..." .. s:sub(-tailLength)
+end
+
 function string.starts(String,Start)
 	return string.sub(String,1,string.len(Start))==Start
 end

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1268,6 +1268,60 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 	}
 	leftOffset = leftOffset + 40
 
+	-- Inline progress slot for throttled chat-paste sends. Hidden by default;
+	-- pushes lblGame / Have-Game / Have-Map / modoptionsHolder down by
+	-- INLINE_PROGRESS_REFLOW px while visible. The bar's own caption carries
+	-- "Option N/M" (same pattern as WG.Chobby.Downloader).
+	local INLINE_PROGRESS_HEIGHT = 30
+	local INLINE_PROGRESS_REFLOW = INLINE_PROGRESS_HEIGHT + 5
+	local inlineProgressOnCancel
+	local inlineProgressBar = Progressbar:New {
+		name = 'inlineProgressBar',
+		x = 5,
+		y = 0,
+		right = 95,
+		bottom = 0,
+		value = 0,
+		max = 1,
+		caption = "",
+		objectOverrideFont = config:GetFont(2),
+	}
+	local inlineProgressCancel = Button:New {
+		name = 'inlineProgressCancel',
+		right = 5,
+		width = 80,
+		y = 0,
+		bottom = 0,
+		caption = i18n("cancel"),
+		classname = "negative_button",
+		objectOverrideFont = config:GetFont(1),
+		OnClick = {
+			function()
+				if inlineProgressOnCancel then
+					inlineProgressOnCancel()
+				end
+			end
+		},
+	}
+	local inlineProgressPanel = Control:New {
+		name = 'inlineProgressPanel',
+		x = 0,
+		y = leftOffset,
+		right = 0,
+		height = INLINE_PROGRESS_HEIGHT,
+		padding = {0, 0, 0, 0},
+		itemPadding = {0, 0, 0, 0},
+		itemMargin = {0, 0, 0, 0},
+		resizable = false,
+		draggable = false,
+		children = {
+			inlineProgressBar,
+			inlineProgressCancel,
+		},
+		parent = leftInfo,
+	}
+	inlineProgressPanel:Hide()
+
 	-- gray out the button if we don't have a modoptions panel to show
 	if not modoptions then
 		-- cosmetics when disabled
@@ -1414,9 +1468,13 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 	--MaybeDownloadArchive("Titan-v2", "map")
 	--MaybeDownloadArchive("tinyskirmishredux1.1", "map")
 
+	local lastDisallowCustomTeams = battle.disallowCustomTeams
 	function externalFunctions.UpdateBattleMode(disallowCustomTeams)
+		if disallowCustomTeams ~= nil then
+			lastDisallowCustomTeams = disallowCustomTeams
+		end
 		local offset = 0
-		if disallowCustomTeams then
+		if lastDisallowCustomTeams then
 			btnNewTeam:SetVisibility(false)
 		else
 			btnNewTeam:SetVisibility(true)
@@ -1429,6 +1487,10 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		offset = offset + 38
 		btnOptionPresets:SetPos(nil, offset)
 		offset = offset + 40
+		if inlineProgressPanel.visible then
+			inlineProgressPanel:SetPos(nil, offset)
+			offset = offset + INLINE_PROGRESS_REFLOW
+		end
 		lblGame:SetPos(nil, offset)
 		offset = offset + 26
 		imHaveGame:SetPos(nil, offset)
@@ -1436,8 +1498,44 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		offset = offset + 25
 		imHaveMap:SetPos(nil, offset)
 		lblHaveMap:SetPos(nil, offset)
+		offset = offset + 30
+		modoptionTopPosition = offset
+		modoptionBottomPosition = offset + 120
+		OnDownloaderVisibility()
 	end
 	externalFunctions.UpdateBattleMode(battle.disallowCustomTeams)
+
+	-- Inline throttled-send progress API. Show/Update/Hide are called by the
+	-- chat-paste interceptor (and any other caller that wants to render a
+	-- throttled send progress bar in the battleroom). The bar lives in the
+	-- inlineProgressPanel slot; toggling visibility reflows leftInfo.
+	WG.BattleRoomInlineProgress = {
+		Show = function(opts)
+			opts = opts or {}
+			inlineProgressOnCancel = opts.onCancel
+			inlineProgressBar:SetMinMax(0, 1)
+			inlineProgressBar:SetValue(0)
+			inlineProgressBar:SetCaption("")
+			if not inlineProgressPanel.visible then
+				inlineProgressPanel:Show()
+				externalFunctions.UpdateBattleMode()
+			end
+		end,
+		Update = function(current, total)
+			if total and total > 0 then
+				inlineProgressBar:SetMinMax(0, total)
+			end
+			inlineProgressBar:SetValue(current or 0)
+			inlineProgressBar:SetCaption("Loading... " .. tostring(current or 0) .. "/" .. tostring(total or 0))
+		end,
+		Hide = function()
+			inlineProgressOnCancel = nil
+			if inlineProgressPanel.visible then
+				inlineProgressPanel:Hide()
+				externalFunctions.UpdateBattleMode()
+			end
+		end,
+	}
 
 	function externalFunctions.SetHaveGame(newHaveGame)
 		if newHaveGame then
@@ -3717,6 +3815,45 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 	local battleRoomConsole = WG.Chobby.Console("Battleroom Chat", MessageListener, true, nil, true)
 	WG.BattleRoomChatInput = battleRoomConsole.ebInputText
 
+	-- Large-paste interceptor. External configurators have users paste 50k+ char
+	-- blobs of !preset / !bSet commands into chat. Pasted directly into the
+	-- editbox this freezes the UI on render and (in MP) floods SPADS, getting
+	-- the user kicked. Anything bigger than a single throttle batch is routed
+	-- through the throttled queue (MP) or applied locally via the singleplayer
+	-- bset parser (SP). The editbox itself never receives the blob.
+	do
+		local chatInput = battleRoomConsole.ebInputText
+		local origTextInput = chatInput.TextInput
+		local pasteThreshold = battleLobby.THROTTLED_SAY_MAX_CHARS_PER_BATCH or 20000
+
+		chatInput.TextInput = function(self, utf8char, ...)
+			if utf8char and #utf8char > pasteThreshold then
+				if battleLobby.name == "singleplayer" then
+					-- SP: feed the full blob into MessageListener; its !bset
+					-- parser iterates lines and applies SetModOptions locally.
+					MessageListener(utf8char)
+				else
+					-- MP: keep only !-prefixed and $-prefixed commands (matches
+					-- the prefix set ParseMultiCommandMessage recognises) and
+					-- preserve order so !preset lines fire first.
+					local lines = {}
+					for line in utf8char:gmatch("[^\n]+") do
+						local trimmed = line:match("^%s*(.-)%s*$")
+						local first = trimmed:sub(1, 1)
+						if trimmed ~= "" and (first == "!" or first == "$") then
+							lines[#lines + 1] = trimmed
+						end
+					end
+					if #lines > 0 and WG.ThrottledBattleSend and WG.ThrottledBattleSend.Run then
+						WG.ThrottledBattleSend.Run(lines, nil, { renderer = "inline" })
+					end
+				end
+				return self
+			end
+			return origTextInput(self, utf8char, ...)
+		end
+	end
+
 	local chatPanel = Control:New {
 		name = 'chatPanel',
 		x = 0,
@@ -4030,6 +4167,72 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 	local function dontshowvote()
 	end
 
+	-- Display-only cache of the most recent old/new for each modoption key,
+	-- fed by OnSetModOptions's `changes` arg. Keys are lowercased to match
+	-- how SPADS broadcasts battle settings. Used to rewrite SPADS' bSet
+	-- confirmations with both previous and new values without mutating any
+	-- stored state.
+	local recentModoptionDiff = {}
+	local inBSetFragment = false
+
+	local function FormatBSetRewrite(user, key, diff)
+		local oldT = StringUtilities.TruncateMiddle(diff.old)
+		local newT = StringUtilities.TruncateMiddle(diff.new)
+		-- Match SPADS' "* " action prefix so the rewritten line renders the
+		-- same way as the original broadcast (third-person/action style).
+		return "* Battle setting changed by " .. user
+			.. " (from " .. key .. "=" .. oldT
+			.. " to " .. key .. "=" .. newT .. ")"
+	end
+
+	-- SPADS' sayBattle prefixes every chunk with "* " before queuing
+	-- SAYBATTLEEX, so the message text we receive starts with "* ". Match
+	-- with an optional leading "* " (and no leading "^") so single-line and
+	-- fragmented broadcasts both hit.
+	local BSET_HEAD_PARTIAL = "%*?%s*Battle setting changed by (%S+) %(([%w_]+)="
+	local BSET_HEAD_FULL    = "%*?%s*Battle setting changed by (%S+) %(([%w_]+)=.*%)%s*$"
+
+	-- Returns nil (not a bSet broadcast — leave alone),
+	--         { rewritten = "..." } (full or fragmented head match — emit this),
+	--         { suppress = true }   (continuation of a fragmented broadcast).
+	local function RewriteBSetSpadsMessage(message)
+		-- Fragmented continuation: keep swallowing until a line ends with ')'.
+		if inBSetFragment then
+			-- A new bSet head while still in a fragment means the previous
+			-- continuation lines are done; let the head be matched below.
+			if not string.match(message, BSET_HEAD_PARTIAL) then
+				if string.match(message, "%)%s*$") then
+					inBSetFragment = false
+				end
+				return { suppress = true }
+			end
+			inBSetFragment = false
+		end
+
+		-- Full single-line broadcast.
+		local user, key = string.match(message, BSET_HEAD_FULL)
+		if user and key then
+			local diff = recentModoptionDiff[string.lower(key)]
+			if diff then
+				return { rewritten = FormatBSetRewrite(user, key, diff) }
+			end
+			return nil
+		end
+
+		-- Fragmented head (no closing paren on this line).
+		user, key = string.match(message, BSET_HEAD_PARTIAL)
+		if user and key then
+			inBSetFragment = true
+			local diff = recentModoptionDiff[string.lower(key)]
+			if diff then
+				return { rewritten = FormatBSetRewrite(user, key, diff) }
+			end
+			return { suppress = true }
+		end
+
+		return nil
+	end
+
 	local function ParseSpadsMessage(userName, message) -- return hidemessage bool
 		-- should only be called on messages from founder (host)
 		local myUserName = battleLobby:GetMyUserName()
@@ -4221,6 +4424,16 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		local hidemessage = false
 
 		if userName == battle.founder then -- todo dont do this for self-hosted
+			local rewrite = RewriteBSetSpadsMessage(message)
+			if rewrite then
+				if rewrite.suppress then
+					return
+				end
+				if rewrite.rewritten then
+					message = rewrite.rewritten
+				end
+			end
+
 			local hidespads = ParseSpadsMessage(userName,message)
 			local hidevote = ParseForVotingSaidBattle(userName,message)
 			local hidebarmanager = ParseBarManagerSaidBattleEx(userName, message)
@@ -4325,9 +4538,14 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		end
 	end
 
-	local function OnSetModOptions(listener, modoptions)
+	local function OnSetModOptions(listener, modoptions, changes)
 		if not modoptions then
 			return
+		end
+		if changes then
+			for k, change in pairs(changes) do
+				recentModoptionDiff[string.lower(k)] = change
+			end
 		end
 		local factionlimiter = modoptions.factionlimiter
 		if factionlimiter then
@@ -4393,6 +4611,7 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 
 		WG.BattleStatusPanel.RemoveBattleTab()
 		WG.BattleRoomChatInput = nil
+		WG.BattleRoomInlineProgress = nil
 	end
 
 	mainWindow.OnDispose = mainWindow.OnDispose or {}

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1316,6 +1316,51 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		},
 		parent = leftInfo,
 	}
+	local inlineProgressFullCaption = ""
+
+	local function SyncInlineProgressCaption()
+		if not (inlineProgressPanel and inlineProgressPanel.visible) then
+			return
+		end
+		local panelW = inlineProgressPanel.width or 0
+		local barInner = math.max(0, (inlineProgressBar.width or 0) - 10)
+		local font
+		-- Split-pane (~19% of 1440p ≈ 260–290px) should match single-pane caption size; truncation handles overflow on smaller windows.
+		if panelW >= 300 then
+			font = config:GetFont(2)
+		elseif panelW >= 220 then
+			font = config:GetFont(15, "battle_inline_prog_m", {outline = false, shadow = true}, true)
+		else
+			font = config:GetFont(12, "battle_inline_prog_s", {outline = false, shadow = true}, true)
+		end
+		if inlineProgressBar.font ~= font then
+			inlineProgressBar.font = font
+		end
+		local cap = inlineProgressFullCaption
+		if barInner > 0 and cap ~= "" then
+			cap = StringUtilities.GetTruncatedStringWithDotDot(cap, inlineProgressBar.font, barInner)
+		end
+		inlineProgressBar:SetCaption(cap)
+	end
+
+	local inlineSyncGen = 0
+	local function ScheduleInlineProgressSync()
+		inlineSyncGen = inlineSyncGen + 1
+		local gen = inlineSyncGen
+		WG.Delay(function()
+			if gen ~= inlineSyncGen then
+				return
+			end
+			SyncInlineProgressCaption()
+		end, 0.02)
+	end
+
+	inlineProgressPanel.OnResize = inlineProgressPanel.OnResize or {}
+	inlineProgressPanel.OnResize[#inlineProgressPanel.OnResize + 1] = function()
+		SyncInlineProgressCaption()
+		ScheduleInlineProgressSync()
+	end
+
 	inlineProgressPanel:Hide()
 
 	-- gray out the button if we don't have a modoptions panel to show
@@ -1446,6 +1491,9 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 	leftInfo.OnResize = leftInfo.OnResize or {}
 	leftInfo.OnResize[#leftInfo.OnResize + 1] = function ()
 		OnDownloaderVisibility()
+		if WG.ModoptionsPanel and WG.ModoptionsPanel.ScheduleBattleSummaryReflow then
+			WG.ModoptionsPanel.ScheduleBattleSummaryReflow()
+		end
 	end
 
 	local downloaderPos = {
@@ -1498,6 +1546,12 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		modoptionTopPosition = offset
 		modoptionBottomPosition = offset + 120
 		OnDownloaderVisibility()
+		if inlineProgressPanel.visible then
+			ScheduleInlineProgressSync()
+		end
+		if WG.ModoptionsPanel and WG.ModoptionsPanel.ScheduleBattleSummaryReflow then
+			WG.ModoptionsPanel.ScheduleBattleSummaryReflow()
+		end
 	end
 	externalFunctions.UpdateBattleMode(battle.disallowCustomTeams)
 
@@ -1505,12 +1559,15 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		Show = function(opts)
 			opts = opts or {}
 			inlineProgressOnCancel = opts.onCancel
+			inlineProgressFullCaption = ""
 			inlineProgressBar:SetMinMax(0, 1)
 			inlineProgressBar:SetValue(0)
 			inlineProgressBar:SetCaption("")
 			if not inlineProgressPanel.visible then
 				inlineProgressPanel:Show()
 				externalFunctions.UpdateBattleMode()
+				SyncInlineProgressCaption()
+				ScheduleInlineProgressSync()
 			end
 		end,
 		Update = function(current, total)
@@ -1518,7 +1575,9 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 				inlineProgressBar:SetMinMax(0, total)
 			end
 			inlineProgressBar:SetValue(current or 0)
-			inlineProgressBar:SetCaption("Loading... " .. tostring(current or 0) .. "/" .. tostring(total or 0))
+			inlineProgressFullCaption = "Loading... " .. tostring(current or 0) .. "/" .. tostring(total or 0)
+			SyncInlineProgressCaption()
+			ScheduleInlineProgressSync()
 		end,
 		Hide = function()
 			inlineProgressOnCancel = nil

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -3807,7 +3807,7 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 	local battleRoomConsole = WG.Chobby.Console("Battleroom Chat", MessageListener, true, nil, true)
 	WG.BattleRoomChatInput = battleRoomConsole.ebInputText
 
-	-- Oversized paste: throttle singleplayer or apply via singleplayer MessageListener (SPADS / UI).
+	-- Oversized paste: throttle multiplayer or apply via singleplayer MessageListener (SPADS / UI).
 	do
 		local chatInput = battleRoomConsole.ebInputText
 		local origTextInput = chatInput.TextInput

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1268,10 +1268,6 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 	}
 	leftOffset = leftOffset + 40
 
-	-- Inline progress slot for throttled chat-paste sends. Hidden by default;
-	-- pushes lblGame / Have-Game / Have-Map / modoptionsHolder down by
-	-- INLINE_PROGRESS_REFLOW px while visible. The bar's own caption carries
-	-- "Option N/M" (same pattern as WG.Chobby.Downloader).
 	local INLINE_PROGRESS_HEIGHT = 30
 	local INLINE_PROGRESS_REFLOW = INLINE_PROGRESS_HEIGHT + 5
 	local inlineProgressOnCancel
@@ -1505,10 +1501,6 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 	end
 	externalFunctions.UpdateBattleMode(battle.disallowCustomTeams)
 
-	-- Inline throttled-send progress API. Show/Update/Hide are called by the
-	-- chat-paste interceptor (and any other caller that wants to render a
-	-- throttled send progress bar in the battleroom). The bar lives in the
-	-- inlineProgressPanel slot; toggling visibility reflows leftInfo.
 	WG.BattleRoomInlineProgress = {
 		Show = function(opts)
 			opts = opts or {}
@@ -3815,12 +3807,7 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 	local battleRoomConsole = WG.Chobby.Console("Battleroom Chat", MessageListener, true, nil, true)
 	WG.BattleRoomChatInput = battleRoomConsole.ebInputText
 
-	-- Large-paste interceptor. External configurators have users paste 50k+ char
-	-- blobs of !preset / !bSet commands into chat. Pasted directly into the
-	-- editbox this freezes the UI on render and (in MP) floods SPADS, getting
-	-- the user kicked. Anything bigger than a single throttle batch is routed
-	-- through the throttled queue (MP) or applied locally via the singleplayer
-	-- bset parser (SP). The editbox itself never receives the blob.
+	-- Oversized paste: throttle singleplayer or apply via singleplayer MessageListener (SPADS / UI).
 	do
 		local chatInput = battleRoomConsole.ebInputText
 		local origTextInput = chatInput.TextInput
@@ -3829,13 +3816,9 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		chatInput.TextInput = function(self, utf8char, ...)
 			if utf8char and #utf8char > pasteThreshold then
 				if battleLobby.name == "singleplayer" then
-					-- SP: feed the full blob into MessageListener; its !bset
-					-- parser iterates lines and applies SetModOptions locally.
 					MessageListener(utf8char)
 				else
-					-- MP: keep only !-prefixed and $-prefixed commands (matches
-					-- the prefix set ParseMultiCommandMessage recognises) and
-					-- preserve order so !preset lines fire first.
+					-- MP: ! and $ lines only; order preserved
 					local lines = {}
 					for line in utf8char:gmatch("[^\n]+") do
 						local trimmed = line:match("^%s*(.-)%s*$")
@@ -4167,39 +4150,24 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 	local function dontshowvote()
 	end
 
-	-- Display-only cache of the most recent old/new for each modoption key,
-	-- fed by OnSetModOptions's `changes` arg. Keys are lowercased to match
-	-- how SPADS broadcasts battle settings. Used to rewrite SPADS' bSet
-	-- confirmations with both previous and new values without mutating any
-	-- stored state.
+	-- Per-key old/new from OnSetModOptions(changes); lowercased keys for SPADS SAYBATTLEEX rewrite.
 	local recentModoptionDiff = {}
 	local inBSetFragment = false
 
 	local function FormatBSetRewrite(user, key, diff)
 		local oldT = StringUtilities.TruncateMiddle(diff.old)
 		local newT = StringUtilities.TruncateMiddle(diff.new)
-		-- Match SPADS' "* " action prefix so the rewritten line renders the
-		-- same way as the original broadcast (third-person/action style).
 		return "* Battle setting changed by " .. user
 			.. " (from " .. key .. "=" .. oldT
 			.. " to " .. key .. "=" .. newT .. ")"
 	end
 
-	-- SPADS' sayBattle prefixes every chunk with "* " before queuing
-	-- SAYBATTLEEX, so the message text we receive starts with "* ". Match
-	-- with an optional leading "* " (and no leading "^") so single-line and
-	-- fragmented broadcasts both hit.
 	local BSET_HEAD_PARTIAL = "%*?%s*Battle setting changed by (%S+) %(([%w_]+)="
 	local BSET_HEAD_FULL    = "%*?%s*Battle setting changed by (%S+) %(([%w_]+)=.*%)%s*$"
 
-	-- Returns nil (not a bSet broadcast — leave alone),
-	--         { rewritten = "..." } (full or fragmented head match — emit this),
-	--         { suppress = true }   (continuation of a fragmented broadcast).
+	-- Returns; nil | { rewritten = "..." } | { suppress = true }
 	local function RewriteBSetSpadsMessage(message)
-		-- Fragmented continuation: keep swallowing until a line ends with ')'.
 		if inBSetFragment then
-			-- A new bSet head while still in a fragment means the previous
-			-- continuation lines are done; let the head be matched below.
 			if not string.match(message, BSET_HEAD_PARTIAL) then
 				if string.match(message, "%)%s*$") then
 					inBSetFragment = false
@@ -4209,7 +4177,6 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 			inBSetFragment = false
 		end
 
-		-- Full single-line broadcast.
 		local user, key = string.match(message, BSET_HEAD_FULL)
 		if user and key then
 			local diff = recentModoptionDiff[string.lower(key)]
@@ -4219,7 +4186,6 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 			return nil
 		end
 
-		-- Fragmented head (no closing paren on this line).
 		user, key = string.match(message, BSET_HEAD_PARTIAL)
 		if user and key then
 			inBSetFragment = true

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -4154,12 +4154,18 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 	local recentModoptionDiff = {}
 	local inBSetFragment = false
 
+	local function FormatBSetValueForChat(raw)
+		if raw == nil or tostring(raw) == "" then
+			return '""'
+		end
+		return StringUtilities.TruncateMiddle(raw)
+	end
+
 	local function FormatBSetRewrite(user, key, diff)
-		local oldT = StringUtilities.TruncateMiddle(diff.old)
-		local newT = StringUtilities.TruncateMiddle(diff.new)
+		local oldDisp = FormatBSetValueForChat(diff.old)
+		local newDisp = FormatBSetValueForChat(diff.new)
 		return "* Battle setting changed by " .. user
-			.. " (from " .. key .. "=" .. oldT
-			.. " to " .. key .. "=" .. newT .. ")"
+			.. " (" .. key .. " from " .. oldDisp .. " to " .. newDisp .. ")"
 	end
 
 	local BSET_HEAD_PARTIAL = "%*?%s*Battle setting changed by (%S+) %(([%w_]+)="

--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -243,6 +243,7 @@ local function createProgressDialog(parentWindow, title, onCancel)
 		right = 15,
 		height = 30,
 		align = "left",
+		autosize = false,
 		caption = "Loading settings...",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
 	}
@@ -264,6 +265,7 @@ local function createProgressDialog(parentWindow, title, onCancel)
 		right = 15,
 		height = 30,
 		align = "center",
+		autosize = false,
 		caption = "0 / 0 batches",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
 	}

--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -43,13 +43,13 @@ local currentMPBattleSettings
 local multiplayerModoptions
 
 -- now we need to store the object in this class
-local jsondata;
+local jsondata
 
 -- preset that is selected in the dropdown menu
-local selectedPresetName = placeHolder;
+local selectedPresetName = placeHolder
 
 -- preset that is currently applied
-local appliedPresetName  = placeHolder;
+local appliedPresetName  = placeHolder
 
 -- active throttled preset load, used to cancel delayed batches when closing UI
 local activeLoadToken
@@ -212,68 +212,49 @@ local function applyPreset(presetName, progressCallback, cancelToken)
 					return
 				end
 			end
-			-- Use throttled loading with optional progress callback
-			if progressCallback then
-				battleLobby:SetModOptionsThrottled(currentModoptions, 20000, 5, progressCallback, cancelToken)
-			else
-				battleLobby:SetModOptionsThrottled(currentModoptions, 20000, 5, nil, cancelToken)
-			end
+			-- Use throttled loading; batch size and interval defaults live in interface.lua
+			battleLobby:SetModOptionsThrottled(currentModoptions, nil, nil, progressCallback, cancelToken)
 		end
 	end
 end
 
 -- create a progress dialog for throttled loading
-local function createProgressDialog(parentWindow, title, onCancel)
-	local dialogWindow = Window:New {
-		caption = title or "Loading",
+local function createProgressDialog(parentWindow, onCancel)
+	local dialogWindow = Window:New({
 		name = "presetLoadProgressDialog",
 		parent = parentWindow,
 		align = "center",
 		width = 450,
-		height = 180,
+		height = 190,
 		resizable = false,
 		draggable = false,
 		classname = "main_window",
-	}
+	})
 
-	-- Progress label
-	local progressLabel = Label:New {
+	local progressLabel = Label:New({
 		x = 15,
-		y = 15,
+		y = 20,
 		right = 15,
 		height = 30,
 		align = "left",
 		autosize = false,
 		caption = "Loading settings...",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-	}
+	})
 
-	-- Progress bar
-	local progressBar = Progressbar:New {
+	local progressBar = Progressbar:New({
 		x = 15,
-		y = 50,
+		y = 60,
 		right = 15,
 		height = 25,
 		value = 0,
 		max = 1,
-	}
+	})
 
-	-- Status text
-	local statusLabel = Label:New {
-		x = 15,
-		y = 80,
-		right = 15,
-		height = 30,
-		align = "center",
-		autosize = false,
-		caption = "0 / 0 batches",
-		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-	}
-
-	local cancelButton = Button:New {
+	local cancelButton = Button:New({
 		right = 15,
 		width = 135,
-		bottom = 12,
+		bottom = 20,
 		height = 45,
 		caption = i18n("cancel"),
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
@@ -286,13 +267,12 @@ local function createProgressDialog(parentWindow, title, onCancel)
 				if dialogWindow and dialogWindow.parent then
 					dialogWindow:Dispose()
 				end
-			end
+			end,
 		},
-	}
+	})
 
 	dialogWindow:AddChild(progressLabel)
 	dialogWindow:AddChild(progressBar)
-	dialogWindow:AddChild(statusLabel)
 	dialogWindow:AddChild(cancelButton)
 	dialogWindow:BringToFront()
 
@@ -300,16 +280,9 @@ local function createProgressDialog(parentWindow, title, onCancel)
 		if not (dialogWindow and dialogWindow.parent) then
 			return
 		end
-
-		if total > 0 then
-			progressBar:SetMinMax(0, total)
-			progressBar:SetValue(current)
-			statusLabel:SetCaption(current .. " / " .. total .. " batches")
-		else
-			progressLabel:SetCaption("No changes needed")
-			progressBar:SetValue(0)
-			statusLabel:SetCaption("0 / 0 batches")
-		end
+		progressBar:SetMinMax(0, total)
+		progressBar:SetValue(current)
+		progressLabel:SetCaption("Loading settings... " .. current .. " / " .. total .. " batches")
 	end
 
 	local closeDialog = function()
@@ -329,7 +302,7 @@ local function applyPresetThrottled(modoptions, progressCallback, cancelToken)
 	
 	-- Check if throttled method exists
 	if battleLobby.SetModOptionsThrottled then
-		battleLobby:SetModOptionsThrottled(modoptions, 20000, 5, progressCallback, cancelToken)
+		battleLobby:SetModOptionsThrottled(modoptions, nil, nil, progressCallback, cancelToken)
 		return true
 	else
 		-- Fallback to regular method
@@ -650,32 +623,37 @@ local function PopulatePresetPanel(parentPanel)
 				
 				local cancelToken = { cancelled = false }
 				activeLoadToken = cancelToken
-				local progressDialog, updateProgress, closeDialog = createProgressDialog(window, "Loading Preset", function()
-					cancelToken.cancelled = true
-					activeLoadToken = nil
-				end)
-				
-				-- Apply preset with progress tracking
+				local progressDialog, updateProgress, closeDialog
+
 				local updateWrapper = function(current, total, cancelled)
-					updateProgress(current, total)
 					if cancelled then
 						activeLoadToken = nil
 						return
 					end
 
-					if total == 0 then
-						activeLoadToken = nil
-						WG.Delay(function()
-							closeDialog()
+					-- Single- or zero-batch loads finish instantly; skip the dialog
+					-- and just close the preset window like the non-throttled path did.
+					if total <= 1 then
+						if current == total then
+							activeLoadToken = nil
+							window:Dispose()
 							if WG.BattleRoomChatInput then
 								screen0:FocusControl(WG.BattleRoomChatInput)
 							end
-						end, 0.5)
+						end
 						return
 					end
 
-					-- Auto-close after a short delay when complete
-					if current == total and total > 0 then
+					if not progressDialog then
+						progressDialog, updateProgress, closeDialog = createProgressDialog(window, function()
+							cancelToken.cancelled = true
+							activeLoadToken = nil
+						end)
+					end
+
+					updateProgress(current, total)
+
+					if current == total then
 						activeLoadToken = nil
 						WG.Delay(function()
 							closeDialog()
@@ -685,7 +663,7 @@ local function PopulatePresetPanel(parentPanel)
 						end, 0.5)
 					end
 				end
-				
+
 				applyPreset(selectedPresetName, updateWrapper, cancelToken)
 			end
 		},

--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -201,10 +201,15 @@ local function applyPreset(presetName, progressCallback, cancelToken)
 			if (multiplayer) then
 				local isBoss = battle.bossed
 				if isBoss and isBoss == true then
-					-- now apply the modoptions as the baseline
-					local combinedModoptions = multiplayerModoptions
+					-- Fresh-clone the initial snapshot each load, otherwise
+					-- successive preset loads would accumulate previous
+					-- presets' keys into multiplayerModoptions. After a
+					-- cancelled load that effectively re-queues the prior
+					-- preset's leftover keys on top of the new one, which
+					-- the user perceives as "the old batching continues".
+					local combinedModoptions = Spring.Utilities.CopyTable(multiplayerModoptions)
 					for key, value in pairs(currentModoptions) do
-						multiplayerModoptions[key] = value
+						combinedModoptions[key] = value
 					end
 					currentModoptions = combinedModoptions
 				else
@@ -218,37 +223,58 @@ local function applyPreset(presetName, progressCallback, cancelToken)
 	end
 end
 
+-- Center a Chili window inside the screen-sized lobbyInterfaceHolder. Done by
+-- explicit x/y (align="center" on Window:New only affects child layout, not
+-- the window's own position). Recomputes against current holder size so it
+-- stays centered after a window resize.
+local function CenterInHolder(child)
+	if not child then return end
+	local holder = WG.Chobby and WG.Chobby.lobbyInterfaceHolder
+	local hw = (holder and holder.width) or 0
+	local hh = (holder and holder.height) or 0
+	if hw <= 0 or hh <= 0 then
+		local ww, wh = Spring.GetWindowGeometry()
+		hw, hh = ww or 0, wh or 0
+	end
+	local cw = child.width or 0
+	local ch = child.height or 0
+	child:SetPos(
+		math.floor((hw - cw) / 2),
+		math.floor((hh - ch) / 2)
+	)
+end
+
 -- create a progress dialog for throttled loading
+--
+-- Parented to lobbyInterfaceHolder (matching ConfirmationPopup) rather than
+-- the preset window — that container is screen-sized so centering math is
+-- straightforward and unaffected by the preset window's chrome/padding.
 local function createProgressDialog(parentWindow, onCancel)
+	local dlgW, dlgH = 450, 190
+	local holder = (WG.Chobby and WG.Chobby.lobbyInterfaceHolder) or parentWindow
+
 	local dialogWindow = Window:New({
 		name = "presetLoadProgressDialog",
-		parent = parentWindow,
-		align = "center",
-		width = 450,
-		height = 190,
+		parent = holder,
+		width = dlgW,
+		height = dlgH,
 		resizable = false,
 		draggable = false,
 		classname = "main_window",
 	})
+	CenterInHolder(dialogWindow)
 
-	local progressLabel = Label:New({
-		x = 15,
-		y = 20,
-		right = 15,
-		height = 30,
-		align = "left",
-		autosize = false,
-		caption = "Loading settings...",
-		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-	})
-
+	-- Progressbar carries its own caption (matching WG.Chobby.Downloader and
+	-- gui_download_window.lua), so we avoid a separate label widget.
 	local progressBar = Progressbar:New({
 		x = 15,
-		y = 60,
+		y = 30,
 		right = 15,
-		height = 25,
+		height = 40,
 		value = 0,
 		max = 1,
+		caption = "Loading settings...",
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
 	})
 
 	local cancelButton = Button:New({
@@ -271,10 +297,31 @@ local function createProgressDialog(parentWindow, onCancel)
 		},
 	})
 
-	dialogWindow:AddChild(progressLabel)
 	dialogWindow:AddChild(progressBar)
 	dialogWindow:AddChild(cancelButton)
 	dialogWindow:BringToFront()
+
+	-- Re-center if the holder resizes (covers window resizes that reshape
+	-- the lobby container).
+	local recenter = function()
+		CenterInHolder(dialogWindow)
+	end
+	if holder then
+		holder.OnResize = holder.OnResize or {}
+		holder.OnResize[#holder.OnResize + 1] = recenter
+	end
+
+	-- The preset window owns the load lifecycle. If it disposes (user hits
+	-- the outer Cancel / closes the panel) make sure we don't leave the
+	-- progress dialog orphaned over the lobby UI.
+	if parentWindow then
+		parentWindow.OnDispose = parentWindow.OnDispose or {}
+		parentWindow.OnDispose[#parentWindow.OnDispose + 1] = function()
+			if dialogWindow and dialogWindow.parent then
+				dialogWindow:Dispose()
+			end
+		end
+	end
 
 	local updateProgress = function(current, total)
 		if not (dialogWindow and dialogWindow.parent) then
@@ -282,7 +329,7 @@ local function createProgressDialog(parentWindow, onCancel)
 		end
 		progressBar:SetMinMax(0, total)
 		progressBar:SetValue(current)
-		progressLabel:SetCaption("Loading settings... " .. current .. " / " .. total .. " batches")
+		progressBar:SetCaption("Loading settings... " .. current .. " / " .. total .. " batches")
 	end
 
 	local closeDialog = function()
@@ -292,6 +339,127 @@ local function createProgressDialog(parentWindow, onCancel)
 	end
 
 	return dialogWindow, updateProgress, closeDialog
+end
+
+-- Renderer adapters for throttled progress.
+--
+-- Both adapters return { cancelToken, progressCallback } and own all UI work
+-- (creation/teardown). They share the "≤1 batch silent" short-circuit so
+-- normal paste loads stay invisible.
+--
+-- onComplete fires once after the final batch (or immediately for 0/1-batch).
+-- onCancel  fires when the user cancels (via UI or cancelToken.cancelled).
+
+-- Popup adapter — lazily creates a centered dialog over parentWindow on the
+-- first multi-batch update and closes it 0.5s after the last batch.
+local function createPopupThrottleProgress(parentWindow, opts)
+	opts = opts or {}
+	local cancelToken = { cancelled = false }
+	local progressDialog, updateProgress, closeDialog
+
+	local progressCallback = function(current, total, cancelled)
+		if cancelled then
+			if opts.onCancel then opts.onCancel() end
+			return
+		end
+
+		if total <= 1 then
+			if current == total and opts.onComplete then
+				opts.onComplete()
+			end
+			return
+		end
+
+		if not progressDialog then
+			progressDialog, updateProgress, closeDialog = createProgressDialog(parentWindow, function()
+				cancelToken.cancelled = true
+				if opts.onCancel then opts.onCancel() end
+			end)
+		end
+
+		updateProgress(current, total)
+
+		if current == total then
+			WG.Delay(function()
+				if closeDialog then closeDialog() end
+				if opts.onComplete then opts.onComplete() end
+			end, 0.5)
+		end
+	end
+
+	return cancelToken, progressCallback
+end
+
+-- Inline adapter — drives WG.BattleRoomInlineProgress's slot in the battle
+-- room's leftInfo column. Falls back to silent execution if the inline
+-- progress API is not available (e.g. outside a battle room).
+local function createInlineThrottleProgress(opts)
+	opts = opts or {}
+	local cancelToken = { cancelled = false }
+	local shown = false
+
+	local progressCallback = function(current, total, cancelled)
+		if cancelled then
+			if shown and WG.BattleRoomInlineProgress then
+				WG.BattleRoomInlineProgress.Hide()
+			end
+			shown = false
+			if opts.onCancel then opts.onCancel() end
+			return
+		end
+
+		if total <= 1 then
+			if current == total and opts.onComplete then
+				opts.onComplete()
+			end
+			return
+		end
+
+		if not WG.BattleRoomInlineProgress then
+			-- No inline slot available (not in a battleroom). Stay silent.
+			if current == total and opts.onComplete then
+				opts.onComplete()
+			end
+			return
+		end
+
+		if not shown then
+			WG.BattleRoomInlineProgress.Show({
+				onCancel = function()
+					cancelToken.cancelled = true
+					if shown and WG.BattleRoomInlineProgress then
+						WG.BattleRoomInlineProgress.Hide()
+					end
+					shown = false
+					if opts.onCancel then opts.onCancel() end
+				end,
+			})
+			shown = true
+		end
+
+		WG.BattleRoomInlineProgress.Update(current, total)
+
+		if current == total then
+			WG.Delay(function()
+				if shown and WG.BattleRoomInlineProgress then
+					WG.BattleRoomInlineProgress.Hide()
+				end
+				shown = false
+				if opts.onComplete then opts.onComplete() end
+			end, 0.5)
+		end
+	end
+
+	return cancelToken, progressCallback
+end
+
+-- Backwards-compatible wrapper retained as an internal alias for the popup
+-- adapter; callers in this file still use this name.
+local function buildThrottledProgressCallback(parentWindow, onComplete, onCancel)
+	return createPopupThrottleProgress(parentWindow, {
+		onComplete = onComplete,
+		onCancel = onCancel,
+	})
 end
 
 -- apply modoptions with throttling and progress feedback
@@ -620,51 +788,25 @@ local function PopulatePresetPanel(parentPanel)
 				if (selectedPresetName == nil or selectedPresetName == placeHolder or selectedPresetName == "<new>") then
 					return
 				end
-				
-				local cancelToken = { cancelled = false }
-				activeLoadToken = cancelToken
-				local progressDialog, updateProgress, closeDialog
 
-				local updateWrapper = function(current, total, cancelled)
-					if cancelled then
-						activeLoadToken = nil
-						return
+				local finishAndClose = function()
+					activeLoadToken = nil
+					if window and window.parent then
+						window:Dispose()
 					end
-
-					-- Single- or zero-batch loads finish instantly; skip the dialog
-					-- and just close the preset window like the non-throttled path did.
-					if total <= 1 then
-						if current == total then
-							activeLoadToken = nil
-							window:Dispose()
-							if WG.BattleRoomChatInput then
-								screen0:FocusControl(WG.BattleRoomChatInput)
-							end
-						end
-						return
-					end
-
-					if not progressDialog then
-						progressDialog, updateProgress, closeDialog = createProgressDialog(window, function()
-							cancelToken.cancelled = true
-							activeLoadToken = nil
-						end)
-					end
-
-					updateProgress(current, total)
-
-					if current == total then
-						activeLoadToken = nil
-						WG.Delay(function()
-							closeDialog()
-							if WG.BattleRoomChatInput then
-								screen0:FocusControl(WG.BattleRoomChatInput)
-							end
-						end, 0.5)
+					if WG.BattleRoomChatInput then
+						screen0:FocusControl(WG.BattleRoomChatInput)
 					end
 				end
 
-				applyPreset(selectedPresetName, updateWrapper, cancelToken)
+				local cancelToken, progressCallback = buildThrottledProgressCallback(
+					window,
+					finishAndClose,
+					function() activeLoadToken = nil end
+				)
+				activeLoadToken = cancelToken
+
+				applyPreset(selectedPresetName, progressCallback, cancelToken)
 			end
 		},
 	}
@@ -958,11 +1100,53 @@ function OptionpresetsPanel.ShowPresetPanel()
 	CreateOptionpresetWindow()
 end
 
+-- Send an ordered list of battleroom chat lines through the throttled queue
+-- with renderer-driven progress feedback. Skips any UI entirely if the
+-- payload fits in one batch (typical normal use).
+--
+-- lines:        array of strings (each a SayBattle line, e.g. "!preset foo" or "!bSet x y")
+-- parentWindow: parent for the popup dialog when renderer == "popup" (ignored for "inline")
+-- opts (optional):
+--   renderer    = "popup" (default) | "inline"
+--   onComplete  = func, onCancel = func
+-- Returns: cancelToken (callers can imperatively flip cancelToken.cancelled)
+local function runThrottledBattleSend(lines, parentWindow, opts)
+	opts = opts or {}
+	local lobby = WG.LibLobby and (WG.LibLobby.lobby or WG.LibLobby.localLobby)
+	if not lobby or not lobby.SayBattleThrottled then
+		return nil
+	end
+
+	local cancelToken, progressCallback
+	if opts.renderer == "inline" then
+		cancelToken, progressCallback = createInlineThrottleProgress({
+			onComplete = opts.onComplete,
+			onCancel = opts.onCancel,
+		})
+	else
+		cancelToken, progressCallback = createPopupThrottleProgress(parentWindow, {
+			onComplete = opts.onComplete,
+			onCancel = opts.onCancel,
+		})
+	end
+
+	lobby:SayBattleThrottled(lines, nil, nil, progressCallback, cancelToken)
+	return cancelToken
+end
+
 -- make the widget accessible from the preset Panel
 function widget:Initialize()
 	CHOBBY_DIR = LUA_DIRNAME .. "widgets/chobby/"
 	VFS.Include(LUA_DIRNAME .. "widgets/chobby/headers/exports.lua", nil, VFS.RAW_FIRST)
 
-	-- clone multiplayer options, if they are defined
+	-- Compatibility alias on the presets panel for callers that already wired
+	-- against it; the canonical entry point is WG.ThrottledBattleSend.Run.
+	OptionpresetsPanel.RunThrottledBattleSend = runThrottledBattleSend
 	WG.OptionpresetsPanel = OptionpresetsPanel
+
+	-- Neutral namespace for chat-paste / generic callers — the throttled
+	-- sender is no longer semantically tied to presets.
+	WG.ThrottledBattleSend = {
+		Run = runThrottledBattleSend,
+	}
 end

--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -51,6 +51,9 @@ local selectedPresetName = placeHolder;
 -- preset that is currently applied
 local appliedPresetName  = placeHolder;
 
+-- active throttled preset load, used to cancel delayed batches when closing UI
+local activeLoadToken
+
 -- defining function to later overwrite
 local refreshPresetMenu  = function()
 end
@@ -117,7 +120,7 @@ local function saveJSONData()
 end
 
 -- apply specific preset to the current Lobby
-local function applyPreset(presetName)
+local function applyPreset(presetName, progressCallback, cancelToken)
 	appliedPresetName = presetName
 
 	local presetObj = jsondata[presetName]
@@ -209,8 +212,130 @@ local function applyPreset(presetName)
 					return
 				end
 			end
-			battleLobby:SetModOptions(currentModoptions)
+			-- Use throttled loading with optional progress callback
+			if progressCallback then
+				battleLobby:SetModOptionsThrottled(currentModoptions, 20000, 5, progressCallback, cancelToken)
+			else
+				battleLobby:SetModOptionsThrottled(currentModoptions, 20000, 5, nil, cancelToken)
+			end
 		end
+	end
+end
+
+-- create a progress dialog for throttled loading
+local function createProgressDialog(parentWindow, title, onCancel)
+	local dialogWindow = Window:New {
+		caption = title or "Loading",
+		name = "presetLoadProgressDialog",
+		parent = parentWindow,
+		align = "center",
+		width = 450,
+		height = 180,
+		resizable = false,
+		draggable = false,
+		classname = "main_window",
+	}
+
+	-- Progress label
+	local progressLabel = Label:New {
+		x = 15,
+		y = 15,
+		right = 15,
+		height = 30,
+		align = "left",
+		caption = "Loading settings...",
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
+	}
+
+	-- Progress bar
+	local progressBar = Progressbar:New {
+		x = 15,
+		y = 50,
+		right = 15,
+		height = 25,
+		value = 0,
+		max = 1,
+	}
+
+	-- Status text
+	local statusLabel = Label:New {
+		x = 15,
+		y = 80,
+		right = 15,
+		height = 30,
+		align = "center",
+		caption = "0 / 0 batches",
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
+	}
+
+	local cancelButton = Button:New {
+		right = 15,
+		width = 135,
+		bottom = 12,
+		height = 45,
+		caption = i18n("cancel"),
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
+		classname = "negative_button",
+		OnClick = {
+			function()
+				if onCancel then
+					onCancel()
+				end
+				if dialogWindow and dialogWindow.parent then
+					dialogWindow:Dispose()
+				end
+			end
+		},
+	}
+
+	dialogWindow:AddChild(progressLabel)
+	dialogWindow:AddChild(progressBar)
+	dialogWindow:AddChild(statusLabel)
+	dialogWindow:AddChild(cancelButton)
+	dialogWindow:BringToFront()
+
+	local updateProgress = function(current, total)
+		if not (dialogWindow and dialogWindow.parent) then
+			return
+		end
+
+		if total > 0 then
+			progressBar:SetMinMax(0, total)
+			progressBar:SetValue(current)
+			statusLabel:SetCaption(current .. " / " .. total .. " batches")
+		else
+			progressLabel:SetCaption("No changes needed")
+			progressBar:SetValue(0)
+			statusLabel:SetCaption("0 / 0 batches")
+		end
+	end
+
+	local closeDialog = function()
+		if dialogWindow and dialogWindow.parent then
+			dialogWindow:Dispose()
+		end
+	end
+
+	return dialogWindow, updateProgress, closeDialog
+end
+
+-- apply modoptions with throttling and progress feedback
+local function applyPresetThrottled(modoptions, progressCallback, cancelToken)
+	if not battleLobby then
+		return false, "No battle lobby available"
+	end
+	
+	-- Check if throttled method exists
+	if battleLobby.SetModOptionsThrottled then
+		battleLobby:SetModOptionsThrottled(modoptions, 20000, 5, progressCallback, cancelToken)
+		return true
+	else
+		-- Fallback to regular method
+		battleLobby:SetModOptions(modoptions)
+		if progressCallback then
+			progressCallback(1, 1)
+		end
+		return true
 	end
 end
 
@@ -520,11 +645,46 @@ local function PopulatePresetPanel(parentPanel)
 				if (selectedPresetName == nil or selectedPresetName == placeHolder or selectedPresetName == "<new>") then
 					return
 				end
-				applyPreset(selectedPresetName)
-				window:Dispose()
-				if WG.BattleRoomChatInput then
-					screen0:FocusControl(WG.BattleRoomChatInput)
+				
+				local cancelToken = { cancelled = false }
+				activeLoadToken = cancelToken
+				local progressDialog, updateProgress, closeDialog = createProgressDialog(window, "Loading Preset", function()
+					cancelToken.cancelled = true
+					activeLoadToken = nil
+				end)
+				
+				-- Apply preset with progress tracking
+				local updateWrapper = function(current, total, cancelled)
+					updateProgress(current, total)
+					if cancelled then
+						activeLoadToken = nil
+						return
+					end
+
+					if total == 0 then
+						activeLoadToken = nil
+						WG.Delay(function()
+							closeDialog()
+							if WG.BattleRoomChatInput then
+								screen0:FocusControl(WG.BattleRoomChatInput)
+							end
+						end, 0.5)
+						return
+					end
+
+					-- Auto-close after a short delay when complete
+					if current == total and total > 0 then
+						activeLoadToken = nil
+						WG.Delay(function()
+							closeDialog()
+							if WG.BattleRoomChatInput then
+								screen0:FocusControl(WG.BattleRoomChatInput)
+							end
+						end, 0.5)
+					end
 				end
+				
+				applyPreset(selectedPresetName, updateWrapper, cancelToken)
 			end
 		},
 	}
@@ -566,7 +726,7 @@ local function PopulatePresetPanel(parentPanel)
 
 	-- overload the writeError function
 	writeError = function(errorM)
-		errorLabel.caption = errorM
+		errorLabel:SetCaption(errorM)
 	end
 
 	refreshPresetMenu()
@@ -681,6 +841,10 @@ local function CreateOptionpresetWindow()
 		OnClick = {
 			function()
 				-- CancelFunc()
+				if activeLoadToken then
+					activeLoadToken.cancelled = true
+					activeLoadToken = nil
+				end
 				window:Dispose()
 				if WG.BattleRoomChatInput then
 					screen0:FocusControl(WG.BattleRoomChatInput)
@@ -708,6 +872,10 @@ local function CreateOptionpresetWindow()
 	end
 
 	local function CancelFunc()
+		if activeLoadToken then
+			activeLoadToken.cancelled = true
+			activeLoadToken = nil
+		end
 		window:Dispose()
 		if WG.BattleRoomChatInput then
 			screen0:FocusControl(WG.BattleRoomChatInput)

--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -201,12 +201,7 @@ local function applyPreset(presetName, progressCallback, cancelToken)
 			if (multiplayer) then
 				local isBoss = battle.bossed
 				if isBoss and isBoss == true then
-					-- Fresh-clone the initial snapshot each load, otherwise
-					-- successive preset loads would accumulate previous
-					-- presets' keys into multiplayerModoptions. After a
-					-- cancelled load that effectively re-queues the prior
-					-- preset's leftover keys on top of the new one, which
-					-- the user perceives as "the old batching continues".
+					-- Clone baseline each load (don't mutate multiplayerModoptions in place).
 					local combinedModoptions = Spring.Utilities.CopyTable(multiplayerModoptions)
 					for key, value in pairs(currentModoptions) do
 						combinedModoptions[key] = value
@@ -217,16 +212,12 @@ local function applyPreset(presetName, progressCallback, cancelToken)
 					return
 				end
 			end
-			-- Use throttled loading; batch size and interval defaults live in interface.lua
 			battleLobby:SetModOptionsThrottled(currentModoptions, nil, nil, progressCallback, cancelToken)
 		end
 	end
 end
 
--- Center a Chili window inside the screen-sized lobbyInterfaceHolder. Done by
--- explicit x/y (align="center" on Window:New only affects child layout, not
--- the window's own position). Recomputes against current holder size so it
--- stays centered after a window resize.
+-- Center in lobbyInterfaceHolder (explicit x/y; Window.align is not window position).
 local function CenterInHolder(child)
 	if not child then return end
 	local holder = WG.Chobby and WG.Chobby.lobbyInterfaceHolder
@@ -244,11 +235,7 @@ local function CenterInHolder(child)
 	)
 end
 
--- create a progress dialog for throttled loading
---
--- Parented to lobbyInterfaceHolder (matching ConfirmationPopup) rather than
--- the preset window — that container is screen-sized so centering math is
--- straightforward and unaffected by the preset window's chrome/padding.
+-- Throttle progress dialog; parent lobbyInterfaceHolder (cf. ConfirmationPopup).
 local function createProgressDialog(parentWindow, onCancel)
 	local dlgW, dlgH = 450, 190
 	local holder = (WG.Chobby and WG.Chobby.lobbyInterfaceHolder) or parentWindow
@@ -264,8 +251,6 @@ local function createProgressDialog(parentWindow, onCancel)
 	})
 	CenterInHolder(dialogWindow)
 
-	-- Progressbar carries its own caption (matching WG.Chobby.Downloader and
-	-- gui_download_window.lua), so we avoid a separate label widget.
 	local progressBar = Progressbar:New({
 		x = 15,
 		y = 30,
@@ -301,8 +286,6 @@ local function createProgressDialog(parentWindow, onCancel)
 	dialogWindow:AddChild(cancelButton)
 	dialogWindow:BringToFront()
 
-	-- Re-center if the holder resizes (covers window resizes that reshape
-	-- the lobby container).
 	local recenter = function()
 		CenterInHolder(dialogWindow)
 	end
@@ -311,9 +294,6 @@ local function createProgressDialog(parentWindow, onCancel)
 		holder.OnResize[#holder.OnResize + 1] = recenter
 	end
 
-	-- The preset window owns the load lifecycle. If it disposes (user hits
-	-- the outer Cancel / closes the panel) make sure we don't leave the
-	-- progress dialog orphaned over the lobby UI.
 	if parentWindow then
 		parentWindow.OnDispose = parentWindow.OnDispose or {}
 		parentWindow.OnDispose[#parentWindow.OnDispose + 1] = function()
@@ -341,17 +321,7 @@ local function createProgressDialog(parentWindow, onCancel)
 	return dialogWindow, updateProgress, closeDialog
 end
 
--- Renderer adapters for throttled progress.
---
--- Both adapters return { cancelToken, progressCallback } and own all UI work
--- (creation/teardown). They share the "≤1 batch silent" short-circuit so
--- normal paste loads stay invisible.
---
--- onComplete fires once after the final batch (or immediately for 0/1-batch).
--- onCancel  fires when the user cancels (via UI or cancelToken.cancelled).
-
--- Popup adapter — lazily creates a centered dialog over parentWindow on the
--- first multi-batch update and closes it 0.5s after the last batch.
+-- Throttle progress: popup vs inline; no UI when total<=1. Popup opens on first multi-batch.
 local function createPopupThrottleProgress(parentWindow, opts)
 	opts = opts or {}
 	local cancelToken = { cancelled = false }
@@ -390,9 +360,6 @@ local function createPopupThrottleProgress(parentWindow, opts)
 	return cancelToken, progressCallback
 end
 
--- Inline adapter — drives WG.BattleRoomInlineProgress's slot in the battle
--- room's leftInfo column. Falls back to silent execution if the inline
--- progress API is not available (e.g. outside a battle room).
 local function createInlineThrottleProgress(opts)
 	opts = opts or {}
 	local cancelToken = { cancelled = false }
@@ -416,7 +383,6 @@ local function createInlineThrottleProgress(opts)
 		end
 
 		if not WG.BattleRoomInlineProgress then
-			-- No inline slot available (not in a battleroom). Stay silent.
 			if current == total and opts.onComplete then
 				opts.onComplete()
 			end
@@ -453,8 +419,6 @@ local function createInlineThrottleProgress(opts)
 	return cancelToken, progressCallback
 end
 
--- Backwards-compatible wrapper retained as an internal alias for the popup
--- adapter; callers in this file still use this name.
 local function buildThrottledProgressCallback(parentWindow, onComplete, onCancel)
 	return createPopupThrottleProgress(parentWindow, {
 		onComplete = onComplete,
@@ -1100,16 +1064,7 @@ function OptionpresetsPanel.ShowPresetPanel()
 	CreateOptionpresetWindow()
 end
 
--- Send an ordered list of battleroom chat lines through the throttled queue
--- with renderer-driven progress feedback. Skips any UI entirely if the
--- payload fits in one batch (typical normal use).
---
--- lines:        array of strings (each a SayBattle line, e.g. "!preset foo" or "!bSet x y")
--- parentWindow: parent for the popup dialog when renderer == "popup" (ignored for "inline")
--- opts (optional):
---   renderer    = "popup" (default) | "inline"
---   onComplete  = func, onCancel = func
--- Returns: cancelToken (callers can imperatively flip cancelToken.cancelled)
+-- SayBattleThrottled wrapper; opts.renderer "popup"|"inline"; returns cancelToken.
 local function runThrottledBattleSend(lines, parentWindow, opts)
 	opts = opts or {}
 	local lobby = WG.LibLobby and (WG.LibLobby.lobby or WG.LibLobby.localLobby)
@@ -1139,13 +1094,9 @@ function widget:Initialize()
 	CHOBBY_DIR = LUA_DIRNAME .. "widgets/chobby/"
 	VFS.Include(LUA_DIRNAME .. "widgets/chobby/headers/exports.lua", nil, VFS.RAW_FIRST)
 
-	-- Compatibility alias on the presets panel for callers that already wired
-	-- against it; the canonical entry point is WG.ThrottledBattleSend.Run.
 	OptionpresetsPanel.RunThrottledBattleSend = runThrottledBattleSend
 	WG.OptionpresetsPanel = OptionpresetsPanel
 
-	-- Neutral namespace for chat-paste / generic callers — the throttled
-	-- sender is no longer semantically tied to presets.
 	WG.ThrottledBattleSend = {
 		Run = runThrottledBattleSend,
 	}

--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -1094,7 +1094,6 @@ function widget:Initialize()
 	CHOBBY_DIR = LUA_DIRNAME .. "widgets/chobby/"
 	VFS.Include(LUA_DIRNAME .. "widgets/chobby/headers/exports.lua", nil, VFS.RAW_FIRST)
 
-	OptionpresetsPanel.RunThrottledBattleSend = runThrottledBattleSend
 	WG.OptionpresetsPanel = OptionpresetsPanel
 
 	WG.ThrottledBattleSend = {

--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -256,6 +256,33 @@ local function createProgressDialog(parentWindow, onCancel)
 	local dlgW, dlgH = 450, 190
 	local holder = (WG.Chobby and WG.Chobby.lobbyInterfaceHolder) or parentWindow
 
+	local progressCaptionFull = "Loading settings..."
+
+	local function applyProgressCaption()
+		if not (progressBar and progressBar.parent) then
+			return
+		end
+		local dw = dialogWindow.width or 0
+		local barInner = math.max(0, (progressBar.width or 0) - 16)
+		local Configuration = WG.Chobby.Configuration
+		local font
+		if dw >= 420 then
+			font = Configuration:GetFont(2)
+		elseif dw >= 340 then
+			font = Configuration:GetFont(13, "preset_prog_m", {outline = false, shadow = true}, true)
+		else
+			font = Configuration:GetFont(11, "preset_prog_s", {outline = false, shadow = true}, true)
+		end
+		if progressBar.font ~= font then
+			progressBar.font = font
+		end
+		local cap = progressCaptionFull
+		if barInner > 0 then
+			cap = StringUtilities.GetTruncatedStringWithDotDot(cap, progressBar.font, barInner)
+		end
+		progressBar:SetCaption(cap)
+	end
+
 	local dialogWindow = Window:New({
 		name = "presetLoadProgressDialog",
 		parent = holder,
@@ -302,6 +329,14 @@ local function createProgressDialog(parentWindow, onCancel)
 	dialogWindow:AddChild(cancelButton)
 	dialogWindow:BringToFront()
 
+	dialogWindow.OnResize = dialogWindow.OnResize or {}
+	dialogWindow.OnResize[#dialogWindow.OnResize + 1] = function()
+		applyProgressCaption()
+		WG.Delay(applyProgressCaption, 0.02)
+	end
+	applyProgressCaption()
+	WG.Delay(applyProgressCaption, 0.02)
+
 	local recenter = function()
 		CenterInHolder(dialogWindow)
 	end
@@ -325,7 +360,9 @@ local function createProgressDialog(parentWindow, onCancel)
 		end
 		progressBar:SetMinMax(0, total)
 		progressBar:SetValue(current)
-		progressBar:SetCaption("Loading settings... " .. current .. " / " .. total .. " batches")
+		progressCaptionFull = "Loading settings... " .. current .. " / " .. total .. " batches"
+		applyProgressCaption()
+		WG.Delay(applyProgressCaption, 0.02)
 	end
 
 	local closeDialog = function()

--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -119,6 +119,22 @@ local function saveJSONData()
 	modfile:close()
 end
 
+local function applyPresetThrottled(modoptions, progressCallback, cancelToken)
+	if not battleLobby then
+		return false, "No battle lobby available"
+	end
+	-- Skirmish: SetModOptions only. Online: SetModOptionsThrottled (don't gate on lobby.SetModOptionsThrottled — LCS dot lookup can miss methods).
+	if battleLobby.name == "singleplayer" then
+		battleLobby:SetModOptions(modoptions)
+		if progressCallback then
+			progressCallback(1, 1)
+		end
+		return true
+	end
+	battleLobby:SetModOptionsThrottled(modoptions, nil, nil, progressCallback, cancelToken)
+	return true
+end
+
 -- apply specific preset to the current Lobby
 local function applyPreset(presetName, progressCallback, cancelToken)
 	appliedPresetName = presetName
@@ -212,7 +228,7 @@ local function applyPreset(presetName, progressCallback, cancelToken)
 					return
 				end
 			end
-			battleLobby:SetModOptionsThrottled(currentModoptions, nil, nil, progressCallback, cancelToken)
+			applyPresetThrottled(currentModoptions, progressCallback, cancelToken)
 		end
 	end
 end
@@ -424,26 +440,6 @@ local function buildThrottledProgressCallback(parentWindow, onComplete, onCancel
 		onComplete = onComplete,
 		onCancel = onCancel,
 	})
-end
-
--- apply modoptions with throttling and progress feedback
-local function applyPresetThrottled(modoptions, progressCallback, cancelToken)
-	if not battleLobby then
-		return false, "No battle lobby available"
-	end
-	
-	-- Check if throttled method exists
-	if battleLobby.SetModOptionsThrottled then
-		battleLobby:SetModOptionsThrottled(modoptions, nil, nil, progressCallback, cancelToken)
-		return true
-	else
-		-- Fallback to regular method
-		battleLobby:SetModOptions(modoptions)
-		if progressCallback then
-			progressCallback(1, 1)
-		end
-		return true
-	end
 end
 
 -- deletes a preset by name
@@ -1002,22 +998,24 @@ end
 -- clones the multiplayer modoptions to have a reset point that can be used when applying reset value
 function OptionpresetsPanel.cloneMPModoptions(force)
 	if multiplayerModoptions == nil or force then
-		battleLobby = WG.LibLobby.localLobby
 		multiplayerModoptions = Spring.Utilities.CopyTable(battleLobby:GetMyBattleModoptions() or {})
 	end
 end
 
 -- external function to open the preset Panel
 function OptionpresetsPanel.ShowPresetPanel()
-	battleLobby = WG.LibLobby.localLobby
-	battle = battleLobby:GetBattle(battleLobby:GetMyBattleID())
+	local mpLobby = WG.LibLobby and WG.LibLobby.lobby
+	local spLobby = WG.LibLobby and WG.LibLobby.localLobby
+	local mpBattle = mpLobby and mpLobby:GetBattle(mpLobby:GetMyBattleID())
+	local spBattle = spLobby and spLobby:GetBattle(spLobby:GetMyBattleID())
 
-	-- multiplayer case, battle/ lobby are the WG.LibLobby.lobby
-	if not battle then
-		battleLobby = WG.LibLobby.lobby
-		battle = battleLobby:GetBattle(battleLobby:GetMyBattleID())
+	if mpBattle then
+		battleLobby = mpLobby
+		battle = mpBattle
 		multiplayer = true
 	else
+		battleLobby = spLobby
+		battle = spBattle
 		multiplayer = false
 	end
 
@@ -1067,8 +1065,9 @@ end
 -- SayBattleThrottled wrapper; opts.renderer "popup"|"inline"; returns cancelToken.
 local function runThrottledBattleSend(lines, parentWindow, opts)
 	opts = opts or {}
-	local lobby = WG.LibLobby and (WG.LibLobby.lobby or WG.LibLobby.localLobby)
-	if not lobby or not lobby.SayBattleThrottled then
+	local mpLobby = WG.LibLobby and WG.LibLobby.lobby
+	local lobby = mpLobby and mpLobby:GetBattle(mpLobby:GetMyBattleID()) and mpLobby or nil
+	if not lobby then
 		return nil
 	end
 

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -518,14 +518,14 @@ end
 
 -- Throttled version for large preset loading - prevents rate limit kicks
 -- maxCharsPerBatch: maximum characters to batch before delay (default 20000)
--- intervalSeconds: delay between batches in seconds (default 5)
+-- intervalSeconds: delay between batches in seconds (default 4)
 -- progressCallback: optional function(current, total, cancelled) called for each batch sent
 -- cancelToken: optional table with a `cancelled` field; set it to true to stop remaining batches
 function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSeconds, progressCallback, cancelToken)
 	maxCharsPerBatch = maxCharsPerBatch or 20000
-	intervalSeconds = intervalSeconds or 5
+	intervalSeconds = intervalSeconds or 4
 	cancelToken = cancelToken or {}
-	
+
 	-- Build list of commands to send
 	local commands = {}
 	for k, v in pairs(data) do
@@ -533,19 +533,19 @@ function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSecond
 			table.insert(commands, "!bSet " .. tostring(k) .. " " .. tostring(v))
 		end
 	end
-	
+
 	if #commands == 0 then
 		if progressCallback then
 			progressCallback(0, 0)
 		end
 		return self
 	end
-	
+
 	-- Batch commands by character size
 	local batches = {}
 	local currentBatch = {}
 	local currentSize = 0
-	
+
 	for _, cmd in ipairs(commands) do
 		local cmdSize = #cmd + 1 -- +1 for newline
 		if currentSize + cmdSize > maxCharsPerBatch and #currentBatch > 0 then
@@ -559,12 +559,12 @@ function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSecond
 	if #currentBatch > 0 then
 		table.insert(batches, currentBatch)
 	end
-	
+
 	-- Send batches with throttling
 	local totalBatches = #batches
 	local batchIndex = 0
 	local sendNextBatch
-	
+
 	sendNextBatch = function()
 		if cancelToken.cancelled then
 			if progressCallback then
@@ -580,21 +580,21 @@ function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSecond
 			end
 			return
 		end
-		
+
 		local batch = batches[batchIndex]
 		for _, cmd in ipairs(batch) do
 			self:SayBattle(cmd)
 		end
-		
+
 		if progressCallback then
 			progressCallback(batchIndex, totalBatches)
 		end
-		
+
 		if batchIndex < totalBatches then
 			WG.Delay(sendNextBatch, intervalSeconds)
 		end
 	end
-	
+
 	sendNextBatch()
 	return self
 end

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -2244,11 +2244,7 @@ function Interface:_OnSetScriptTags(tagsTxt)
 	for _, tag in pairs(tags) do
 		if string_starts(tag, mod_opts_pre) then
 			local kv = tag:sub(mod_opts_pre_indx)
-			-- Split on the FIRST '=' only. Using explode("=", ...) here
-			-- silently truncated values that themselves contain '=' (e.g.
-			-- base64-padded tweakdefs blobs, or any Lua expression with
-			-- assignment operators), which made the local modoptions cache
-			-- diverge from SPADS' authoritative state.
+			-- Should only split on the FIRST '='. Base64url encoded tweak values may contain '=' as padding
 			local eqPos = kv:find("=", 1, true)
 			local k, v
 			if eqPos then

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -516,29 +516,16 @@ function Interface:SetModOptions(data)
 	return self
 end
 
--- Throttling defaults shared by SayBattleThrottled / SetModOptionsThrottled.
--- Tuned to stay under SPADS' chat rate limit so large preset/tweak loads don't
--- get the user kicked. Public on the class so UI code can read the threshold
--- (e.g. to decide whether a paste is large enough to intercept).
+-- SPADS chat throttle; THROTTLED_SAY_MAX_CHARS_PER_BATCH also gates oversized paste.
 Interface.THROTTLED_SAY_MAX_CHARS_PER_BATCH = 20000
 Interface.THROTTLED_SAY_INTERVAL_SECONDS = 4
 
--- Send an ordered list of battleroom chat lines, batched by character size,
--- with a delay between batches. Each line is sent via self:SayBattle.
--- lines:           array of strings (preserved in order)
--- maxCharsPerBatch: optional, defaults to THROTTLED_SAY_MAX_CHARS_PER_BATCH
--- intervalSeconds:  optional, defaults to THROTTLED_SAY_INTERVAL_SECONDS
--- progressCallback: optional function(current, total, cancelled) called per batch
--- cancelToken:      optional table; set its `cancelled` field to stop further batches
+-- Batch SayBattle lines by size; delay between batches; cancelToken.cancelled stops pending sends.
 function Interface:SayBattleThrottled(lines, maxCharsPerBatch, intervalSeconds, progressCallback, cancelToken)
 	maxCharsPerBatch = maxCharsPerBatch or Interface.THROTTLED_SAY_MAX_CHARS_PER_BATCH
 	intervalSeconds = intervalSeconds or Interface.THROTTLED_SAY_INTERVAL_SECONDS
 	cancelToken = cancelToken or {}
 
-	-- Defensive: if a previous throttled queue is still running, force-cancel
-	-- it before scheduling a new one. Without this, a freshly-started load
-	-- would race against the prior load's still-pending WG.Delay tick (the
-	-- old queue's user-driven cancellation may not yet have fired).
 	if self._activeThrottleToken and self._activeThrottleToken ~= cancelToken then
 		self._activeThrottleToken.cancelled = true
 	end
@@ -551,7 +538,6 @@ function Interface:SayBattleThrottled(lines, maxCharsPerBatch, intervalSeconds, 
 		return self
 	end
 
-	-- Batch by total character size (lines preserved in input order)
 	local batches = {}
 	local currentBatch = {}
 	local currentSize = 0
@@ -576,9 +562,6 @@ function Interface:SayBattleThrottled(lines, maxCharsPerBatch, intervalSeconds, 
 
 	sendNextBatch = function()
 		if cancelToken.cancelled then
-			-- Drop any remaining batches and clear the active-throttle ref
-			-- if it still points at us. Subsequent stale ticks (if any)
-			-- will exit on the cancelled check above.
 			batches = {}
 			batchIndex = totalBatches
 			if self._activeThrottleToken == cancelToken then
@@ -623,8 +606,6 @@ function Interface:SayBattleThrottled(lines, maxCharsPerBatch, intervalSeconds, 
 	return self
 end
 
--- Throttled SetModOptions for large preset loads. Diffs against the current
--- modoptions, builds !bSet lines, and routes them through SayBattleThrottled.
 function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSeconds, progressCallback, cancelToken)
 	local lines = {}
 	for k, v in pairs(data) do
@@ -2244,7 +2225,7 @@ function Interface:_OnSetScriptTags(tagsTxt)
 	for _, tag in pairs(tags) do
 		if string_starts(tag, mod_opts_pre) then
 			local kv = tag:sub(mod_opts_pre_indx)
-			-- Should only split on the FIRST '='. Base64url encoded tweak values may contain '=' as padding
+			-- Split on first '=' only; values may contain '=' (e.g. base64 padding).
 			local eqPos = kv:find("=", 1, true)
 			local k, v
 			if eqPos then

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -516,57 +516,74 @@ function Interface:SetModOptions(data)
 	return self
 end
 
--- Throttled version for large preset loading - prevents rate limit kicks
--- maxCharsPerBatch: maximum characters to batch before delay (default 20000)
--- intervalSeconds: delay between batches in seconds (default 4)
--- progressCallback: optional function(current, total, cancelled) called for each batch sent
--- cancelToken: optional table with a `cancelled` field; set it to true to stop remaining batches
-function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSeconds, progressCallback, cancelToken)
-	maxCharsPerBatch = maxCharsPerBatch or 20000
-	intervalSeconds = intervalSeconds or 4
+-- Throttling defaults shared by SayBattleThrottled / SetModOptionsThrottled.
+-- Tuned to stay under SPADS' chat rate limit so large preset/tweak loads don't
+-- get the user kicked. Public on the class so UI code can read the threshold
+-- (e.g. to decide whether a paste is large enough to intercept).
+Interface.THROTTLED_SAY_MAX_CHARS_PER_BATCH = 20000
+Interface.THROTTLED_SAY_INTERVAL_SECONDS = 4
+
+-- Send an ordered list of battleroom chat lines, batched by character size,
+-- with a delay between batches. Each line is sent via self:SayBattle.
+-- lines:           array of strings (preserved in order)
+-- maxCharsPerBatch: optional, defaults to THROTTLED_SAY_MAX_CHARS_PER_BATCH
+-- intervalSeconds:  optional, defaults to THROTTLED_SAY_INTERVAL_SECONDS
+-- progressCallback: optional function(current, total, cancelled) called per batch
+-- cancelToken:      optional table; set its `cancelled` field to stop further batches
+function Interface:SayBattleThrottled(lines, maxCharsPerBatch, intervalSeconds, progressCallback, cancelToken)
+	maxCharsPerBatch = maxCharsPerBatch or Interface.THROTTLED_SAY_MAX_CHARS_PER_BATCH
+	intervalSeconds = intervalSeconds or Interface.THROTTLED_SAY_INTERVAL_SECONDS
 	cancelToken = cancelToken or {}
 
-	-- Build list of commands to send
-	local commands = {}
-	for k, v in pairs(data) do
-		if self.modoptions[k] ~= v then
-			table.insert(commands, "!bSet " .. tostring(k) .. " " .. tostring(v))
-		end
+	-- Defensive: if a previous throttled queue is still running, force-cancel
+	-- it before scheduling a new one. Without this, a freshly-started load
+	-- would race against the prior load's still-pending WG.Delay tick (the
+	-- old queue's user-driven cancellation may not yet have fired).
+	if self._activeThrottleToken and self._activeThrottleToken ~= cancelToken then
+		self._activeThrottleToken.cancelled = true
 	end
+	self._activeThrottleToken = cancelToken
 
-	if #commands == 0 then
+	if not lines or #lines == 0 then
 		if progressCallback then
 			progressCallback(0, 0)
 		end
 		return self
 	end
 
-	-- Batch commands by character size
+	-- Batch by total character size (lines preserved in input order)
 	local batches = {}
 	local currentBatch = {}
 	local currentSize = 0
 
-	for _, cmd in ipairs(commands) do
-		local cmdSize = #cmd + 1 -- +1 for newline
-		if currentSize + cmdSize > maxCharsPerBatch and #currentBatch > 0 then
+	for _, line in ipairs(lines) do
+		local lineSize = #line + 1 -- +1 for newline
+		if currentSize + lineSize > maxCharsPerBatch and #currentBatch > 0 then
 			table.insert(batches, currentBatch)
 			currentBatch = {}
 			currentSize = 0
 		end
-		table.insert(currentBatch, cmd)
-		currentSize = currentSize + cmdSize
+		table.insert(currentBatch, line)
+		currentSize = currentSize + lineSize
 	end
 	if #currentBatch > 0 then
 		table.insert(batches, currentBatch)
 	end
 
-	-- Send batches with throttling
 	local totalBatches = #batches
 	local batchIndex = 0
 	local sendNextBatch
 
 	sendNextBatch = function()
 		if cancelToken.cancelled then
+			-- Drop any remaining batches and clear the active-throttle ref
+			-- if it still points at us. Subsequent stale ticks (if any)
+			-- will exit on the cancelled check above.
+			batches = {}
+			batchIndex = totalBatches
+			if self._activeThrottleToken == cancelToken then
+				self._activeThrottleToken = nil
+			end
 			if progressCallback then
 				progressCallback(batchIndex, totalBatches, true)
 			end
@@ -575,6 +592,9 @@ function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSecond
 
 		batchIndex = batchIndex + 1
 		if batchIndex > totalBatches then
+			if self._activeThrottleToken == cancelToken then
+				self._activeThrottleToken = nil
+			end
 			if progressCallback then
 				progressCallback(totalBatches, totalBatches)
 			end
@@ -582,8 +602,10 @@ function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSecond
 		end
 
 		local batch = batches[batchIndex]
-		for _, cmd in ipairs(batch) do
-			self:SayBattle(cmd)
+		Spring.Echo("[SayBattleThrottled] sending batch " .. batchIndex .. "/" .. totalBatches ..
+			" (" .. #batch .. " lines)")
+		for _, line in ipairs(batch) do
+			self:SayBattle(line)
 		end
 
 		if progressCallback then
@@ -592,11 +614,25 @@ function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSecond
 
 		if batchIndex < totalBatches then
 			WG.Delay(sendNextBatch, intervalSeconds)
+		elseif self._activeThrottleToken == cancelToken then
+			self._activeThrottleToken = nil
 		end
 	end
 
 	sendNextBatch()
 	return self
+end
+
+-- Throttled SetModOptions for large preset loads. Diffs against the current
+-- modoptions, builds !bSet lines, and routes them through SayBattleThrottled.
+function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSeconds, progressCallback, cancelToken)
+	local lines = {}
+	for k, v in pairs(data) do
+		if self.modoptions[k] ~= v then
+			table.insert(lines, "!bSet " .. tostring(k) .. " " .. tostring(v))
+		end
+	end
+	return self:SayBattleThrottled(lines, maxCharsPerBatch, intervalSeconds, progressCallback, cancelToken)
 end
 
 function Interface:AddAi(aiName, aiLib, allyNumber, version, aiOptions, battleStatusOptions)
@@ -2204,12 +2240,28 @@ function Interface:_OnSetScriptTags(tagsTxt)
 	if self.modoptions == nil then
 		self.modoptions = {}
 	end
+	local changes = {}
 	for _, tag in pairs(tags) do
 		if string_starts(tag, mod_opts_pre) then
 			local kv = tag:sub(mod_opts_pre_indx)
-			local kvTable = explode("=", kv)
-			local k = kvTable[1]
-			local v = kvTable[2]
+			-- Split on the FIRST '=' only. Using explode("=", ...) here
+			-- silently truncated values that themselves contain '=' (e.g.
+			-- base64-padded tweakdefs blobs, or any Lua expression with
+			-- assignment operators), which made the local modoptions cache
+			-- diverge from SPADS' authoritative state.
+			local eqPos = kv:find("=", 1, true)
+			local k, v
+			if eqPos then
+				k = kv:sub(1, eqPos - 1)
+				v = kv:sub(eqPos + 1)
+			else
+				k = kv
+				v = ""
+			end
+			local oldV = self.modoptions[k]
+			if oldV ~= v then
+				changes[k] = { old = oldV, new = v }
+			end
 			self.modoptions[k] = v
 		elseif string_starts(tag, scriptTagPlayers) then
 			local userNameLC, status = self:GetSkillFromScriptTag(tag:sub(scriptTagPlayersIndx))
@@ -2221,7 +2273,7 @@ function Interface:_OnSetScriptTags(tagsTxt)
 			end
 		end
 	end
-	self:_OnSetModOptions(self.modoptions)
+	self:_OnSetModOptions(self.modoptions, changes)
 end
 Interface.commands["SETSCRIPTTAGS"] = Interface._OnSetScriptTags
 Interface.commandPattern["SETSCRIPTTAGS"] = "(.*)"

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -516,6 +516,89 @@ function Interface:SetModOptions(data)
 	return self
 end
 
+-- Throttled version for large preset loading - prevents rate limit kicks
+-- maxCharsPerBatch: maximum characters to batch before delay (default 20000)
+-- intervalSeconds: delay between batches in seconds (default 5)
+-- progressCallback: optional function(current, total, cancelled) called for each batch sent
+-- cancelToken: optional table with a `cancelled` field; set it to true to stop remaining batches
+function Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSeconds, progressCallback, cancelToken)
+	maxCharsPerBatch = maxCharsPerBatch or 20000
+	intervalSeconds = intervalSeconds or 5
+	cancelToken = cancelToken or {}
+	
+	-- Build list of commands to send
+	local commands = {}
+	for k, v in pairs(data) do
+		if self.modoptions[k] ~= v then
+			table.insert(commands, "!bSet " .. tostring(k) .. " " .. tostring(v))
+		end
+	end
+	
+	if #commands == 0 then
+		if progressCallback then
+			progressCallback(0, 0)
+		end
+		return self
+	end
+	
+	-- Batch commands by character size
+	local batches = {}
+	local currentBatch = {}
+	local currentSize = 0
+	
+	for _, cmd in ipairs(commands) do
+		local cmdSize = #cmd + 1 -- +1 for newline
+		if currentSize + cmdSize > maxCharsPerBatch and #currentBatch > 0 then
+			table.insert(batches, currentBatch)
+			currentBatch = {}
+			currentSize = 0
+		end
+		table.insert(currentBatch, cmd)
+		currentSize = currentSize + cmdSize
+	end
+	if #currentBatch > 0 then
+		table.insert(batches, currentBatch)
+	end
+	
+	-- Send batches with throttling
+	local totalBatches = #batches
+	local batchIndex = 0
+	local sendNextBatch
+	
+	sendNextBatch = function()
+		if cancelToken.cancelled then
+			if progressCallback then
+				progressCallback(batchIndex, totalBatches, true)
+			end
+			return
+		end
+
+		batchIndex = batchIndex + 1
+		if batchIndex > totalBatches then
+			if progressCallback then
+				progressCallback(totalBatches, totalBatches)
+			end
+			return
+		end
+		
+		local batch = batches[batchIndex]
+		for _, cmd in ipairs(batch) do
+			self:SayBattle(cmd)
+		end
+		
+		if progressCallback then
+			progressCallback(batchIndex, totalBatches)
+		end
+		
+		if batchIndex < totalBatches then
+			WG.Delay(sendNextBatch, intervalSeconds)
+		end
+	end
+	
+	sendNextBatch()
+	return self
+end
+
 function Interface:AddAi(aiName, aiLib, allyNumber, version, aiOptions, battleStatusOptions)
 	local userData = {
 		isReady = true,

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -516,7 +516,7 @@ function Interface:SetModOptions(data)
 	return self
 end
 
--- SPADS chat throttle; THROTTLED_SAY_MAX_CHARS_PER_BATCH also gates oversized paste.
+-- multiplayer chat throttling for presets and large battle settings pastes
 Interface.THROTTLED_SAY_MAX_CHARS_PER_BATCH = 20000
 Interface.THROTTLED_SAY_INTERVAL_SECONDS = 4
 

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -1621,10 +1621,7 @@ function Lobby:_OnUserVoted(userName, voteOption)
 	self:_CallListeners("OnUserVoted", userName, voteOption)
 end
 
--- changes: optional {[key] = {old = ..., new = ...}, ...}. If absent, derived
--- by diffing data against the previous self.modoptions before it is replaced.
--- Forwarded as the second listener arg so widgets can rewrite SPADS bSet
--- broadcasts with both old and new values.
+-- Optional changes {[key]={old,new}}; else diff vs previous modoptions. Second listener arg.
 function Lobby:_OnSetModOptions(data, changes)
 	if not changes then
 		changes = {}

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -1621,9 +1621,22 @@ function Lobby:_OnUserVoted(userName, voteOption)
 	self:_CallListeners("OnUserVoted", userName, voteOption)
 end
 
-function Lobby:_OnSetModOptions(data)
+-- changes: optional {[key] = {old = ..., new = ...}, ...}. If absent, derived
+-- by diffing data against the previous self.modoptions before it is replaced.
+-- Forwarded as the second listener arg so widgets can rewrite SPADS bSet
+-- broadcasts with both old and new values.
+function Lobby:_OnSetModOptions(data, changes)
+	if not changes then
+		changes = {}
+		local oldM = self.modoptions or {}
+		for k, v in pairs(data) do
+			if oldM[k] ~= v then
+				changes[k] = { old = oldM[k], new = v }
+			end
+		end
+	end
 	self.modoptions = data
-	self:_CallListeners("OnSetModOptions", data)
+	self:_CallListeners("OnSetModOptions", data, changes)
 end
 
 function Lobby:_OnResetModOptions()


### PR DESCRIPTION
95% done with AI.

# Throttled Preset Loading

## Context

Large saved option presets can emit enough battle commands to hit Teiserver's Spring command rate limit. The observed failure mode is a user being kicked while applying a large preset. The backend rate limit exists to protect server memory, so the client-side fix is to avoid bursts rather than bypass the limit.

This change keeps the existing saved preset flow, but sends modoption changes in delayed batches.

## Changed Files

- `libs/liblobby/lobby/interface.lua`
  - Adds `Interface:SetModOptionsThrottled(...)`.
- `LuaMenu/widgets/gui_optionpresets_panel.lua`
  - Routes saved preset modoption loading through the throttled sender.
  - Adds progress and cancellation UI for delayed loads.

## Throttled Sender

Signature:

```lua
Interface:SetModOptionsThrottled(data, maxCharsPerBatch, intervalSeconds, progressCallback, cancelToken)
```

Parameters:

- `data`: modoption key/value table.
- `maxCharsPerBatch`: maximum accumulated command text per batch. Defaults to `20000`.
- `intervalSeconds`: delay between batches. Defaults to `4`.
- `progressCallback`: optional callback as `function(current, total, cancelled)`.
- `cancelToken`: optional table; setting `cancelToken.cancelled = true` stops the next unsent batch.

The implementation mirrors `SetModOptions()` by skipping values that already match `self.modoptions`. Remaining commands are grouped by approximate command text size, then sent batch by batch with `WG.Delay()`.

Cancellation is cooperative. A batch already sent cannot be undone, but closing/cancelling the UI prevents later delayed batches from being sent.

## UI Behavior

Saved presets now show a small progress dialog while modoptions are being sent. The dialog updates the batch counter and progress bar after each batch and includes a cancel button.

Progress labels use Chili `SetCaption()` instead of mutating `caption` directly, because direct mutation does not reliably redraw labels.

The attempted raw text import path was intentionally removed. Large preset text in Chili edit boxes and `Spring.GetClipboard()` both proved capable of blocking the UI. The supported path for this change is saved preset loading.

## Rate Limit Choice

Current UI call sites use:

```lua
battleLobby:SetModOptionsThrottled(modoptions, 20000, 4, progressCallback, cancelToken)
```

This is intentionally conservative:

- Teiserver Spring command limit: roughly `200` commands/minute by default.
- Client sends at most one batch every `4` seconds.
- The `20000` character limit stays well below the default `64KB` message buffer.

The batching limit is character-based rather than count-based because tweakdef values can vary significantly in size. This keeps large values from forming very large single sends while avoiding protocol changes.

## Review Notes

- Existing `SetModOptions()` is unchanged.
- Non-modoption preset parts still apply immediately as before.
- The new throttling only affects saved preset modoption application.
- `WG.Delay()` keeps the UI responsive between batches.
- No retry or acknowledgement layer was added; that would require stronger server/protocol feedback than this client path currently has.

## Suggested Verification

- Load a saved preset with enough changed modoptions to produce multiple batches; confirm the batch counter and progress bar advance together.
- Cancel after the first batch; confirm no further delayed batches are sent.
- Close the preset window during a load; confirm pending batches are cancelled.
- Test a small/no-op preset; confirm the UI closes cleanly and no unnecessary commands are sent.


## References

- **Backend rate limit**: `teiserver.Spring rate limit per minute` (default: 200)
- **Buffer size**: `teiserver.Spring max message buffer size` (default: 64KB)
- **Teiserver Config**: https://github.com/beyond-all-reason/teiserver/blob/master/lib/teiserver/libs/teiserver_configs.ex
