### PR TITLE
Improve rename account UX

### DIFF
--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -557,9 +557,9 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 		x = pad + formw * 0 ,
 		y = pad + formh * 0 ,
 		width =   formw * 3 ,
-		height =  formh * 2 ,
+		height =  60 ,
 		-- caption = i18n("register_long"),
-		text = "Change username. Max: 20 chars. Cooldown: no more than twice a week, 3/month. Login required.",
+		text = "Change username. You must be logged in, and will be logged out on successful change. Max: 20 characters. Cooldown: no more than twice a week, 3/month.",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
 		objectOverrideHintFont = WG.Chobby.Configuration:GetFont(1),
 	}
@@ -567,7 +567,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.ebChangeUserName = EditBox:New {
 		x = pad ,
-		y = pad + formh * 2 ,
+		y = 80 ,
 		width =   350 ,
 		height =  formh * 1 ,
 		text = Configuration.userName or Configuration.suggestedNameFromSteam or "",
@@ -579,7 +579,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnChangeUserName = Button:New {
 		x = pad + 360 ,
-		y = pad + formh * 2 ,
+		y = 80 ,
 		width =   150 ,
 		height =  formh * 1 ,
 		caption = i18n("change_username"),
@@ -593,23 +593,34 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	}
 	recoverChildren[#recoverChildren+1] = self.btnChangeUserName
 
+	self.txtHelpChangeUserName = TextBox:New {
+		x = pad + formw * 0 ,
+		y = 105 ,
+		width =   formw * 3 + 60 ,
+		height =  formh * 1 ,
+		text = "If this doesnt work contact us on Discord.",
+		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
+		objectOverrideHintFont = WG.Chobby.Configuration:GetFont(1),
+	}
+	recoverChildren[#recoverChildren+1] = self.txtHelpChangeUserName
+
 	self.txtErrorChangeUserName = TextBox:New {
 		x = pad + formw * 0 ,
-		y = 4 + pad + formh * 3 ,
+		y = 128 ,
 		width =   formw * 3 + 60 ,
-		height =  32 ,
+		height =  28 ,
 		text = "",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
 		objectOverrideHintFont = WG.Chobby.Configuration:GetFont(1),
 	}
 	recoverChildren[#recoverChildren+1] = self.txtErrorChangeUserName
 
-	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=126,right=5, height = 1}
+	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=165,right=5, height = 1}
 
 ------------------------------RESET PASSWORD----------------------------------
 	self.txtResetPassword = TextBox:New {
 		x = pad + formw * 0 ,
-		y = 135 ,
+		y = 175 ,
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		-- caption = i18n("register_long"),
@@ -621,7 +632,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnResetPassword = Button:New {
 		x = pad + formw * 0 ,
-		y = 185 ,
+		y = 230 ,
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		caption = "Reset your password via a browser link",
@@ -635,7 +646,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	}
 	recoverChildren[#recoverChildren+1] = self.btnResetPassword
 	
-	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=250,right=5, height = 1}
+	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=295,right=5, height = 1}
 --[[
 
 
@@ -734,7 +745,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 ---------------------------Change Password--------------------------------
 	self.txtChangePassword = TextBox:New {
 		x = pad + formw * 0 ,
-		y = 265 ,
+		y = 310 ,
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		-- caption = i18n("register_long"),
@@ -746,7 +757,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnChangePassword = Button:New {
 		x = pad + formw * 0 ,
-		y = 325 ,
+		y = 370 ,
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		caption = "Edit your password via a browser link",
@@ -759,7 +770,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 		},
 	}
 	recoverChildren[#recoverChildren+1] = self.btnChangePassword
-	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=405,right=5, height = 1}
+	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=450,right=5, height = 1}
 
 --[[
 	self.lblChangePasswordOld =  Label:New {
@@ -840,8 +851,8 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	---------------------------Change Email-------------------------------
 	self.txtChangeEmail = TextBox:New {
 		x = pad + formw * 0 ,
-		y = 414 ,
-		width =   560 ,
+		y = 465 ,
+		width =   520 ,
 		height =  82 ,
 		-- caption = i18n("register_long"),
 		text = "Change email address associated with your account. You must be logged in. Enter the new email address you wish to use, then enter the validation code sent to the new email address.",
@@ -852,9 +863,11 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.lblChangeEmailEmail =  Label:New {
 		x = pad + formw * 0 ,
-		y = 515 ,
-		width =   formw * 1 ,
+		y = 560 ,
+		width =   170 ,
 		height =  formh * 1 ,
+		autosize = false,
+		valign = "center",
 		-- caption = i18n("register_long"),
 		caption = "New email address:",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -863,7 +876,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.ebChangeEmailEmail = EditBox:New {
 		x = 190 ,
-		y = 515 ,
+		y = 560 ,
 		width =   210 ,
 		height =  formh * 1 ,
 		text = "",
@@ -875,9 +888,11 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.lblChangeEmailVerification =  Label:New {
 		x = pad + formw * 0 ,
-		y = 545 ,
-		width =   formw * 1 ,
+		y = 590 ,
+		width =   170 ,
 		height =  formh * 1 ,
+		autosize = false,
+		valign = "center",
 		-- caption = i18n("register_long"),
 		caption = "Verification Code:",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -886,7 +901,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.ebChangeEmailVerification = EditBox:New {
 		x = 190 ,
-		y = 545 ,
+		y = 590 ,
 		width =   210 ,
 		height =  formh * 1 ,
 		text = "",
@@ -898,7 +913,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnChangeEmail = Button:New {
 		x = 405 ,
-		y = 515 ,
+		y = 560 ,
 		width =   155 ,
 		height =  formh * 1 ,
 		caption = i18n("submit_email"),
@@ -914,7 +929,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnChangeEmailVerification = Button:New {
 		x = 405 ,
-		y = 545 ,
+		y = 590 ,
 		width =   155 ,
 		height =  formh * 1 ,
 		caption = i18n("submit_verification"),
@@ -930,7 +945,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.txtErrorChangeEmail = TextBox:New {
 		x = pad + formw * 0 ,
-		y = 590 ,
+		y = 635 ,
 		width =   560 ,
 		height =  formh * 1 ,
 		text = "If this doesnt work contact us on Discord",

--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -59,8 +59,10 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 		Log.Error("Tried to spawn duplicate login window")
 		return
 	end
+	local ww, wh = Spring.GetWindowGeometry()
 	self.emailRequired = (params and params.emailRequired) or false
-	self.windowHeight = (params and params.windowHeight) or (self.emailRequired and 800) or 800
+	local defaultWindowHeight = (params and params.windowHeight) or (self.emailRequired and 800) or 800
+	self.windowHeight = math.min(defaultWindowHeight, math.max(740, wh - 20))
 	self.loginAfterRegister = (params and params.loginAfterRegister) or false
 
 	local registerChildren = {}
@@ -615,12 +617,12 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	}
 	recoverChildren[#recoverChildren+1] = self.txtErrorChangeUserName
 
-	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=165,right=5, height = 1}
+	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=160,right=5, height = 1}
 
 ------------------------------RESET PASSWORD----------------------------------
 	self.txtResetPassword = TextBox:New {
 		x = pad + formw * 0 ,
-		y = 175 ,
+		y = 168 ,
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		-- caption = i18n("register_long"),
@@ -632,7 +634,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnResetPassword = Button:New {
 		x = pad + formw * 0 ,
-		y = 230 ,
+		y = 220 ,
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		caption = "Reset your password via a browser link",
@@ -646,7 +648,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	}
 	recoverChildren[#recoverChildren+1] = self.btnResetPassword
 	
-	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=295,right=5, height = 1}
+	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=280,right=5, height = 1}
 --[[
 
 
@@ -745,7 +747,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 ---------------------------Change Password--------------------------------
 	self.txtChangePassword = TextBox:New {
 		x = pad + formw * 0 ,
-		y = 310 ,
+		y = 292 ,
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		-- caption = i18n("register_long"),
@@ -757,7 +759,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnChangePassword = Button:New {
 		x = pad + formw * 0 ,
-		y = 370 ,
+		y = 342 ,
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		caption = "Edit your password via a browser link",
@@ -770,7 +772,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 		},
 	}
 	recoverChildren[#recoverChildren+1] = self.btnChangePassword
-	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=450,right=5, height = 1}
+	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=410,right=5, height = 1}
 
 --[[
 	self.lblChangePasswordOld =  Label:New {
@@ -851,7 +853,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	---------------------------Change Email-------------------------------
 	self.txtChangeEmail = TextBox:New {
 		x = pad + formw * 0 ,
-		y = 465 ,
+		y = 420 ,
 		width =   520 ,
 		height =  82 ,
 		-- caption = i18n("register_long"),
@@ -863,7 +865,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.lblChangeEmailEmail =  Label:New {
 		x = pad + formw * 0 ,
-		y = 560 ,
+		y = 510 ,
 		width =   170 ,
 		height =  formh * 1 ,
 		autosize = false,
@@ -876,7 +878,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.ebChangeEmailEmail = EditBox:New {
 		x = 190 ,
-		y = 560 ,
+		y = 510 ,
 		width =   210 ,
 		height =  formh * 1 ,
 		text = "",
@@ -888,7 +890,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.lblChangeEmailVerification =  Label:New {
 		x = pad + formw * 0 ,
-		y = 590 ,
+		y = 540 ,
 		width =   170 ,
 		height =  formh * 1 ,
 		autosize = false,
@@ -901,7 +903,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.ebChangeEmailVerification = EditBox:New {
 		x = 190 ,
-		y = 590 ,
+		y = 540 ,
 		width =   210 ,
 		height =  formh * 1 ,
 		text = "",
@@ -913,7 +915,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnChangeEmail = Button:New {
 		x = 405 ,
-		y = 560 ,
+		y = 510 ,
 		width =   155 ,
 		height =  formh * 1 ,
 		caption = i18n("submit_email"),
@@ -929,7 +931,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnChangeEmailVerification = Button:New {
 		x = 405 ,
-		y = 590 ,
+		y = 540 ,
 		width =   155 ,
 		height =  formh * 1 ,
 		caption = i18n("submit_verification"),
@@ -945,7 +947,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.txtErrorChangeEmail = TextBox:New {
 		x = pad + formw * 0 ,
-		y = 635 ,
+		y = 570 ,
 		width =   560 ,
 		height =  formh * 1 ,
 		text = "If this doesnt work contact us on Discord",
@@ -1001,11 +1003,10 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	
 	recoverChildren[#recoverChildren+1] = self.btnTeiserver
 
-	local ww, wh = Spring.GetWindowGeometry()
-	local width = 620
+	local width = math.min(620, math.max(580, ww - 20))
 
 	self.window = Window:New {
-		x = math.floor((ww - width) / 2),
+		x = math.floor(math.max(0, (ww - width) / 2)),
 		y = math.floor(math.max(0,(wh - self.windowHeight) / 2)),
 		width = width,
 		height = self.windowHeight,
@@ -1074,7 +1075,8 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 		right = 5,
 		y = 30,
 		bottom = 4,
-		horizontalScrollbar = true,
+		horizontalScrollbar = false,
+		verticalScrollbar = false,
 		children = {
 			self.tabPanel,
 			self.btnCancel

--- a/LuaMenu/widgets/chobby/components/login_window.lua
+++ b/LuaMenu/widgets/chobby/components/login_window.lua
@@ -60,7 +60,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 		return
 	end
 	self.emailRequired = (params and params.emailRequired) or false
-	self.windowHeight = (params and params.windowHeight) or (self.emailRequired and 460+200) or 420+200
+	self.windowHeight = (params and params.windowHeight) or (self.emailRequired and 800) or 800
 	self.loginAfterRegister = (params and params.loginAfterRegister) or false
 
 	local registerChildren = {}
@@ -559,39 +559,28 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		-- caption = i18n("register_long"),
-		text = "Change user name. You must be logged in, and will be logged out on successful change.",
+		text = "Change username. Max: 20 chars. Cooldown: no more than twice a week, 3/month. Login required.",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
 		objectOverrideHintFont = WG.Chobby.Configuration:GetFont(1),
 	}
 	recoverChildren[#recoverChildren+1] = self.txtChangeUserName
 
-	self.lblChangeUserName =  Label:New {
-		x = pad + formw * 0 ,
-		y = pad + formh * 1 ,
-		width =   formw * 1 ,
-		height =  formh * 1 ,
-		-- caption = i18n("register_long"),
-		caption = "New user name:",
-		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
-	}
-	recoverChildren[#recoverChildren+1] = self.lblChangeUserName
-
 	self.ebChangeUserName = EditBox:New {
-		x = pad + formw * 1 ,
+		x = pad ,
 		y = pad + formh * 2 ,
-		width =   formw * 1 ,
+		width =   350 ,
 		height =  formh * 1 ,
 		text = Configuration.userName or Configuration.suggestedNameFromSteam or "",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
 		objectOverrideHintFont = WG.Chobby.Configuration:GetFont(1),
-		tooltip = 'User name may contain only letters, numbers, square brackets and underscores',
+		tooltip = '3-20 characters. Letters, numbers, square brackets, and underscores only.',
 	}
 	recoverChildren[#recoverChildren+1] = self.ebChangeUserName
 
 	self.btnChangeUserName = Button:New {
-		x = pad + formw * 2 ,
+		x = pad + 360 ,
 		y = pad + formh * 2 ,
-		width =   formw * 1 ,
+		width =   150 ,
 		height =  formh * 1 ,
 		caption = i18n("change_username"),
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -607,22 +596,22 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	self.txtErrorChangeUserName = TextBox:New {
 		x = pad + formw * 0 ,
 		y = 4 + pad + formh * 3 ,
-		width =   formw * 3 ,
-		height =  formh * 1 ,
-		text = "If this doesnt work contact us on Discord",
+		width =   formw * 3 + 60 ,
+		height =  32 ,
+		text = "",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
 		objectOverrideHintFont = WG.Chobby.Configuration:GetFont(1),
 	}
 	recoverChildren[#recoverChildren+1] = self.txtErrorChangeUserName
 
-	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=formh * 5,right=5, height = 1}
+	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=126,right=5, height = 1}
 
 ------------------------------RESET PASSWORD----------------------------------
 	self.txtResetPassword = TextBox:New {
 		x = pad + formw * 0 ,
-		y = pad + formh * 5 ,
+		y = 135 ,
 		width =   formw * 3 ,
-		height =  formh * 1 ,
+		height =  formh * 2 ,
 		-- caption = i18n("register_long"),
 		text = "Reset forgotten password: You need to use your web browser to reset a forgotten password.",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -632,7 +621,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnResetPassword = Button:New {
 		x = pad + formw * 0 ,
-		y = pad + formh * 7 ,
+		y = 185 ,
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		caption = "Reset your password via a browser link",
@@ -646,7 +635,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	}
 	recoverChildren[#recoverChildren+1] = self.btnResetPassword
 	
-	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=formh * 11,right=5, height = 1}
+	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=250,right=5, height = 1}
 --[[
 
 
@@ -745,9 +734,9 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 ---------------------------Change Password--------------------------------
 	self.txtChangePassword = TextBox:New {
 		x = pad + formw * 0 ,
-		y = pad + formh * 11 ,
+		y = 265 ,
 		width =   formw * 3 ,
-		height =  formh * 1 ,
+		height =  formh * 2 ,
 		-- caption = i18n("register_long"),
 		text = "Change Password: You must be logged in, enter your old and your new password",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -757,7 +746,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.btnChangePassword = Button:New {
 		x = pad + formw * 0 ,
-		y = pad + formh * 13 ,
+		y = 325 ,
 		width =   formw * 3 ,
 		height =  formh * 2 ,
 		caption = "Edit your password via a browser link",
@@ -770,7 +759,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 		},
 	}
 	recoverChildren[#recoverChildren+1] = self.btnChangePassword
-	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=formh * 17,right=5, height = 1}
+	recoverChildren[#recoverChildren+1] = Line:New{x=5,y=405,right=5, height = 1}
 
 --[[
 	self.lblChangePasswordOld =  Label:New {
@@ -851,9 +840,9 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	---------------------------Change Email-------------------------------
 	self.txtChangeEmail = TextBox:New {
 		x = pad + formw * 0 ,
-		y = pad + formh * 17 ,
-		width =   formw * 3 ,
-		height =  formh * 1 ,
+		y = 414 ,
+		width =   560 ,
+		height =  82 ,
 		-- caption = i18n("register_long"),
 		text = "Change email address associated with your account. You must be logged in. Enter the new email address you wish to use, then enter the validation code sent to the new email address.",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -863,7 +852,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.lblChangeEmailEmail =  Label:New {
 		x = pad + formw * 0 ,
-		y = pad + formh * 20 ,
+		y = 515 ,
 		width =   formw * 1 ,
 		height =  formh * 1 ,
 		-- caption = i18n("register_long"),
@@ -873,9 +862,9 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	recoverChildren[#recoverChildren+1] = self.lblChangeEmailEmail
 
 	self.ebChangeEmailEmail = EditBox:New {
-		x = pad + formw * 1 ,
-		y = pad + formh * 20 ,
-		width =   formw * 1 ,
+		x = 190 ,
+		y = 515 ,
+		width =   210 ,
 		height =  formh * 1 ,
 		text = "",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -886,7 +875,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.lblChangeEmailVerification =  Label:New {
 		x = pad + formw * 0 ,
-		y = pad + formh * 19 ,
+		y = 545 ,
 		width =   formw * 1 ,
 		height =  formh * 1 ,
 		-- caption = i18n("register_long"),
@@ -896,9 +885,9 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	recoverChildren[#recoverChildren+1] = self.lblChangeEmailVerification
 
 	self.ebChangeEmailVerification = EditBox:New {
-		x = pad + formw * 1 ,
-		y = pad + formh * 21 ,
-		width =   formw * 1 ,
+		x = 190 ,
+		y = 545 ,
+		width =   210 ,
 		height =  formh * 1 ,
 		text = "",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -908,9 +897,9 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	recoverChildren[#recoverChildren+1] = self.ebChangeEmailVerification
 
 	self.btnChangeEmail = Button:New {
-		x = pad + formw * 2 ,
-		y = pad + formh * 20 ,
-		width =   formw * 1 ,
+		x = 405 ,
+		y = 515 ,
+		width =   155 ,
 		height =  formh * 1 ,
 		caption = i18n("submit_email"),
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -924,9 +913,9 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	recoverChildren[#recoverChildren+1] = self.btnChangeEmail
 
 	self.btnChangeEmailVerification = Button:New {
-		x = pad + formw * 2 ,
-		y = pad + formh * 21 ,
-		width =   formw * 1 ,
+		x = 405 ,
+		y = 545 ,
+		width =   155 ,
 		height =  formh * 1 ,
 		caption = i18n("submit_verification"),
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -941,8 +930,8 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 
 	self.txtErrorChangeEmail = TextBox:New {
 		x = pad + formw * 0 ,
-		y = 4 + pad + formh * 22 ,
-		width =   formw * 3 ,
+		y = 590 ,
+		width =   560 ,
 		height =  formh * 1 ,
 		text = "If this doesnt work contact us on Discord",
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(1),
@@ -998,7 +987,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 	recoverChildren[#recoverChildren+1] = self.btnTeiserver
 
 	local ww, wh = Spring.GetWindowGeometry()
-	local width = 3 * (formw  + 30) --used to be bout tree fiddy
+	local width = 620
 
 	self.window = Window:New {
 		x = math.floor((ww - width) / 2),
@@ -1097,6 +1086,7 @@ function LoginWindow:init(failFunction, cancelText, windowClassname, params)
 end
 
 function LoginWindow:RemoveListeners()
+	self:ClearRenameListeners()
 	if self.onAgreementEnd then
 		lobby:RemoveListener("OnAgreementEnd", self.onAgreementEnd)
 		self.onAgreementEnd = nil
@@ -1116,6 +1106,22 @@ function LoginWindow:RemoveListeners()
 	-- FIXME: the rest should be removed too
 	if self.OnChangeEmailRequestDenied then
 		lobby:RemoveListener("OnChangeEmailRequestDenied", self.OnChangeEmailRequestDenied)
+	end
+end
+
+function LoginWindow:ClearRenameListeners()
+	self.pendingRenameUserName = nil
+	if self.onRenameServerMSG then
+		lobby:RemoveListener("OnServerMSG", self.onRenameServerMSG)
+		self.onRenameServerMSG = nil
+	end
+	if self.onRenameDenied then
+		lobby:RemoveListener("OnDenied", self.onRenameDenied)
+		self.onRenameDenied = nil
+	end
+	if self.onRenameDisconnected then
+		lobby:RemoveListener("OnDisconnected", self.onRenameDisconnected)
+		self.onRenameDisconnected = nil
 	end
 end
 
@@ -1341,6 +1347,7 @@ end
 
 function LoginWindow:tryChangeUserName()
 	Spring.Echo("lobby:GetConnectionStatus()",lobby:GetConnectionStatus())
+	self:ClearRenameListeners()
 	local newusername = self.ebChangeUserName.text
 	local isinValidUserName = isInValidUserName(newusername)
 	if isinValidUserName then
@@ -1348,9 +1355,59 @@ function LoginWindow:tryChangeUserName()
 		return
 	end
 	if lobby:GetConnectionStatus() == "connected" then
+		local function SetRenameButtonEnabled(enabled)
+			if self.btnChangeUserName then
+				self.btnChangeUserName:SetEnabled(enabled)
+			end
+		end
+
+		local function FinishRenameRequest(message, color)
+			self.pendingRenameUserName = nil
+			SetRenameButtonEnabled(true)
+			if self.txtErrorChangeUserName then
+				self.txtErrorChangeUserName:SetText((color or "") .. message)
+			end
+			self:ClearRenameListeners()
+		end
+
+		local function GetRenameResponseColor(message)
+			local lowerMessage = string.lower(tostring(message or ""))
+			if lowerMessage:find("success", 1, true) or lowerMessage:find("renamed", 1, true) then
+				return Configuration:GetSuccessColor()
+			end
+			if lowerMessage:find("fail", 1, true) or lowerMessage:find("denied", 1, true) or lowerMessage:find("taken", 1, true) or lowerMessage:find("already", 1, true) or lowerMessage:find("cooldown", 1, true) or lowerMessage:find("week", 1, true) or lowerMessage:find("month", 1, true) or lowerMessage:find("max", 1, true) or lowerMessage:find("too ", 1, true) then
+				return Configuration:GetErrorColor()
+			end
+			return Configuration:GetWarningColor()
+		end
+
 		WG.Analytics.SendOnetimeEvent("lobby:try_changeusername")
+		self.pendingRenameUserName = newusername
+		SetRenameButtonEnabled(false)
+		self.txtErrorChangeUserName:SetText(Configuration:GetWarningColor() .. "Sending rename request for: " .. newusername)
+
+		self.onRenameServerMSG = function(listener, message)
+			FinishRenameRequest(tostring(message or "No message"), GetRenameResponseColor(message))
+		end
+		lobby:AddListener("OnServerMSG", self.onRenameServerMSG)
+
+		self.onRenameDenied = function(listener, reason)
+			FinishRenameRequest("Rename denied: " .. tostring(reason or "No reason provided"), Configuration:GetErrorColor())
+		end
+		lobby:AddListener("OnDenied", self.onRenameDenied)
+
+		self.onRenameDisconnected = function(listener)
+			FinishRenameRequest("Disconnected after rename request. This usually means success; log in as: " .. newusername, Configuration:GetWarningColor())
+		end
+		lobby:AddListener("OnDisconnected", self.onRenameDisconnected)
+
+		WG.Delay(function()
+			if self.pendingRenameUserName == newusername then
+				FinishRenameRequest("No reply yet. Check whether you are still connected, then try again if needed.", Configuration:GetWarningColor())
+			end
+		end, 30)
+
 		lobby:RenameAccount(newusername)
-		self.txtErrorChangeUserName:SetText("You will be disconnected on success. Your new user name is: " .. newusername)
 	else
 		self.txtErrorChangeUserName:SetText(Configuration:GetErrorColor() .. "Must be logged in to change user name!")
 	end


### PR DESCRIPTION
Changes Recover/Change UI in account settings"

Fixes #1214 


Provides error message if username is over 20 characters. States maximum allowed character length as well as stating maximum username changing frequency. 

Text no longer clips. 


<img width="643" height="798" alt="image" src="https://github.com/user-attachments/assets/1b989493-5030-4ede-890d-ebeca40a0a4a" />


used codex for formatting
