### PR TITLE
Lobby: fix nil _defaultGameArchiveName crash and HiDPI resize-loop

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/mainConfig.lua
+++ b/LuaMenu/configs/gameConfig/byar/mainConfig.lua
@@ -75,7 +75,7 @@ end
 local externalFuncAndData = {
 	dirName                = "byar",
 	name                   = "Beyond All Reason",
-	--_defaultGameArchiveName = "??", fill this in.
+	_defaultGameArchiveName = "Beyond All Reason $VERSION", -- Fallback when rapid is unavailable (e.g. dev .sdd install).
 	_defaultGameRapidTag   = "byar:test", -- Do not read directly
 	--editor                 = "rapid://sb-byar:test",
 	--editor                 = "SpringBoard BYAR $VERSION",

--- a/LuaMenu/widgets/gfx_resolution_limiter.lua
+++ b/LuaMenu/widgets/gfx_resolution_limiter.lua
@@ -12,8 +12,20 @@ end
 
 
 function checkResolution()
-	-- resize resolution if is larger than screen resolution
-	local vsx,vsy = Spring.Orig.GetViewSizes()
+	-- resize resolution if is larger than screen resolution.
+	--
+	-- HiDPI note: Spring.Orig.GetViewSizes() (gl.GetViewSizes) returns BACKING
+	-- pixels while Spring.GetScreenGeometry() returns LOGICAL points. On any
+	-- HiDPI display these diverge and the original comparison would re-fire
+	-- every ViewResize, creating a feedback loop (ViewResize -> SetConfigInt
+	-- -> SDL_SetWindowSize -> ViewResize). Compare the *configured* resolution
+	-- (logical points, as written by SaveWindowPosAndSize) against the screen
+	-- instead.
+	local vsx = Spring.GetConfigInt("XResolutionWindowed", 0)
+	local vsy = Spring.GetConfigInt("YResolutionWindowed", 0)
+	if vsx == 0 or vsy == 0 then
+		vsx, vsy = Spring.Orig.GetViewSizes()
+	end
 	local ssx,ssy,spx,spy = Spring.GetScreenGeometry()
 	if (vsx > ssx or vsy > ssy)  then
 		if Spring.SendCommands ~= nil then


### PR DESCRIPTION
## Summary

Two unrelated lobby bugs that hit dev / .sdd / offline installs and HiDPI displays:

- **`_defaultGameArchiveName` nil crash** (`mainConfig.lua`): commented-out default fell through to `ShortenNameString(nil)` at `interface_root.lua:119`, preventing `WG.Chobby` from registering and bailing every dependent widget. Now set to `"Beyond All Reason \$VERSION"` (matches the dev-config and the existing error-log fallback string). Only surfaces when rapid is unavailable, which is any dev / .sdd / offline install.

- **HiDPI resize-loop** (`gfx_resolution_limiter.lua`): compared `Spring.GetViewSizes()` (backing pixels) against `Spring.GetScreenGeometry()` (logical points). On any HiDPI setup (Retina, Wayland HiDPI, X11 HiDPI) view > screen always, so the widget reset `X/YResolutionWindowed` every `ViewResize` callin → `ConfigNotify` → `SetWindowAttributes` → `SDL_SetWindowSize` → next-frame `ViewResize` → ~10 Hz thrash. Compare `Spring.GetConfigInt(...)` instead, which is stored in logical points and unit-consistent with `GetScreenGeometry()`.

Both are platform-agnostic logic fixes; structurally repair behavior on any HiDPI configuration.

## Test plan

- [x] Lobby boots and renders end-to-end on a HiDPI display
- [x] Window no longer rapidly resizes by a few pixels
- [ ] Lobby boots on Linux (relies on community / CI verification)
- [ ] Lobby boots on Windows (relies on community / CI verification)