### PR TITLE
Fix selecting player names in lobby chat

### DIFF
--- a/LuaMenu/widgets/chobby/components/console.lua
+++ b/LuaMenu/widgets/chobby/components/console.lua
@@ -165,17 +165,6 @@ function Console:init(channelName, sendMessageListener, noHistoryLoad, onResizeF
 			self.sentMessageIndex = 1
 		end
 	}
-	self.fakeImage = Image:New {
-		x = 0, y = 0,
-		bottom = 0, right = 0,
-		OnClick = { function()
-			if self.emojiPicker then
-				self.emojiPicker:Hide()
-			end
-			screen0:FocusControl(self.ebInputText)
-		end}
-	}
-
 	self.panel = Control:New {
 		x = 0,
 		y = 0,
@@ -187,7 +176,6 @@ function Console:init(channelName, sendMessageListener, noHistoryLoad, onResizeF
 		children = {
 			self.spHistory,
 			self.ebInputText,
-			self.fakeImage,
 			self.emojiPicker,
 			self.btnEmojiPicker,
 		},


### PR DESCRIPTION
Removed the ability to close the emoji selector by pressing anywhere in the chatbox. Previously this was an invisible overlay on that chatbox however it is causing issues where players could not select the player names of anyone by pressing their username within chat once the emoji button was pressed.

This PR will reset hover and right click behavior in chobby to previous versions. 

Issue described by @fightwar :  https://discord.com/channels/549281623154229250/549281623577722899/1526746208390086758
<img width="864" height="412" alt="image" src="https://github.com/user-attachments/assets/17cf7e49-43ed-4b40-bf8b-4ac60ab33f2e" />

