### PR TITLE
various emoji changes

### DIFF
--- a/LuaMenu/widgets/chobby/components/chat_emojis.lua
+++ b/LuaMenu/widgets/chobby/components/chat_emojis.lua
@@ -50,12 +50,10 @@ end
 table.sort(ChatEmojis.sortedAliases)
 
 ChatEmojis._aliasImagePath = {}
-ChatEmojis._unicodeStartChars = {}
-ChatEmojis._unicodeStartSet = {}
 ChatEmojis._candidateCache = {}
 ChatEmojis._candidateCacheCount = 0
 ChatEmojis._candidateCacheMax = 4096
-
+-- Only known :alias:  should enable emoji parsing
 local function HasRenderableAlias(text)
 	for alias in string.gmatch(text, ":([%a_]+):") do
 		if ChatEmojis._aliasImagePath[alias] ~= nil then
@@ -69,13 +67,6 @@ for alias, data in pairs(ChatEmojis.aliasData) do
 	if data and data.image then
 		ChatEmojis._aliasImagePath[alias] = (data.custom and ChatEmojis.customImageDir or ChatEmojis.imageDir) .. data.image
 	end
-	if data and data.unicode then
-		local firstByte = string.byte(data.unicode, 1)
-		if firstByte and not ChatEmojis._unicodeStartSet[firstByte] then
-			ChatEmojis._unicodeStartSet[firstByte] = true
-			ChatEmojis._unicodeStartChars[#ChatEmojis._unicodeStartChars + 1] = string.char(firstByte)
-		end
-	end
 end
 
 function ChatEmojis.HasEmojiCandidate(text)
@@ -88,7 +79,10 @@ function ChatEmojis.HasEmojiCandidate(text)
 		return cached
 	end
 
-	local hasEmoji = HasRenderableAlias(text)
+	local hasEmoji = false
+	if string.find(text, ":", 1, true) then
+		hasEmoji = HasRenderableAlias(text)
+	end
 
 	if ChatEmojis._candidateCache[text] == nil then
 		ChatEmojis._candidateCacheCount = ChatEmojis._candidateCacheCount + 1

--- a/LuaMenu/widgets/chobby/components/chat_emojis.lua
+++ b/LuaMenu/widgets/chobby/components/chat_emojis.lua
@@ -56,6 +56,16 @@ ChatEmojis._candidateCache = {}
 ChatEmojis._candidateCacheCount = 0
 ChatEmojis._candidateCacheMax = 4096
 
+local function HasRenderableAlias(text)
+	-- Find a real :alias: token; timestamps and usernames also contain colons.
+	for alias in string.gmatch(text, ":([%a_]+):") do
+		if ChatEmojis._aliasImagePath[alias] ~= nil then
+			return true
+		end
+	end
+	return false
+end
+
 for alias, data in pairs(ChatEmojis.aliasData) do
 	if data and data.image then
 		ChatEmojis._aliasImagePath[alias] = (data.custom and ChatEmojis.customImageDir or ChatEmojis.imageDir) .. data.image
@@ -79,18 +89,7 @@ function ChatEmojis.HasEmojiCandidate(text)
 		return cached
 	end
 
-	local hasEmoji = false
-	local firstColon = string.find(text, ":", 1, true)
-	if firstColon and string.find(text, ":", firstColon + 1, true) then
-		hasEmoji = true
-	else
-		for i = 1, #ChatEmojis._unicodeStartChars do
-			if string.find(text, ChatEmojis._unicodeStartChars[i], 1, true) then
-				hasEmoji = true
-				break
-			end
-		end
-	end
+	local hasEmoji = HasRenderableAlias(text)
 
 	if ChatEmojis._candidateCache[text] == nil then
 		ChatEmojis._candidateCacheCount = ChatEmojis._candidateCacheCount + 1

--- a/LuaMenu/widgets/chobby/components/chat_emojis.lua
+++ b/LuaMenu/widgets/chobby/components/chat_emojis.lua
@@ -53,7 +53,8 @@ ChatEmojis._aliasImagePath = {}
 ChatEmojis._candidateCache = {}
 ChatEmojis._candidateCacheCount = 0
 ChatEmojis._candidateCacheMax = 4096
--- Only known :alias:  should enable emoji parsing
+
+-- Only known :alias: should enable emoji parsing
 local function HasRenderableAlias(text)
 	for alias in string.gmatch(text, ":([%a_]+):") do
 		if ChatEmojis._aliasImagePath[alias] ~= nil then
@@ -79,10 +80,7 @@ function ChatEmojis.HasEmojiCandidate(text)
 		return cached
 	end
 
-	local hasEmoji = false
-	if string.find(text, ":", 1, true) then
-		hasEmoji = HasRenderableAlias(text)
-	end
+	local hasEmoji = string.find(text, ":", 1, true) ~= nil and HasRenderableAlias(text)
 
 	if ChatEmojis._candidateCache[text] == nil then
 		ChatEmojis._candidateCacheCount = ChatEmojis._candidateCacheCount + 1

--- a/LuaMenu/widgets/chobby/components/chat_emojis.lua
+++ b/LuaMenu/widgets/chobby/components/chat_emojis.lua
@@ -57,7 +57,6 @@ ChatEmojis._candidateCacheCount = 0
 ChatEmojis._candidateCacheMax = 4096
 
 local function HasRenderableAlias(text)
-	-- Find a real :alias: token; timestamps and usernames also contain colons.
 	for alias in string.gmatch(text, ":([%a_]+):") do
 		if ChatEmojis._aliasImagePath[alias] ~= nil then
 			return true

--- a/LuaMenu/widgets/chobby/components/console.lua
+++ b/LuaMenu/widgets/chobby/components/console.lua
@@ -477,7 +477,7 @@ function Console:AddMessage(message, userName, dateOverride, color, thirdPerson,
 	end
 
 	-- Check before formatting adds colons (raw message)
-	local allowEmoji = userName ~= nil and ChatEmojis and ChatEmojis.HasEmojiCandidate and ChatEmojis.HasEmojiCandidate(message)
+	local allowEmoji = (userName ~= nil and ChatEmojis and ChatEmojis.HasEmojiCandidate and ChatEmojis.HasEmojiCandidate(message)) or false
 
 	txt = txt .. message
 	onTextClick, textTooltip = WG.BrowserHandler.AddClickableUrls(txt, onTextClick or {}, textTooltip or {})

--- a/LuaMenu/widgets/chobby/components/console.lua
+++ b/LuaMenu/widgets/chobby/components/console.lua
@@ -476,9 +476,14 @@ function Console:AddMessage(message, userName, dateOverride, color, thirdPerson,
 		end
 	end
 
+	-- Check the raw message; formatted timestamps/user names contain non-emoji colons.
+	local allowEmoji = false
+	if userName ~= nil and ChatEmojis and ChatEmojis.HasEmojiCandidate then
+		allowEmoji = ChatEmojis.HasEmojiCandidate(message)
+	end
+
 	txt = txt .. message
 	onTextClick, textTooltip = WG.BrowserHandler.AddClickableUrls(txt, onTextClick or {}, textTooltip or {})
-	local allowEmoji = (userName ~= nil)
 
 	whiteText = whiteText .. message
 	if self.tbHistory.text == "" then

--- a/LuaMenu/widgets/chobby/components/console.lua
+++ b/LuaMenu/widgets/chobby/components/console.lua
@@ -476,7 +476,7 @@ function Console:AddMessage(message, userName, dateOverride, color, thirdPerson,
 		end
 	end
 
-	-- Checks the raw message
+	-- Check before formatting adds colons (raw message)
 	local allowEmoji = false
 	if userName ~= nil and ChatEmojis and ChatEmojis.HasEmojiCandidate then
 		allowEmoji = ChatEmojis.HasEmojiCandidate(message)

--- a/LuaMenu/widgets/chobby/components/console.lua
+++ b/LuaMenu/widgets/chobby/components/console.lua
@@ -477,10 +477,7 @@ function Console:AddMessage(message, userName, dateOverride, color, thirdPerson,
 	end
 
 	-- Check before formatting adds colons (raw message)
-	local allowEmoji = false
-	if userName ~= nil and ChatEmojis and ChatEmojis.HasEmojiCandidate then
-		allowEmoji = ChatEmojis.HasEmojiCandidate(message)
-	end
+	local allowEmoji = userName ~= nil and ChatEmojis and ChatEmojis.HasEmojiCandidate and ChatEmojis.HasEmojiCandidate(message)
 
 	txt = txt .. message
 	onTextClick, textTooltip = WG.BrowserHandler.AddClickableUrls(txt, onTextClick or {}, textTooltip or {})

--- a/LuaMenu/widgets/chobby/components/console.lua
+++ b/LuaMenu/widgets/chobby/components/console.lua
@@ -476,7 +476,7 @@ function Console:AddMessage(message, userName, dateOverride, color, thirdPerson,
 		end
 	end
 
-	-- Check the raw message; formatted timestamps/user names contain non-emoji colons.
+	-- Checks the raw message
 	local allowEmoji = false
 	if userName ~= nil and ChatEmojis and ChatEmojis.HasEmojiCandidate then
 		allowEmoji = ChatEmojis.HasEmojiCandidate(message)

--- a/LuaMenu/widgets/chobby/components/emoji_text_box.lua
+++ b/LuaMenu/widgets/chobby/components/emoji_text_box.lua
@@ -414,7 +414,7 @@ function EmojiTextBox:AddLine(text, tooltips, OnTextClick, allowEmoji)
 		pls = {},
 	}
 	self.text = self.text == "" and (text or "") or (self.text .. "\n" .. (text or ""))
-	--  only wrap the new line
+	-- Catchup appends many lines; only wrap the new one on the common path.
 	self:GeneratePhysicalLines(#self.lines)
 	if self.selStart and not rebuilt then
 		self:_SetSelection(self.selStart, self.selStartY, self.selEnd, self.selEndY)
@@ -447,11 +447,11 @@ function EmojiTextBox:GetPhysicalLinePosition(distanceFromBottom, usePhysical)
 	return 0
 end
 
-function EmojiTextBox:DrawEmoji(token, x, y, size, padding, yOffset, textureHandler)
-	size = size or self:GetEmojiSize()
-	padding = padding or self:GetEmojiInlinePadding(size)
-	local emojiY = y + (yOffset or self:GetEmojiYOffset(size))
-	textureHandler = textureHandler or GetTextureHandler()
+function EmojiTextBox:DrawEmoji(token, x, y)
+	local size = self:GetEmojiSize()
+	local padding = self:GetEmojiInlinePadding(size)
+	local emojiY = y + self:GetEmojiYOffset(size)
+	local textureHandler = GetTextureHandler()
 	if token.image and textureHandler and textureHandler.LoadTexture then
 		gl.Color(1, 1, 1, 1)
 		local loaded = pcall(textureHandler.LoadTexture, 0, token.image, self)
@@ -480,10 +480,10 @@ function EmojiTextBox:GetVisiblePhysicalLineRange()
 
 	local lineHeight = self:GetLineHeight()
 	local clientY = self.clientArea and self.clientArea[2] or 0
-	local topY = math.max(0, parent.scrollPosY - clientY)
-	local bottomY = topY + (parent.clientArea[4] or self.height or 0)
-	local firstLine = math.max(1, math.floor(topY / lineHeight) + 1)
-	local lastLine = math.min(lineCount, math.ceil(bottomY / lineHeight) + 1)
+	local visibleTop = math.max(0, parent.scrollPosY - (self.y or 0) - clientY)
+	local visibleBottom = visibleTop + (parent.clientArea[4] or self.height or 0)
+	local firstLine = math.max(1, math.floor(visibleTop / lineHeight) + 1)
+	local lastLine = math.min(lineCount, math.ceil(visibleBottom / lineHeight) + 1)
 	return firstLine, lastLine
 end
 
@@ -539,10 +539,6 @@ function EmojiTextBox:DrawControl()
 	self:DrawSelection()
 	local clientX, clientY = self.clientArea[1], self.clientArea[2]
 	local firstLine, lastLine = self:GetVisiblePhysicalLineRange()
-	local emojiSize = self:GetEmojiSize()
-	local emojiPadding = self:GetEmojiInlinePadding(emojiSize)
-	local emojiYOffset = self:GetEmojiYOffset(emojiSize)
-	local textureHandler = GetTextureHandler()
 	for i = firstLine, lastLine do
 		local physicalLine = self.physicalLines[i]
 		local y = clientY + physicalLine.y
@@ -550,7 +546,7 @@ function EmojiTextBox:DrawControl()
 		for j = 1, #drawRuns do
 			local run = drawRuns[j]
 			if run.type == "emoji" then
-				self:DrawEmoji(run.token, clientX + run.x, y, emojiSize, emojiPadding, emojiYOffset, textureHandler)
+				self:DrawEmoji(run.token, clientX + run.x, y)
 			elseif run.text and run.text ~= "" then
 				self.font:Draw(run.text, clientX + run.x, y)
 			end

--- a/LuaMenu/widgets/chobby/components/emoji_text_box.lua
+++ b/LuaMenu/widgets/chobby/components/emoji_text_box.lua
@@ -350,14 +350,22 @@ function EmojiTextBox:RebuildPhysicalLines()
 	end
 end
 
+function EmojiTextBox:ResizeToContent()
+	if self.autoHeight then
+		local hadPendingRealign = self._realignRequested
+		self:Resize(nil, math.max(1, #self.physicalLines * self:GetLineHeight()), true, true)
+		if not hadPendingRealign then
+			self._realignRequested = nil
+		end
+	end
+end
+
 function EmojiTextBox:UpdateLayout()
 	self:RebuildPhysicalLines()
 	if self.selStart then
 		self:_SetSelection(self.selStart, self.selStartY, self.selEnd, self.selEndY)
 	end
-	if self.autoHeight then
-		self:Resize(nil, math.max(1, #self.physicalLines * self:GetLineHeight()), true, true)
-	end
+	self:ResizeToContent()
 	self:Invalidate()
 	return true
 end
@@ -381,6 +389,7 @@ function EmojiTextBox:SetText(newtext, tooltips, OnTextClick, allowEmoji)
 end
 
 function EmojiTextBox:AddLine(text, tooltips, OnTextClick, allowEmoji)
+	local rebuilt = false
 	if self.agressiveMaxLines and #self.lines > self.agressiveMaxLines then
 		local preserve = {}
 		for i = math.max(1, #self.lines - self.agressiveMaxLinesPreserve), #self.lines do
@@ -393,6 +402,8 @@ function EmojiTextBox:AddLine(text, tooltips, OnTextClick, allowEmoji)
 			preservedText[#preservedText + 1] = self.lines[i].text
 		end
 		self.text = table.concat(preservedText, "\n")
+		self:RebuildPhysicalLines()
+		rebuilt = true
 	end
 
 	self.lines[#self.lines + 1] = {
@@ -403,7 +414,13 @@ function EmojiTextBox:AddLine(text, tooltips, OnTextClick, allowEmoji)
 		pls = {},
 	}
 	self.text = self.text == "" and (text or "") or (self.text .. "\n" .. (text or ""))
-	self:UpdateLayout()
+	--  only wrap the new line
+	self:GeneratePhysicalLines(#self.lines)
+	if self.selStart and not rebuilt then
+		self:_SetSelection(self.selStart, self.selStartY, self.selEnd, self.selEndY)
+	end
+	self:ResizeToContent()
+	self:Invalidate()
 end
 
 function EmojiTextBox:GetPhysicalLinePosition(distanceFromBottom, usePhysical)
@@ -430,11 +447,11 @@ function EmojiTextBox:GetPhysicalLinePosition(distanceFromBottom, usePhysical)
 	return 0
 end
 
-function EmojiTextBox:DrawEmoji(token, x, y)
-	local size = self:GetEmojiSize()
-	local padding = self:GetEmojiInlinePadding(size)
-	local emojiY = y + self:GetEmojiYOffset(size)
-	local textureHandler = GetTextureHandler()
+function EmojiTextBox:DrawEmoji(token, x, y, size, padding, yOffset, textureHandler)
+	size = size or self:GetEmojiSize()
+	padding = padding or self:GetEmojiInlinePadding(size)
+	local emojiY = y + (yOffset or self:GetEmojiYOffset(size))
+	textureHandler = textureHandler or GetTextureHandler()
 	if token.image and textureHandler and textureHandler.LoadTexture then
 		gl.Color(1, 1, 1, 1)
 		local loaded = pcall(textureHandler.LoadTexture, 0, token.image, self)
@@ -448,6 +465,26 @@ function EmojiTextBox:DrawEmoji(token, x, y)
 	if token.fallback then
 		self.font:Draw(token.fallback, x + padding, y)
 	end
+end
+
+function EmojiTextBox:GetVisiblePhysicalLineRange()
+	local lineCount = #self.physicalLines
+	if lineCount == 0 then
+		return 1, 0
+	end
+
+	local parent = self.parent and UnlinkSafe and UnlinkSafe(self.parent) or self.parent
+	if not (parent and parent.scrollPosY and parent.clientArea) then
+		return 1, lineCount
+	end
+
+	local lineHeight = self:GetLineHeight()
+	local clientY = self.clientArea and self.clientArea[2] or 0
+	local topY = math.max(0, parent.scrollPosY - clientY)
+	local bottomY = topY + (parent.clientArea[4] or self.height or 0)
+	local firstLine = math.max(1, math.floor(topY / lineHeight) + 1)
+	local lastLine = math.min(lineCount, math.ceil(bottomY / lineHeight) + 1)
+	return firstLine, lastLine
 end
 
 function EmojiTextBox:DrawSelection()
@@ -482,8 +519,9 @@ function EmojiTextBox:DrawSelection()
 
 	local color, lineHeight = self.selectionColor or {0, 1, 1, 0.3}, self:GetLineHeight()
 	local clientX, clientY = self.clientArea[1], self.clientArea[2]
+	local firstLine, lastLine = self:GetVisiblePhysicalLineRange()
 	gl.Color(color[1], color[2], color[3], color[4])
-	for i = 1, #self.physicalLines do
+	for i = firstLine, lastLine do
 		local physicalLine = self.physicalLines[i]
 		if physicalLine.lineID >= startLine and physicalLine.lineID <= endLine then
 			local leftIndex = math.max(physicalLine.startIndex, physicalLine.lineID == startLine and startIndex or physicalLine.startIndex)
@@ -500,14 +538,19 @@ end
 function EmojiTextBox:DrawControl()
 	self:DrawSelection()
 	local clientX, clientY = self.clientArea[1], self.clientArea[2]
-	for i = 1, #self.physicalLines do
+	local firstLine, lastLine = self:GetVisiblePhysicalLineRange()
+	local emojiSize = self:GetEmojiSize()
+	local emojiPadding = self:GetEmojiInlinePadding(emojiSize)
+	local emojiYOffset = self:GetEmojiYOffset(emojiSize)
+	local textureHandler = GetTextureHandler()
+	for i = firstLine, lastLine do
 		local physicalLine = self.physicalLines[i]
 		local y = clientY + physicalLine.y
 		local drawRuns = physicalLine.drawRuns or {}
 		for j = 1, #drawRuns do
 			local run = drawRuns[j]
 			if run.type == "emoji" then
-				self:DrawEmoji(run.token, clientX + run.x, y)
+				self:DrawEmoji(run.token, clientX + run.x, y, emojiSize, emojiPadding, emojiYOffset, textureHandler)
 			elseif run.text and run.text ~= "" then
 				self.font:Draw(run.text, clientX + run.x, y)
 			end


### PR DESCRIPTION
Few optimizations to how emojis work to remove chobby stutters. Not sure if all of these were necessary but im bundling a few optimizations into one PR. Spectated an 8v8 match and waited for catchup It "feels" faster with these optimizations so it should fix the problem.


Main problem diagnosed by Rysica: https://discord.com/channels/549281623154229250/1528864036618240140/1529352967226917106
TLDR: ordinary non emoji messages to go through emoji parsing, and each appended line rebuilt the layout for the entire chat history. Together this led to chobby taking 10+ seconds to catchup after a long 8v8 game

Changes:
1) The chat emoji detection now runs on the raw message before the timestamp and formatting is added (completes the check before the message is formatted like this "[12:00] Username: message". Before 

2) Updated `EmojiTextBox:AddLine` to append a new line instead of rebuilding the chat history

3) Limited emoji chat drawing to visible physical lines inside the scroll panel









AI Disclosure:  used Codex GPT 5.5 to assist with programming

