### PR TITLE
Clientside player notes

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -114,6 +114,8 @@ local votedUsers = {} -- 2023-06-29 FB: ToDo: Does not get reset, if user leaves
 local usersAllowedToVote = {}
 
 local PLAYER_NOTES_OPTION = "Add Player Notes"
+local PLAYER_NOTES_FILE = "playerNotes.json"
+local playerNotes
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -374,17 +376,72 @@ local function GetPlayerNoteKey(userName, userInfo)
 	return "name_" .. tostring(userName or "")
 end
 
-local function GetPlayerNote(userName, userInfo)
-	local Configuration = WG.Chobby and WG.Chobby.Configuration
-	local playerNotes = Configuration and Configuration.playerNotes
-	if type(playerNotes) ~= "table" then
-		return nil
+local function CleanPlayerNotes(rawNotes)
+	local cleanNotes = {}
+	if type(rawNotes) ~= "table" then
+		return cleanNotes
 	end
 
+	for key, value in pairs(rawNotes) do
+		if type(key) == "string" and type(value) == "string" and value ~= "" then
+			cleanNotes[key] = value
+		end
+	end
+	return cleanNotes
+end
+
+local function SavePlayerNotes()
+	local notesFile = io.open(PLAYER_NOTES_FILE, "w")
+	if not notesFile then
+		Spring.Echo("Unable to save player notes to " .. PLAYER_NOTES_FILE)
+		return
+	end
+	notesFile:write(Json.encode(playerNotes or {}))
+	notesFile:close()
+end
+
+local function LoadPlayerNotes()
+	if playerNotes then
+		return playerNotes
+	end
+
+	playerNotes = {}
+	if VFS.FileExists(PLAYER_NOTES_FILE) then
+		local rawNotes = VFS.LoadFile(PLAYER_NOTES_FILE)
+		if rawNotes and rawNotes ~= "" then
+			local success, decodedNotes = pcall(Json.decode, rawNotes)
+			if success then
+				playerNotes = CleanPlayerNotes(decodedNotes)
+			else
+				Spring.Echo("Unable to read player notes from " .. PLAYER_NOTES_FILE)
+			end
+		end
+	end
+
+	-- One-time migration for notes saved by the earlier config-backed version.
+	local configNotes = WG.Chobby and WG.Chobby.Configuration and WG.Chobby.Configuration.playerNotes
+	local migrated = false
+	if type(configNotes) == "table" then
+		for key, value in pairs(CleanPlayerNotes(configNotes)) do
+			if playerNotes[key] == nil then
+				playerNotes[key] = value
+				migrated = true
+			end
+		end
+	end
+	if migrated then
+		SavePlayerNotes()
+	end
+
+	return playerNotes
+end
+
+local function GetPlayerNote(userName, userInfo)
+	local notes = LoadPlayerNotes()
 	local noteKey = GetPlayerNoteKey(userName, userInfo)
-	local note = playerNotes[noteKey]
+	local note = notes[noteKey]
 	if (not note or note == "") and userInfo and userInfo.accountID ~= nil then
-		note = playerNotes["name_" .. tostring(userName or "")]
+		note = notes["name_" .. tostring(userName or "")]
 	end
 	if type(note) == "string" and note ~= "" then
 		return note
@@ -392,35 +449,22 @@ local function GetPlayerNote(userName, userInfo)
 end
 
 local function SetPlayerNote(userName, userInfo, note)
-	local Configuration = WG.Chobby and WG.Chobby.Configuration
-	if not Configuration then
-		return
-	end
-
-	local playerNotes = {}
-	if type(Configuration.playerNotes) == "table" then
-		for key, value in pairs(Configuration.playerNotes) do
-			if type(value) == "string" and value ~= "" then
-				playerNotes[key] = value
-			end
-		end
-	end
-
+	local notes = LoadPlayerNotes()
 	local cleanNote = TrimPlayerNote(note)
 	local noteKey = GetPlayerNoteKey(userName, userInfo)
 	local nameNoteKey = "name_" .. tostring(userName or "")
 	if cleanNote ~= "" then
