### PR TITLE
Use Engine.version for save game compatibility

### DIFF
--- a/LuaMenu/widgets/gui_loadgame.lua
+++ b/LuaMenu/widgets/gui_loadgame.lua
@@ -178,7 +178,7 @@ local function LoadGameByFilename(filename)
 		return
 	end
 
-	if saveData.engineVersion and (Engine.versionFull ~= saveData.engineVersion) then
+	if saveData.engineVersion and (Engine.version ~= saveData.engineVersion) then
 		-- Both should be "105.1.1-1723-gd990800 BAR105" or whatever
 		local ssfFileName = SAVE_DIR .. '/' .. filename .. ".ssf"
 


### PR DESCRIPTION
The `saveData.engineVersion` stores the simplified `Engine.version` string. Comparing it against `Engine.versionFull`, which includes build-specific details, would lead to false positive version mismatches. This PR ensures the correct and stable version string is used for save game compatibility checks.

As example using a debug build of the engine `Engine.versionFull =
2026.06.06-157-g8c81ba8 vcpkg2 (Debug Signal-NaNs)` but `Engine.version =
2026.06.06-157-g8c81ba8 vcpkg2`. This makes it impossible to load saved games when using such a debug build without this change.
