### PR TITLE
[Draft/Suggestion] Focus replays opened by the launcher

### DIFF
--- a/LuaMenu/widgets/gui_chili_lobby.lua
+++ b/LuaMenu/widgets/gui_chili_lobby.lua
@@ -106,6 +106,9 @@ function widget:Initialize()
 	lobbyInterfaceHolder = interfaceRoot.GetLobbyInterfaceHolder()
 	Chobby.lobbyInterfaceHolder = lobbyInterfaceHolder
 	Chobby.interfaceRoot = interfaceRoot
+	if WG.WrapperLoopback then
+		WG.WrapperLoopback.ReplayHandlerReady()
+	end
 
 	local taskbarTitle = Chobby.Configuration.gameConfig.taskbarTitle
 	local taskbarTitleShort = Chobby.Configuration.gameConfig.taskbarTitleShort or taskbarTitle

--- a/LuaMenu/widgets/gui_replay_handler.lua
+++ b/LuaMenu/widgets/gui_replay_handler.lua
@@ -19,6 +19,23 @@ end
 
 local replayListWindow
 local replayList
+local replayToHighlight
+local highlightedReplay
+
+local function HighlightReplay(replayPath)
+	if replayPath ~= replayToHighlight then
+		return
+	end
+	local control = replayList.controlById[replayPath]
+	if not control then
+		return
+	end
+	replayList.priorityList = {[replayPath] = true}
+	replayList:UpdateOrder()
+	replayList:ScrollToItem(replayPath)
+	highlightedReplay = replayPath
+	replayToHighlight = nil
+end
 
 -- Size constants for the replay window
 local PLAYER_HEIGHT = 20
@@ -631,6 +648,17 @@ local function InitializeControls(parentControl)
 		end
 		local replays = SortReplays(rawReplays)
 
+		replayList.priorityList = highlightedReplay and {[highlightedReplay] = true} or {}
+		if highlightedReplay then
+			for i = 1, #replays do
+				if replays[i] == highlightedReplay then
+					table.remove(replays, i)
+					replays[#replays + 1] = highlightedReplay
+					break
+				end
+			end
+		end
+
 		local index = #replays
 
         --  Add one replay to the replay list
@@ -819,6 +847,7 @@ local function InitializeControls(parentControl)
 
 				if control then
 					replayList:AddItem(replayPath, control, sortData)
+					HighlightReplay(replayPath)
 				end
 			end,
 
@@ -828,6 +857,8 @@ local function InitializeControls(parentControl)
 			end
 		)
 	end
+
+	externalFunctions.Refresh = AddReplays
 
 	return externalFunctions
 end
@@ -855,6 +886,16 @@ function ReplayHandler.GetControl()
 		},
 	}
 	return window
+end
+
+function ReplayHandler.OpenReplay(replayPath)
+	local refreshExistingList = replayListWindow ~= nil
+	replayToHighlight = replayPath
+	highlightedReplay = replayPath
+	WG.Chobby.interfaceRoot.OpenSingleplayerTabByName("replays")
+	if refreshExistingList then
+		replayListWindow.Refresh()
+	end
 end
 
 function ReplayHandler.ReadReplayInfoDone(path, engine, game, map, players, time, winningAllyTeamIds)

--- a/LuaMenu/widgets/sl_loopback.lua
+++ b/LuaMenu/widgets/sl_loopback.lua
@@ -39,6 +39,10 @@ function WrapperLoopback.UploadLog()
 	WG.Connector.Send("UploadLog")
 end
 
+function WrapperLoopback.ReplayHandlerReady()
+	WG.Connector.Send("ReplayHandlerReady")
+end
+
 function WrapperLoopback.ReadReplayInfo(relativePath)
 	local Configuration = WG.Chobby.Configuration
 	if Configuration and Configuration.debugMode then
@@ -227,6 +231,13 @@ local function ReplayInfo(command)
 	)
 end
 
+local function OpenReplay(command)
+	if not command.relativePath or not WG.ReplayHandler then
+		return
+	end
+	WG.ReplayHandler.OpenReplay(command.relativePath)
+end
+
 
 -- init
 function widget:Initialize()
@@ -239,6 +250,7 @@ function widget:Initialize()
 	WG.WrapperLoopback = WrapperLoopback
 
 	WG.Connector.Register('ReplayInfo', ReplayInfo)
+	WG.Connector.Register('OpenReplay', OpenReplay)
 	WG.Connector.Register('ParseMiniMapFinished', ParseMiniMapFinished)
 	WG.Connector.Register('DownloadProgress', DownloadProgress)
 	WG.Connector.Register('DownloadFinished', DownloadFinished)


### PR DESCRIPTION
## Status

> **Draft / suggestion / base for discussion.** This is intentionally proposed as a temporary compatibility improvement for the legacy Chobby client, not as a competing direction for the new client.

The equivalent workflow is expected to arrive in the new client. Still, this small bridge may help some users already using the current launcher and Chobby while that transition is ongoing. Maintainer feedback on whether carrying this temporary solution is worthwhile is very welcome.

## What this suggests

- announce to the launcher when Chobby's replay UI is ready;
- receive an `OpenReplay` request through the existing launcher loopback;
- open the Replays screen, refresh it when necessary, and prioritize/scroll to the imported replay;
- keep replay launching itself as an explicit user action.

The paired launcher change imports the external `.sdfz` into `demos/` and sends the relative replay path after this readiness handshake.

Paired launcher PR: https://github.com/beyond-all-reason/spring-launcher/pull/54

## Verification

- Manually verified on Linux with the local `BYAR-Chobby` checkout linked as **Dev Lobby**.
- Dragging an external `.sdfz` into the paired launcher imported it, started BAR, opened the Replays screen, and focused the imported replay.
- Existing replay list usage and explicit replay start behavior remain unchanged.

## AI usage disclosure

OpenAI Codex was used interactively to trace the launcher/Chobby bridge, assist with implementation, tests, debugging, and drafting this PR text. I reviewed the changes and manually verified the end-to-end behavior described above.