-		playerNotes[noteKey] = cleanNote
+		notes[noteKey] = cleanNote
 		if nameNoteKey ~= noteKey then
-			playerNotes[nameNoteKey] = nil
+			notes[nameNoteKey] = nil
 		end
 	else
-		playerNotes[noteKey] = nil
-		playerNotes[nameNoteKey] = nil
+		notes[noteKey] = nil
+		notes[nameNoteKey] = nil
 	end
 
-	-- Client-side only: persisted in local Chobby config and never sent through lobby.
-	Configuration:SetConfigValue("playerNotes", playerNotes)
+	-- Client-side only: persisted to a local file and never sent through lobby.
+	SavePlayerNotes()
 end
 
 local function OpenPlayerNotesWindow(userName, userInfo)

--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -113,7 +113,6 @@ local UserLevelToImageConfFunction
 local votedUsers = {} -- 2023-06-29 FB: ToDo: Does not get reset, if user leaves battle during vote, but has no impact
 local usersAllowedToVote = {}
 
-local PLAYER_NOTES_OPTION = "Add Player Notes"
 local PLAYER_NOTES_FILE = "playerNotes.json"
 local playerNotes
 
@@ -418,21 +417,6 @@ local function LoadPlayerNotes()
 		end
 	end
 
-	-- One-time migration for notes saved by the earlier config-backed version.
-	local configNotes = WG.Chobby and WG.Chobby.Configuration and WG.Chobby.Configuration.playerNotes
-	local migrated = false
-	if type(configNotes) == "table" then
-		for key, value in pairs(CleanPlayerNotes(configNotes)) do
-			if playerNotes[key] == nil then
-				playerNotes[key] = value
-				migrated = true
-			end
-		end
-	end
-	if migrated then
-		SavePlayerNotes()
-	end
-
 	return playerNotes
 end
 
