### PR TITLE
Update engine test autohost to 2025.06.22

### DIFF
--- a/dist_cfg/config.json
+++ b/dist_cfg/config.json
@@ -104,8 +104,8 @@
                         "optional": true
                     },
                     {
-                        "url": "https://github.com/beyond-all-reason/RecoilEngine/releases/download/2026.06.04/recoil_2026.06.04_amd64-linux.7z",
-                        "destination": "engine/recoil_2026.06.04",
+                        "url": "https://github.com/beyond-all-reason/RecoilEngine/releases/download/2025.06.22/recoil_2025.06.22_amd64-linux.7z",
+                        "destination": "engine/recoil_2025.06.22",
                         "extract": true
                     }
                 ]
@@ -114,7 +114,7 @@
             "logs_s3_bucket": "bar-infologs",
             "launch": {
                 "start_args": ["--menu", "rapid://byar-chobby:test"],
-                "engine": "recoil_2026.06.04",
+                "engine": "recoil_2025.06.22",
                 "springsettings": {
                     "RapidTagResolutionOrder": "repos-cdn.beyondallreason.dev;repos.beyondallreason.dev"
                 }
@@ -143,8 +143,8 @@
                         "optional": true
                     },
                     {           
-                        "url": "https://github.com/beyond-all-reason/RecoilEngine/releases/download/2026.06.04/recoil_2026.06.04_amd64-windows.7z",
-                        "destination": "engine/recoil_2026.06.04",
+                        "url": "https://github.com/beyond-all-reason/RecoilEngine/releases/download/2025.06.22/recoil_2025.06.22_amd64-windows.7z",
+                        "destination": "engine/recoil_2025.06.22",
                         "extract": true
                     }
                 ]
@@ -153,7 +153,7 @@
             "logs_s3_bucket": "bar-infologs",
             "launch": {
                 "start_args": ["--menu", "rapid://byar-chobby:test"],
-                "engine": "recoil_2026.06.04",
+                "engine": "recoil_2025.06.22",
                 "springsettings": {
                     "RapidTagResolutionOrder": "repos-cdn.beyondallreason.dev;repos.beyondallreason.dev"
                 }


### PR DESCRIPTION
Updates the engine test autohost URLs and version from `2026.06.04` to `2025.06.22` in `dist_cfg/config.json`.

Release: https://github.com/beyond-all-reason/RecoilEngine/releases/tag/2025.06.22

After merging, please run the **Publish launcher config.json** GitHub Actions workflow.