### PR TITLE
AI faction set to random on add

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/singleplayerQuickSkirmish.lua
+++ b/LuaMenu/configs/gameConfig/byar/singleplayerQuickSkirmish.lua
@@ -279,7 +279,7 @@ function skirmishSetupData.ApplyFunction(battleLobby, pageChoices)
 			}
 			local battleStatusOptions = {
 				allyNumber = allyNumber,
-				side = math.random(0, 1),
+				side = 2,
 			}
 			if pageConfig[2].options[difficulty] == "Beginner" then
 				battleLobby:AddAi("SimpleAI" .. "(" .. aiNumber .. ")", "SimpleAI", allyNumber, nil, nil, battleStatusOptions)

--- a/LuaMenu/widgets/chobby/components/ai_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/ai_list_window.lua
@@ -199,7 +199,7 @@ function AiListWindow:AddAi(displayName, shortName, version, options)
 		counter = counter + 1
 	end
 
-	local battleStatusOptions = {side = math.random(0,1), teamColor = PickRandomColor(),}
+	local battleStatusOptions = {side = 2, teamColor = PickRandomColor(),}
 
 	if shortName == "BARb" then
 		if type(options) == "table" and options.profile and options.profile ~= "" then

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -4918,13 +4918,13 @@ function BattleRoomWindow.GetSingleplayerControl(setupData)
 
 					for i, ai in ipairs(singleplayerDefault.friendlyAI or {}) do
 						totalAIcount = AddAI(totalAIcount, ai.shortName, ai.version, 0,
-							0, -- Default side for friendly AI is Armada
+							2, -- random faction
 							GetStarterFriendlyAIColorAssignment(i))
 					end
 
 					for i, ai in ipairs(singleplayerDefault.enemyAI or {}) do
 						totalAIcount = AddAI(totalAIcount, ai.shortName, ai.version, 1,
-							1, -- Default side for enemy AI is Cortex
+							2, -- random faction
 							GetStarterEnemyAIColorAssignment(i))
 					end
 					if singleplayerDefault.startboxes then 


### PR DESCRIPTION
When an AI is added in single player and multiplayer  lobby, faction is set to random. 


Discord Discussion: https://discord.com/channels/549281623154229250/1503520595478839336
<img width="218" height="64" alt="image" src="https://github.com/user-attachments/assets/b5bfc02d-78ab-4583-b4ca-e938b5ab4166" />
