### PR TITLE
Restore inline emoji in chat history: add text selection support to EmojiTextBox

### DIFF
--- a/LuaMenu/widgets/chobby/components/console.lua
+++ b/LuaMenu/widgets/chobby/components/console.lua
@@ -42,7 +42,7 @@ function Console:init(channelName, sendMessageListener, noHistoryLoad, onResizeF
 	else
 		font = Configuration:GetFont(Configuration.chatFontSize, "console_" .. Configuration.chatFontSize, {font = "fonts/n019003l.pfb", shadow = true}, true)
 	end
-	local HistoryTextBox = TextBox
+	local HistoryTextBox = EmojiTextBox or TextBox
 	self.tbHistory = HistoryTextBox:New {
 		x = 0,
 		right = 0,

--- a/LuaMenu/widgets/chobby/components/emoji_text_box.lua
+++ b/LuaMenu/widgets/chobby/components/emoji_text_box.lua
@@ -1,3 +1,7 @@
+local spGetKeyCode = Spring.GetKeyCode
+local spGetModKeyState = Spring.GetModKeyState
+local spSetClipboard = Spring.SetClipboard
+
 EmojiTextBox = Control:Inherit{
 	classname = "emojitextbox",
 
@@ -15,6 +19,32 @@ EmojiTextBox = Control:Inherit{
 	emojiInlinePadding = 2,
 	lines = {},
 	physicalLines = {},
+
+	cursor = 1,
+	cursorY = 1,
+	selStart = nil,
+	selStartY = nil,
+	selEnd = nil,
+	selEndY = nil,
+	selectionColor = {0, 1, 1, 0.3},
+
+	inedibleInput = {
+		[spGetKeyCode("enter")] = true,
+		[spGetKeyCode("numpad_enter")] = true,
+		[spGetKeyCode("esc")] = true,
+		[spGetKeyCode("f1")] = true,
+		[spGetKeyCode("f2")] = true,
+		[spGetKeyCode("f3")] = true,
+		[spGetKeyCode("f4")] = true,
+		[spGetKeyCode("f5")] = true,
+		[spGetKeyCode("f6")] = true,
+		[spGetKeyCode("f7")] = true,
+		[spGetKeyCode("f8")] = true,
+		[spGetKeyCode("f9")] = true,
+		[spGetKeyCode("f10")] = true,
+		[spGetKeyCode("f11")] = true,
+		[spGetKeyCode("f12")] = true,
+	},
 }
 
 local this = EmojiTextBox
@@ -357,6 +387,12 @@ function EmojiTextBox:SetText(newtext, tooltips, OnTextClick, allowEmoji)
 	newtext = newtext or ""
 	self.text = newtext
 	self.lines = {}
+	self.cursor = 1
+	self.cursorY = 1
+	self.selStart = nil
+	self.selStartY = nil
+	self.selEnd = nil
+	self.selEndY = nil
 	for line in LineIterator(newtext) do
 		self.lines[#self.lines + 1] = {
 			text = line,
@@ -370,6 +406,14 @@ end
 
 function EmojiTextBox:AddLine(text, tooltips, OnTextClick, allowEmoji)
 	if self.agressiveMaxLines and #self.lines > self.agressiveMaxLines then
+		-- Line indices shift when trimming, so any active selection becomes invalid.
+		self.forgetMouseMove = true
+		self.cursor = 1
+		self.cursorY = 1
+		self.selStart = nil
+		self.selStartY = nil
+		self.selEnd = nil
+		self.selEndY = nil
 		local preserve = {}
 		for i = math.max(1, #self.lines - self.agressiveMaxLinesPreserve), #self.lines do
 			preserve[#preserve + 1] = self.lines[i]
@@ -416,6 +460,148 @@ function EmojiTextBox:GetPhysicalLinePosition(distanceFromBottom, usePhysical)
 	return 0
 end
 
+function EmojiTextBox:_ClampCursor(lineID, cursor)
+	lineID = math.max(1, math.min(lineID or 1, math.max(1, #self.lines)))
+	local lineText = self.lines[lineID] and self.lines[lineID].text or ""
+	cursor = math.max(1, math.min(cursor or 1, #lineText + 1))
+	return lineID, cursor
+end
+
+function EmojiTextBox:_SetSelection(selStart, selStartY, selEnd, selEndY)
+	self.selStart  = selStart  or self.selStart
+	self.selStartY = selStartY or self.selStartY
+	self.selEnd    = selEnd    or self.selEnd
+	self.selEndY   = selEndY   or self.selEndY
+	if self.selStartY then
+		self.selStartY, self.selStart = self:_ClampCursor(self.selStartY, self.selStart)
+	end
+	if self.selEndY then
+		self.selEndY, self.selEnd = self:_ClampCursor(self.selEndY, self.selEnd)
+	end
+end
+
+function EmojiTextBox:_ClearSelection()
+	self.selStart = nil
+	self.selStartY = nil
+	self.selEnd = nil
+	self.selEndY = nil
+end
+
+local function RemoveColorFromText(text)
+	text = text:gsub("\255...", ""):gsub("\b", "")
+	return text
+end
+
+function EmojiTextBox:GetSelectionText()
+	local sy = self.selStartY
+	local ey = self.selEndY
+	local s = self.selStart
+	local e = self.selEnd
+	if not (s and e and sy and ey) then
+		return nil
+	end
+	if sy > ey then
+		sy, ey = ey, sy
+		s, e = e, s
+	elseif sy == ey and s > e then
+		s, e = e, s
+	end
+	if sy == ey then
+		return RemoveColorFromText(self.lines[sy].text:sub(s, e - 1))
+	end
+	local ls = {}
+	table.insert(ls, RemoveColorFromText(self.lines[sy].text:sub(s)))
+	for i = sy + 1, ey - 1 do
+		table.insert(ls, RemoveColorFromText(self.lines[i].text))
+	end
+	table.insert(ls, RemoveColorFromText(self.lines[ey].text:sub(1, e - 1)))
+	return table.concat(ls, "\n")
+end
+
+function EmojiTextBox:SelectAll()
+	if #self.lines == 0 then
+		return
+	end
+	self:_SetSelection(1, 1, #self.lines[#self.lines].text + 1, #self.lines)
+	self:Invalidate()
+end
+
+function EmojiTextBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
+	local eatInput = true
+	if mods.ctrl and (key == spGetKeyCode("c") or key == spGetKeyCode("insert")) then
+		local txt = self:GetSelectionText()
+		if txt then
+			spSetClipboard(txt)
+		end
+	elseif mods.ctrl and key == spGetKeyCode("a") then
+		self:SelectAll()
+	else
+		eatInput = self.state.focused and not self.inedibleInput[key]
+	end
+	eatInput = inherited.KeyPress(self, key, mods, isRepeat, label, unicode, ...) or eatInput
+	self:Invalidate()
+	return eatInput
+end
+
+-- Returns the x offset of a byte cursor within a physical line, walking token widths.
+function EmojiTextBox:GetCursorXOffset(physicalLine, cursor)
+	local x = 0
+	local tokens = physicalLine.tokens
+	for i = 1, #tokens do
+		local token = tokens[i]
+		if cursor <= token.startIndex then
+			return x
+		end
+		if token.type == "text" and cursor <= token.endIndex then
+			return x + self:GetTextWidth(string.sub(token.text, 1, cursor - token.startIndex))
+		end
+		x = x + (token.width or 0)
+	end
+	return x
+end
+
+function EmojiTextBox:DrawSelection()
+	local top, left = self.selStartY, self.selStart
+	local bottom, right = self.selEndY, self.selEnd
+	if not (top and left and bottom and right) then
+		return
+	end
+	if top > bottom then
+		top, bottom = bottom, top
+		left, right = right, left
+	elseif top == bottom and left > right then
+		left, right = right, left
+	end
+	if top == bottom and left == right then
+		return
+	end
+	local clientX, clientY = self.clientArea[1], self.clientArea[2]
+	local lineHeight = self:GetLineHeight()
+	local cc = self.selectionColor
+	gl.Color(cc[1], cc[2], cc[3], cc[4])
+	for i = 1, #self.physicalLines do
+		local physicalLine = self.physicalLines[i]
+		if physicalLine.lineID >= top and physicalLine.lineID <= bottom then
+			local tokens = physicalLine.tokens
+			local firstToken = tokens[1]
+			local lastToken = tokens[#tokens]
+			local lineStart = firstToken and firstToken.startIndex or 1
+			local lineEnd = lastToken and (lastToken.endIndex + 1) or 1
+			local selFrom = (physicalLine.lineID == top) and math.max(left, lineStart) or lineStart
+			local selTo = (physicalLine.lineID == bottom) and math.min(right, lineEnd) or lineEnd
+			if selTo > selFrom then
+				local x1 = self:GetCursorXOffset(physicalLine, selFrom)
+				local x2 = self:GetCursorXOffset(physicalLine, selTo)
+				if x2 > x1 then
+					local y = clientY + physicalLine.y
+					gl.Rect(clientX + x1, y, clientX + x2, y + lineHeight)
+				end
+			end
+		end
+	end
+	gl.Color(1, 1, 1, 1)
+end
+
 function EmojiTextBox:DrawEmoji(token, x, y)
 	local size = self:GetEmojiSize()
 	local padding = self:GetEmojiInlinePadding(size)
@@ -450,6 +636,9 @@ function EmojiTextBox:DrawControl()
 				self.font:Draw(run.text, clientX + run.x, y)
 			end
 		end
+	end
+	if self.selStart and self.state.focused then
+		self:DrawSelection()
 	end
 end
 
@@ -495,10 +684,11 @@ function EmojiTextBox:GetCursorByMousePos(x, y)
 	end
 
 	local lastToken = physicalLine.tokens[#physicalLine.tokens]
-	return physicalLine.lineID, lastToken and lastToken.endIndex or 1
+	return physicalLine.lineID, lastToken and (lastToken.endIndex + 1) or 1
 end
 
 function EmojiTextBox:MouseDown(x, y, ...)
+	self.forgetMouseMove = nil
 	local lineID, cursor = self:GetCursorByMousePos(x, y)
 	local line = lineID and self.lines[lineID]
 	if line and line.OnTextClick then
@@ -514,7 +704,28 @@ function EmojiTextBox:MouseDown(x, y, ...)
 		end
 	end
 	local localX, localY = self:NormalizeLocalMousePos(x, y)
-	return inherited.MouseDown(self, localX, localY, ...)
+	if not self.selectable then
+		return inherited.MouseDown(self, localX, localY, ...)
+	end
+
+	local _, _, _, shift = spGetModKeyState()
+	local oldCursor, oldCursorY = self.cursor, self.cursorY
+	local lineID2, cursor2 = self:GetCursorByMousePos(localX, localY)
+	if lineID2 then
+		self.cursorY, self.cursor = self:_ClampCursor(lineID2, cursor2)
+	end
+	if shift then
+		if not self.selStart then
+			self:_SetSelection(oldCursor, oldCursorY, nil, nil)
+		end
+		self:_SetSelection(nil, nil, self.cursor, self.cursorY)
+	elseif self.selStart then
+		self:_ClearSelection()
+	end
+
+	inherited.MouseDown(self, localX, localY, ...)
+	self:Invalidate()
+	return self
 end
 
 function EmojiTextBox:MouseMove(x, y, dx, dy, button)
@@ -538,7 +749,37 @@ function EmojiTextBox:MouseMove(x, y, dx, dy, button)
 			self.tooltip = nil
 		end
 	end
-	return inherited.MouseMove(self, localX, localY, dx, dy, button)
+
+	if button ~= 1 and button ~= true then
+		return inherited.MouseMove(self, localX, localY, dx, dy, button)
+	end
+	if self.forgetMouseMove then
+		return self
+	end
+	if not self.selectable then
+		return inherited.MouseMove(self, localX, localY, dx, dy, button)
+	end
+
+	local oldCursor, oldCursorY = self.cursor, self.cursorY
+	local lineID, cursor = self:GetCursorByMousePos(localX, localY)
+	if lineID then
+		self.cursorY, self.cursor = self:_ClampCursor(lineID, cursor)
+		if not self.selStart then
+			self:_SetSelection(oldCursor, oldCursorY, nil, nil)
+		end
+		self:_SetSelection(nil, nil, self.cursor, self.cursorY)
+	end
+
+	inherited.MouseMove(self, localX, localY, dx, dy, button)
+	self:Invalidate()
+	return self
+end
+
+function EmojiTextBox:MouseUp(x, y, ...)
+	local localX, localY = self:NormalizeLocalMousePos(x, y)
+	inherited.MouseUp(self, localX, localY, ...)
+	self:Invalidate()
+	return self
 end
 
 function EmojiTextBox:HitTest()


### PR DESCRIPTION
Happy World Emoji Day! 📅 I saw the addition of emoji to chat (as images rather than font) and the issues it then caused with text selection. I don't know Lua so had to use AI to help out. Full details below. Apologies for the slightly insane level of detail.

## Summary

`ae59d1ea` ("fix text selections") switched the console history back to plain
`TextBox` because `EmojiTextBox` didn't support text selection. This PR adds
EditBox-parity selection/copy to `EmojiTextBox` and restores
`local HistoryTextBox = EmojiTextBox or TextBox`, bringing inline emoji back to
lobby chat without losing selection.

## What was added to EmojiTextBox

- Drag selection with per-physical-line highlight (drawn in `DrawControl`, only
  while focused, using EditBox's `selectionColor` default), including wrapped
  lines, multi-message ranges, and reverse drags.
- Shift-click to extend a selection.
- `Ctrl+C` / `Ctrl+Insert` copy via `Spring.SetClipboard`, `Ctrl+A` select-all.
  Copied text strips inline color codes (same regex as EditBox) and keeps emoji
  as their `:alias:` shortcodes, so pastes stay readable.
- Selection state follows EditBox conventions (`selStart`/`selStartY`/`selEnd`/
  `selEndY`, logical line + byte cursor) and is cleared on `SetText` and on
  `agressiveMaxLines` trimming (with `forgetMouseMove`, like EditBox, so an
  in-progress drag doesn't resurrect a stale selection).
- `MouseDown` now returns `self` so `Screen` assigns focus and routes the drag
  (`activeControl`), which is also what makes `KeyPress` reachable; `MouseUp`
  added for symmetry. Key handling mirrors EditBox's eat/`inedibleInput` rules.
- `GetCursorByMousePos` now returns `endIndex + 1` past the last token, which
  also stops clicks in the empty space right of a line from triggering a
  trailing clickable URL (matches EditBox's out-of-bounds behavior).

Clicking an emoji cell snaps the cursor to the shortcode boundary, so emoji are
selected atomically.

## Testing

Manual pass in the Dev Lobby (Windows, engine per current launcher config),
2026-07-17 — all sections PASSED:

- **Emoji rendering:** inline images in sent/received messages, multi-emoji
  runs, unknown aliases stay literal text, custom `:cookie:`, picker insertion,
  wrapped long lines, reloaded chat history; system lines (no username) are not
  substituted.
- **Selection/copy (the `ae59d1ea` regression):** drag highlight within and
  across messages and over emoji, reverse drags, shift-click extend,
  Ctrl+C/Ctrl+Insert/Ctrl+A — pasted text has colors stripped and emoji as
  `:alias:` shortcodes; plain click clears; focus handoff to the input box
  behaves as on master.
- **Clickable URLs & names:** URL click/tooltip works, clicks past end-of-line
  no longer trigger a trailing URL, player-name click opens the user dropdown,
  name tooltips show/clear.
- **Console mechanics:** smart autoscroll pinning, >500-line trimming, live
  chat-font-size changes, battleroom/private/debug (monospaced) consoles, tab
  autocomplete of shortcodes, picker overlay clickthrough.
- **Stability:** busy-channel soak, infolog clean of Lua errors.

Demo recording:

https://github.com/user-attachments/assets/d35bff24-633e-46f9-9475-0635e476998b

See`Recording 2026-07-17 165519.mp4`

Additionally, a headless unit suite (51 cases) exercises the real
`chat_emojis.lua`/`emoji_text_box.lua` under LuaJIT with a stubbed Chili env:
tokenizer, wrapping, cursor mapping, selection/copy incl. color stripping,
trim-clears-selection, OnTextClick/tooltip ranges, and a 620-message
console-parity smoke test. Harness kept out of the repo; happy to share or add
it if wanted.

## AI disclosure (per AI_POLICY.md)

This contribution was AI-assisted: implementation and the unit-test harness were
written with Claude Code (Claude Fable 5), directed and reviewed by me. All
in-lobby verification above was performed by me by hand; the recording is
attached.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