@@ -477,7 +461,7 @@ local function OpenPlayerNotesWindow(userName, userInfo)
 
 	WG.TextEntryWindow.CreateTextEntryWindow({
 		defaultValue = GetPlayerNote(userName, userInfo) or "",
-		caption = PLAYER_NOTES_OPTION,
+		caption = "Add Player Notes",
 		labelCaption = "Local note for " .. userName .. ". Leave blank to remove the note.",
 		hint = "Enter a local player note",
 		height = 260,
@@ -535,7 +519,7 @@ local function GetUserComboBoxOptions(userName, isInBattle, control, showTeamCol
 	if bs.aiLib then																								comboOptions[#comboOptions + 1] = "Clone AI" end
 	if bs.aiLib and bs.owner == myUserName and isInBattle then														comboOptions[#comboOptions + 1] = "Remove" end
 	if not itsme and not info.isBot and not bs.aiLib then															comboOptions[#comboOptions + 1] = "Report User" end
-	if not (info.isBot or bs.aiLib) then																			comboOptions[#comboOptions + 1] = PLAYER_NOTES_OPTION end
+	if not (info.isBot or bs.aiLib) then																			comboOptions[#comboOptions + 1] = "Add Player Notes" end
 																													comboOptions[#comboOptions + 1] = "Copy Name"
 	if (iAmBoss or iPlay) and not (control.isSingleplayer or bs.aiLib or info.isBot) and isInBattle  then			comboOptions[#comboOptions + 1] = "\255\128\128\128" .. "--------------"
 																													comboOptions[#comboOptions + 1] =  isBoss and "Disable Boss" or "Make Boss" end
@@ -1421,7 +1405,7 @@ local function GetUserControls(userName, opts)
 						local chatWindow = WG.Chobby.interfaceRoot.OpenPrivateChat(userName)
 					elseif selectedName == "Copy Name" then
 						Spring.SetClipboard(userName)
-					elseif selectedName == PLAYER_NOTES_OPTION then
+					elseif selectedName == "Add Player Notes" then
 						local latestUserInfo = userControls.lobby:GetUser(userName) or userInfo or {}
 						OpenPlayerNotesWindow(userName, latestUserInfo)
 					elseif selectedName == "Kickban" then

--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -113,6 +113,8 @@ local UserLevelToImageConfFunction
 local votedUsers = {} -- 2023-06-29 FB: ToDo: Does not get reset, if user leaves battle during vote, but has no impact
 local usersAllowedToVote = {}
 
+local PLAYER_NOTES_OPTION = "Add Player Notes"
+
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Globally Applicable Utilities
@@ -357,6 +359,95 @@ local function GetUserClanImage(userName, userControl)
 	return file, needDownload
 end
 
+local function TrimPlayerNote(note)
+	if type(note) ~= "string" then
+		return ""
+	end
+	return note:gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+local function GetPlayerNoteKey(userName, userInfo)
+	userInfo = userInfo or {}
+	if userInfo.accountID ~= nil and tostring(userInfo.accountID) ~= "" then
+		return "account_" .. tostring(userInfo.accountID)
+	end
+	return "name_" .. tostring(userName or "")
+end
+
+local function GetPlayerNote(userName, userInfo)
+	local Configuration = WG.Chobby and WG.Chobby.Configuration
+	local playerNotes = Configuration and Configuration.playerNotes
+	if type(playerNotes) ~= "table" then
+		return nil
+	end
+
+	local noteKey = GetPlayerNoteKey(userName, userInfo)
+	local note = playerNotes[noteKey]
+	if (not note or note == "") and userInfo and userInfo.accountID ~= nil then
+		note = playerNotes["name_" .. tostring(userName or "")]
+	end
+	if type(note) == "string" and note ~= "" then
+		return note
+	end
+end
+
+local function SetPlayerNote(userName, userInfo, note)
+	local Configuration = WG.Chobby and WG.Chobby.Configuration
+	if not Configuration then
+		return
+	end
+
+	local playerNotes = {}
+	if type(Configuration.playerNotes) == "table" then
+		for key, value in pairs(Configuration.playerNotes) do
+			if type(value) == "string" and value ~= "" then
+				playerNotes[key] = value
+			end
+		end
+	end
+
+	local cleanNote = TrimPlayerNote(note)
+	local noteKey = GetPlayerNoteKey(userName, userInfo)
+	local nameNoteKey = "name_" .. tostring(userName or "")
+	if cleanNote ~= "" then
+		playerNotes[noteKey] = cleanNote
+		if nameNoteKey ~= noteKey then
+			playerNotes[nameNoteKey] = nil
+		end
+	else
+		playerNotes[noteKey] = nil
+		playerNotes[nameNoteKey] = nil
+	end
+
+	-- Client-side only: persisted in local Chobby config and never sent through lobby.
+	Configuration:SetConfigValue("playerNotes", playerNotes)
+end
+
+local function OpenPlayerNotesWindow(userName, userInfo)
+	if not WG.TextEntryWindow then
+		if WG.Chobby and WG.Chobby.InformationPopup then
+			WG.Chobby.InformationPopup("Text entry is not available.")
+		end
+		return
+	end
+
+	WG.TextEntryWindow.CreateTextEntryWindow({
+		defaultValue = GetPlayerNote(userName, userInfo) or "",
+		caption = PLAYER_NOTES_OPTION,
+		labelCaption = "Local note for " .. userName .. ". Leave blank to remove the note.",
+		hint = "Enter a local player note",
+		height = 260,
+		width = 520,
+		oklabel = "Save",
+		OnAccepted = function(newNote)
+			SetPlayerNote(userName, userInfo, newNote)
+		end,
+		OnOpen = function(editBox)
+			editBox:SelectAll()
+		end
+	})
+end
+
 local function GetUserComboBoxOptions(userName, isInBattle, control, showTeamColor, showSide)
 	local Configuration = WG.Chobby.Configuration
 	local info = control.lobby:GetUser(userName) or {}
@@ -400,6 +491,7 @@ local function GetUserComboBoxOptions(userName, isInBattle, control, showTeamCol
 	if bs.aiLib then																								comboOptions[#comboOptions + 1] = "Clone AI" end
 	if bs.aiLib and bs.owner == myUserName and isInBattle then														comboOptions[#comboOptions + 1] = "Remove" end
 	if not itsme and not info.isBot and not bs.aiLib then															comboOptions[#comboOptions + 1] = "Report User" end
+	if not (info.isBot or bs.aiLib) then																			comboOptions[#comboOptions + 1] = PLAYER_NOTES_OPTION end
 																													comboOptions[#comboOptions + 1] = "Copy Name"
 	if (iAmBoss or iPlay) and not (control.isSingleplayer or bs.aiLib or info.isBot) and isInBattle  then			comboOptions[#comboOptions + 1] = "\255\128\128\128" .. "--------------"
 																													comboOptions[#comboOptions + 1] =  isBoss and "Disable Boss" or "Make Boss" end
@@ -1285,6 +1377,9 @@ local function GetUserControls(userName, opts)
 						local chatWindow = WG.Chobby.interfaceRoot.OpenPrivateChat(userName)
 					elseif selectedName == "Copy Name" then
 						Spring.SetClipboard(userName)
+					elseif selectedName == PLAYER_NOTES_OPTION then
+						local latestUserInfo = userControls.lobby:GetUser(userName) or userInfo or {}
+						OpenPlayerNotesWindow(userName, latestUserInfo)
 					elseif selectedName == "Kickban" then
 						local function YesFunc()
 							lobby:SayBattle("!kickban "..userName)
@@ -2004,7 +2099,9 @@ end
 local userHandler = {
 	CountryShortnameToFlag = CountryShortnameToFlag,
 	GetUserRankImage = GetUserRankImage,
-	GetClanImage = GetClanImage
+	GetClanImage = GetClanImage,
+	GetPlayerNote = GetPlayerNote,
+	SetPlayerNote = SetPlayerNote
 }
 
 function userHandler.SetTooltipBattle(battle)

--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -437,6 +437,9 @@ end
 local function SetPlayerNote(userName, userInfo, note)
 	local notes = LoadPlayerNotes()
 	local cleanNote = TrimPlayerNote(note)
+	if type(note) == "string" and #(note:gsub("^%s+", ""):gsub("%s+$", "")) > 100 and WG.Chobby and WG.Chobby.InformationPopup then
+		WG.Chobby.InformationPopup("Player notes are limited to 100 characters. Your note was shortened to 100 characters.", {width = 420, height = 180})
+	end
 	local noteKey = GetPlayerNoteKey(userName, userInfo)
 	local nameNoteKey = "name_" .. tostring(userName or "")
 	if cleanNote ~= "" then

--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -113,7 +113,6 @@ local UserLevelToImageConfFunction
 local votedUsers = {} -- 2023-06-29 FB: ToDo: Does not get reset, if user leaves battle during vote, but has no impact
 local usersAllowedToVote = {}
 
-local PLAYER_NOTES_FILE = "playerNotes.json"
 local playerNotes
 
 --------------------------------------------------------------------------------
@@ -364,7 +363,7 @@ local function TrimPlayerNote(note)
 	if type(note) ~= "string" then
 		return ""
 	end
-	return note:gsub("^%s+", ""):gsub("%s+$", "")
+	return note:gsub("^%s+", ""):gsub("%s+$", ""):sub(1, 100)
 end
 
 local function GetPlayerNoteKey(userName, userInfo)
@@ -382,17 +381,20 @@ local function CleanPlayerNotes(rawNotes)
 	end
 
 	for key, value in pairs(rawNotes) do
-		if type(key) == "string" and type(value) == "string" and value ~= "" then
-			cleanNotes[key] = value
+		if type(key) == "string" and type(value) == "string" then
+			local cleanNote = TrimPlayerNote(value)
+			if cleanNote ~= "" then
+				cleanNotes[key] = cleanNote
+			end
 		end
 	end
 	return cleanNotes
 end
 
 local function SavePlayerNotes()
-	local notesFile = io.open(PLAYER_NOTES_FILE, "w")
+	local notesFile = io.open("playerNotes.json", "w")
 	if not notesFile then
-		Spring.Echo("Unable to save player notes to " .. PLAYER_NOTES_FILE)
+		Spring.Echo("Unable to save player notes to playerNotes.json")
 		return
 	end
 	notesFile:write(Json.encode(playerNotes or {}))
@@ -405,14 +407,14 @@ local function LoadPlayerNotes()
 	end
 
 	playerNotes = {}
-	if VFS.FileExists(PLAYER_NOTES_FILE) then
-		local rawNotes = VFS.LoadFile(PLAYER_NOTES_FILE)
+	if VFS.FileExists("playerNotes.json") then
+		local rawNotes = VFS.LoadFile("playerNotes.json")
 		if rawNotes and rawNotes ~= "" then
 			local success, decodedNotes = pcall(Json.decode, rawNotes)
 			if success then
 				playerNotes = CleanPlayerNotes(decodedNotes)
 			else
-				Spring.Echo("Unable to read player notes from " .. PLAYER_NOTES_FILE)
+				Spring.Echo("Unable to read player notes from playerNotes.json")
 			end
 		end
 	end
@@ -462,8 +464,8 @@ local function OpenPlayerNotesWindow(userName, userInfo)
 	WG.TextEntryWindow.CreateTextEntryWindow({
 		defaultValue = GetPlayerNote(userName, userInfo) or "",
 		caption = "Add Player Notes",
-		labelCaption = "Local note for " .. userName .. ". Leave blank to remove the note.",
-		hint = "Enter a local player note",
+		labelCaption = "Local note for " .. userName .. ". 100 character limit. Leave blank to remove the note.",
+		hint = "Enter a local player note, up to 100 characters",
 		height = 260,
 		width = 520,
 		oklabel = "Save",

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -94,7 +94,6 @@ function Configuration:init()
 	self.alreadySeenFactionPopup4 = false
 	self.firstBattleStarted = false
 	self.seenWelcomeItems = {}
-	self.playerNotes = {}
 	self.lobbyTimeoutTime = 60 -- Seconds
 
 	self.battleFilterPassworded2 = true
@@ -709,7 +708,6 @@ function Configuration:GetConfigData()
 		alreadySeenFactionPopup4 = self.alreadySeenFactionPopup4,
 		firstBattleStarted = self.firstBattleStarted,
 		seenWelcomeItems = self.seenWelcomeItems,
-		playerNotes = self.playerNotes,
 		battleFilterPassworded2 = self.battleFilterPassworded2,
 		battleFilterNonFriend = self.battleFilterNonFriend,
 		battleFilterRunning = self.battleFilterRunning,

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -94,6 +94,7 @@ function Configuration:init()
 	self.alreadySeenFactionPopup4 = false
 	self.firstBattleStarted = false
 	self.seenWelcomeItems = {}
+	self.playerNotes = {}
 	self.lobbyTimeoutTime = 60 -- Seconds
 
 	self.battleFilterPassworded2 = true
@@ -708,6 +709,7 @@ function Configuration:GetConfigData()
 		alreadySeenFactionPopup4 = self.alreadySeenFactionPopup4,
 		firstBattleStarted = self.firstBattleStarted,
 		seenWelcomeItems = self.seenWelcomeItems,
+		playerNotes = self.playerNotes,
 		battleFilterPassworded2 = self.battleFilterPassworded2,
 		battleFilterNonFriend = self.battleFilterNonFriend,
 		battleFilterRunning = self.battleFilterRunning,

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -999,10 +999,25 @@ local function GetUserTooltip(userName, userInfo, userBattleInfo, inBattleroom)
 
 	if playerNote then
 		if not userTooltip.playerNote then
-			userTooltip.playerNote = GetTooltipLine(userTooltip.mainControl)
+			userTooltip.playerNote = Chili.TextBox:New{
+				x      = 6,
+				y      = offset,
+				width  = width - 12,
+				height = 20,
+				align  = "left",
+				parent = userTooltip.mainControl,
+				objectOverrideFont = Configuration:GetFont(2, "Nimbus2", {font = "fonts/n019003l.pfb"}),
+				objectOverrideHintFont = Configuration:GetFont(2, "Nimbus2"),
+				text = "",
+			}
+		else
+			userTooltip.playerNote:Show()
 		end
-		userTooltip.playerNote.Update(offset, "Note: " .. playerNote)
-		offset = offset + 20 * math.max(1, userTooltip.playerNote.GetLines())
+		userTooltip.playerNote:SetText("Note: " .. playerNote)
+		userTooltip.playerNote:SetPos(nil, offset, width - 12)
+		userTooltip.playerNote:UpdateLayout()
+		local noteLines = userTooltip.playerNote.physicalLines and #userTooltip.playerNote.physicalLines or 1
+		offset = offset + 20 * math.max(1, noteLines)
 	elseif userTooltip.playerNote then
 		userTooltip.playerNote:Hide()
 	end

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -650,6 +650,10 @@ local function GetUserTooltip(userName, userInfo, userBattleInfo, inBattleroom)
 	end
 
 	local width = 240
+	local playerNote = WG.UserHandler and WG.UserHandler.GetPlayerNote and WG.UserHandler.GetPlayerNote(userName, userInfo)
+	if playerNote then
+		width = 320
+	end
 	if not userTooltip.mainControl then
 		userTooltip.mainControl = Chili.Control:New {
 			x = 0,
@@ -991,6 +995,16 @@ local function GetUserTooltip(userName, userInfo, userBattleInfo, inBattleroom)
 		userTooltip.battleInfoHolder:SetPos(nil, nil, width, battleOffset)
 	elseif userTooltip.battleInfoHolder then
 		userTooltip.battleInfoHolder:Hide()
+	end
+
+	if playerNote then
+		if not userTooltip.playerNote then
+			userTooltip.playerNote = GetTooltipLine(userTooltip.mainControl)
+		end
+		userTooltip.playerNote.Update(offset, "Note: " .. playerNote)
+		offset = offset + 20 * math.max(1, userTooltip.playerNote.GetLines())
+	elseif userTooltip.playerNote then
+		userTooltip.playerNote:Hide()
 	end
 
 	-- Debug Mode


### PR DESCRIPTION
Old feature request: https://discord.com/channels/549281623154229250/1452517663103520840


Players can right-click a player name and choose ``Add Player Notes``. The note is saved locally in a .json and shown at the bottom of that player’s hover tooltip.

Note: Notes are not sent to the server, they are  local state but can be transferred if the .json file is shared. 


- Limits notes to 100 characters. Displays pop up warning if note exceeds char count  
- File path for saved .json file ``Beyond-All-Reason\data\playerNotes.json``
- Accounts by `account_<accountID>` and, with `name_<username>` as a fallback.

<img width="225" height="127" alt="image" src="https://github.com/user-attachments/assets/33bf6ce1-441a-4d59-a522-16b109c022bd" />
<img width="313" height="300" alt="image" src="https://github.com/user-attachments/assets/f19dfd7c-0889-4064-b4aa-9488c10c294b" />



Codex used with for coding assistance 