### PR TITLE
Fix: persist "show hidden modoptions"

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -782,6 +782,7 @@ function Configuration:GetConfigData()
 		enableTextToSpeech = self.enableTextToSpeech,
 		showOldAiVersions = self.showOldAiVersions,
 		showAiOptions = self.showAiOptions,
+		ShowhiddenModopions = self.ShowhiddenModopions,
 		chatFontSize = self.chatFontSize,
 		myAccountID = self.myAccountID,
 		lastAddedAiName = self.lastAddedAiName,


### PR DESCRIPTION
No related github issue.

Today the "show hidden modoptions" checkbox in developer settings is not persisted across restarts.

Confirmed the bug `true -> false` and confirmed the fix both `true -> true` and `false -> false` across back to back restarts.

# AI Disclosure
100% done with Claude Fable