### PR TITLE
Render polygon start box overrides

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
+++ b/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
@@ -305,33 +305,37 @@ local function loadPolygonStartboxesFromBlob(encoded, allyTeamCount)
   return config
 end
 
--- Override modoption -> 1-based rect list, or nil when absent/unset/garbage.
--- "0" is the unset sentinel (SPADS won't broadcast empty values, see
--- sendBattleSetting in spads.pl). Overrides with 3+ point polygons decode to
--- nil too; this lobby only emits 2-point rects.
-local function decodeStartboxOverrideRects(encoded)
+-- Override modoption -> polygon config (see buildPolygonConfig) and whether any
+-- box carries a real polygon, or nil when absent/unset/garbage. "0" is the unset
+-- sentinel (SPADS won't broadcast empty values, see sendBattleSetting in spads.pl).
+--
+-- A hand-written !bSet can carry polygons the editor never emits, and the game
+-- accepts them (expandPoly in startbox_utilities.lua), so rejecting them here
+-- would draw the map defaults over boxes the game is going to enforce.
+local function decodeStartboxOverride(encoded)
   if not encoded or encoded == "" or encoded == "0" then return nil end
   local parsed = decodeBlob(encoded)
   if not parsed or type(parsed.startboxes) ~= "table" then return nil end
+  if #parsed.startboxes == 0 then return nil end
 
-  local rects = {}
-  for i, box in ipairs(parsed.startboxes) do
+  for _, box in ipairs(parsed.startboxes) do
     local poly = type(box) == "table" and box.poly
-    if type(poly) ~= "table" or #poly ~= 2 then return nil end
-    if type(poly[1]) ~= "table" or type(poly[2]) ~= "table" then return nil end
-    local x1, y1 = tonumber(poly[1].x), tonumber(poly[1].y)
-    local x2, y2 = tonumber(poly[2].x), tonumber(poly[2].y)
-    if not (x1 and y1 and x2 and y2) then return nil end
-    rects[i] = {
-      left = math.min(x1, x2),
-      top = math.min(y1, y2),
-      right = math.max(x1, x2),
-      bottom = math.max(y1, y2),
-    }
+    if type(poly) ~= "table" or #poly < 2 then return nil end
+    for _, point in ipairs(poly) do
+      if type(point) ~= "table" then return nil end
+      local x, y = tonumber(point.x), tonumber(point.y)
+      if not (x and y) then return nil end
+      point.x, point.y = x, y
+    end
   end
-  if #rects == 0 then return nil end
 
-  return rects
+  local ok, config = pcall(buildPolygonConfig, parsed)
+  if not ok or not config then
+    Spring.Log("mapStartBoxes", LOG.WARNING, "Skipping malformed startbox override modoption")
+    return nil
+  end
+
+  return config, arrangementHasPolygon(parsed)
 end
 
 local function makeAllyTeamBoxFromPolygon(polygonConfig, allyteamindex)
@@ -481,7 +485,7 @@ return {
   encodeStartboxOverrideModoption = encodeStartboxOverrideModoption,
   loadPolygonStartboxes = loadPolygonStartboxes,
   loadPolygonStartboxesFromBlob = loadPolygonStartboxesFromBlob,
-  decodeStartboxOverrideRects = decodeStartboxOverrideRects,
+  decodeStartboxOverride = decodeStartboxOverride,
   getBox = getBox,
   clearBoxes = clearBoxes,
   removeBox = removeBox,

--- a/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
+++ b/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
@@ -305,13 +305,7 @@ local function loadPolygonStartboxesFromBlob(encoded, allyTeamCount)
   return config
 end
 
--- Override modoption -> polygon config (see buildPolygonConfig) and whether any
--- box carries a real polygon, or nil when absent/unset/garbage. "0" is the unset
--- sentinel (SPADS won't broadcast empty values, see sendBattleSetting in spads.pl).
---
--- A hand-written !bSet can carry polygons the editor never emits, and the game
--- accepts them (expandPoly in startbox_utilities.lua), so rejecting them here
--- would draw the map defaults over boxes the game is going to enforce.
+-- Game accepts 3+ point polygons here (expandPoly), so this has to as well.
 local function decodeStartboxOverride(encoded)
   if not encoded or encoded == "" or encoded == "0" then return nil end
   local parsed = decodeBlob(encoded)

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -2031,14 +2031,22 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		local modoptions = battleLobby.modoptions or {}
 		renderedAllyTeamCount = GetAllyTeamCount(false)
 
-		local overrideRects = mapStartBoxes and mapStartBoxes.decodeStartboxOverrideRects
-			and mapStartBoxes.decodeStartboxOverrideRects(modoptions.mapmetadata_startbox_override)
-		if overrideRects then
+		local overrideConfig, overrideHasPolygon
+		if mapStartBoxes and mapStartBoxes.decodeStartboxOverride then
+			overrideConfig, overrideHasPolygon =
+				mapStartBoxes.decodeStartboxOverride(modoptions.mapmetadata_startbox_override)
+		end
+		if overrideConfig then
 			defaultStartboxMode = false
-			externalFunctions.RemovePolygonOverlays()
-			externalFunctions.RemoveStartRect()
-			for i, rect in ipairs(overrideRects) do
-				externalFunctions.AddStartRect(i - 1, rect.left, rect.top, rect.right, rect.bottom)
+			if overrideHasPolygon then
+				externalFunctions.AddPolygonStartboxes(overrideConfig, renderedAllyTeamCount)
+			else
+				externalFunctions.RemovePolygonOverlays()
+				externalFunctions.RemoveStartRect()
+				for i, entry in ipairs(overrideConfig) do
+					local box = entry.boundingBox
+					externalFunctions.AddStartRect(i - 1, box.left, box.top, box.right, box.bottom)
+				end
 			end
 
 			return


### PR DESCRIPTION
Follows up on #1184: setting the override by hand with !bSet using a polygon got thrown away by the lobby, so the minimap kept showing the map's default boxes while the game went ahead and enforced the polygon.

AI disclosure: written with assistance from Claude Code.
