### PR TITLE
Feat: sort modoptions summary

### DIFF
--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -1092,9 +1092,7 @@ local function InitializeModoptionsDisplay()
 		local text = ""
 		local empty = true
 		panelModoptions = modopts or panelModoptions or {}
-		if not modoptions then
-			return
-		end
+		if not modoptions then return end
 
 		for _, option in pairs(modoptions) do
 			if option.type == "bool" then
@@ -1119,11 +1117,7 @@ local function InitializeModoptionsDisplay()
 					end
 				end
 			elseif option.type == "number" then
-				if
-					option.lock
-					and panelModoptions[option.key]
-					and panelModoptions[option.key] ~= modoptionDefaults[option.key]
-				then
+				if option.lock and panelModoptions[option.key] and panelModoptions[option.key] ~= modoptionDefaults[option.key] then
 					for i = 1, #option.lock do
 						hidenOptions[option.lock[i]] = true
 					end
@@ -1141,8 +1135,7 @@ local function InitializeModoptionsDisplay()
 
 		local entries = {}
 		for key, value in pairs(panelModoptions) do
-			if
-				(modoptionDefaults[key] == nil or modoptionDefaults[key] ~= value or key == "ranked_game")
+			if (modoptionDefaults[key] == nil or modoptionDefaults[key] ~= value or key == "ranked_game")
 				and key:find("^mapmetadata_") == nil
 				and not hidenOptions[key]
 			then
@@ -1166,9 +1159,11 @@ local function InitializeModoptionsDisplay()
 				entries[#entries + 1] = { name = name, text = entry }
 			end
 		end
+
 		table.sort(entries, function(a, b)
 			return a.name:lower() < b.name:lower()
 		end)
+
 		for i = 1, #entries do
 			if i > 1 then
 				text = text .. "\255\128\128\128" .. "------" .. "\n"

--- a/LuaMenu/widgets/gui_modoptions_panel.lua
+++ b/LuaMenu/widgets/gui_modoptions_panel.lua
@@ -1076,7 +1076,7 @@ local function InitializeModoptionsDisplay()
 			if line:sub(1, 2) ~= "--" then -- Line doesn't start with a comment
 				return tweakText
 			end
-			local comment = line:sub(3, 27)
+			local comment = line:sub(3, 27):match("^%s*(.-)%s*$")
 			if not comment:find("[^%w%p ]") then -- Only whitelisted characters found
 				return tweakText .. "\n[" .. comment .. "]"
 			end
@@ -1092,7 +1092,9 @@ local function InitializeModoptionsDisplay()
 		local text = ""
 		local empty = true
 		panelModoptions = modopts or panelModoptions or {}
-		if not modoptions then return end
+		if not modoptions then
+			return
+		end
 
 		for _, option in pairs(modoptions) do
 			if option.type == "bool" then
@@ -1117,7 +1119,11 @@ local function InitializeModoptionsDisplay()
 					end
 				end
 			elseif option.type == "number" then
-				if option.lock and panelModoptions[option.key] and panelModoptions[option.key] ~= modoptionDefaults[option.key] then
+				if
+					option.lock
+					and panelModoptions[option.key]
+					and panelModoptions[option.key] ~= modoptionDefaults[option.key]
+				then
 					for i = 1, #option.lock do
 						hidenOptions[option.lock[i]] = true
 					end
@@ -1133,29 +1139,43 @@ local function InitializeModoptionsDisplay()
 			end
 		end
 
+		local entries = {}
 		for key, value in pairs(panelModoptions) do
-			if (modoptionDefaults[key] == nil or modoptionDefaults[key] ~= value or key == "ranked_game") and key:find("^mapmetadata_") == nil and not hidenOptions[key] then
+			if
+				(modoptionDefaults[key] == nil or modoptionDefaults[key] ~= value or key == "ranked_game")
+				and key:find("^mapmetadata_") == nil
+				and not hidenOptions[key]
+			then
 				local option = getModOptionByKey(key)
-				local name = option.name and option.name or key
-				text = text .. "\255\255\255\255"
-				if text ~= "\255\255\255\255" then
-					text = text .. "\255\128\128\128" .. "------" .. "\n"
-				end
-				text = text .. tostring(name).. " = \255\255\255\255"
-				if (key:sub(1,10) == "tweakunits" or key:sub(1,9) == "tweakdefs") then
+				local name = tostring(option.name and option.name or key)
+				local entry = "\255\255\255\255" .. name .. " = \255\255\255\255"
+				if key:sub(1, 10) == "tweakunits" or key:sub(1, 9) == "tweakdefs" then
 					local success, result = pcall(tweakSummary, value)
 					if success then
-						text = text .. result
+						entry = entry .. result
 					else
-						text = text .. "\255\255\75\75".."Couldn't Parse\n".."\255\128\128\128"..shortenedValue(value)
+						entry = entry
+							.. "\255\255\75\75"
+							.. "Couldn't Parse\n"
+							.. "\255\128\128\128"
+							.. shortenedValue(value)
 					end
 				else
-					text = text .. shortenedValue(value)
+					entry = entry .. shortenedValue(value)
 				end
-				text = text .. "\n"
-				empty = false
+				entries[#entries + 1] = { name = name, text = entry }
 			end
 		end
+		table.sort(entries, function(a, b)
+			return a.name:lower() < b.name:lower()
+		end)
+		for i = 1, #entries do
+			if i > 1 then
+				text = text .. "\255\128\128\128" .. "------" .. "\n"
+			end
+			text = text .. entries[i].text .. "\n"
+		end
+		empty = (#entries == 0)
 		lblText:SetText(text)
 
 		if mainScrollPanel.parent then


### PR DESCRIPTION
No related github issue.

Sort modoptions and trim whitespace on tweak first line comment titles.

# before
<img width="238" height="516" alt="image" src="https://github.com/user-attachments/assets/dca3e8e5-4ff1-4ac7-99e8-287c679a94cf" />


# after
<img width="225" height="410" alt="image" src="https://github.com/user-attachments/assets/7f94cad4-da43-4489-a1eb-609114007da8" />

# Test
Tested with a couple of lobbies and pasting a few times

# AI disclosure
90% written by Claude Fable