### PR TITLE
Add a dev-only Map Editor menu entry

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/singleplayerMenu.lua
+++ b/LuaMenu/configs/gameConfig/byar/singleplayerMenu.lua
@@ -10,6 +10,13 @@ local items = 	{
 		--startWithTabOpen = 1,
 	},
 	{
+		-- devOnly is honoured by interface_root, which is where Configuration.devMode is
+		-- readable: this file is included while Configuration is still being built.
+		name = "terraformer",
+		control = WG.TerraformerWindow.GetControl(),
+		devOnly = true,
+	},
+	{
 		name = "load_game",
 		control = WG.LoadGameWindow.GetControl(),
 		entryCheck = WG.BattleRoomWindow.SetSingleplayerGame,

--- a/LuaMenu/widgets/chobby/components/interface_root.lua
+++ b/LuaMenu/widgets/chobby/components/interface_root.lua
@@ -510,25 +510,33 @@ function GetInterfaceRoot(optionsParent, mainWindowParent, fontFunction)
 		ToggleShowFunc(obj, newTab)
 	end
 
+	-- Built up rather than written as one literal: the singleplayer tabs were indexed by hand,
+	-- so adding one meant editing here too, and devOnly needs checking somewhere Configuration
+	-- is available (the config files load before devMode is set).
+	local mainMenuTabs = {
+		{
+			name = "multiplayer",
+			control = battleListWindow,
+			entryCheck = multiplayerentrycheck,
+		},
+	}
+	for i = 1, #singleplayerConfig do
+		local entry = singleplayerConfig[i]
+		if not entry.devOnly or Configuration.devMode then
+			mainMenuTabs[#mainMenuTabs + 1] = entry
+		end
+	end
+	mainMenuTabs[#mainMenuTabs + 1] = {
+		name = "replays",
+		control = WG.ReplayHandler.GetControl(),
+	}
+	mainMenuTabs[#mainMenuTabs + 1] = Configuration.gameConfig.helpSubmenuConfig[1]
+
 	local submenus = {
 		{
 			name = "Main Menu",
 			titleText = "Main Menu",
-			tabs = {
-				{
-					name = "multiplayer",
-					control = battleListWindow,
-					entryCheck = multiplayerentrycheck,
-				},
-				singleplayerConfig[1],
-				singleplayerConfig[2],
-				singleplayerConfig[3],
-				{
-					name = "replays",
-					control = WG.ReplayHandler.GetControl()
-				},
-				Configuration.gameConfig.helpSubmenuConfig[1],
-			},
+			tabs = mainMenuTabs,
 		}
 	}
 

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -288,6 +288,7 @@ return {
 		download_failed = "Download Failed",
 		wip_challenges = "WiP Challenges",
 		["scenarios"] = "Scenarios",
+		["terraformer"] = "Map Editor",
 		-- Settings
 		autoLaunchAsSpectator = "Auto-launch when spectating",
 		randomSkirmishSetup = "Random Skirmish AI and Map",

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -1,0 +1,714 @@
+function widget:GetInfo()
+	return {
+		name      = "Terraformer Launcher",
+		desc      = "Launches straight into the terraform brush on a chosen map.",
+		author    = "",
+		date      = "2026",
+		license   = "GNU GPL, v2 or later",
+		layer     = 0,
+		enabled   = true,
+	}
+end
+
+local TerraformerWindow = {}
+
+local selectedMap
+local selectedProject
+local listMode = "maps" -- "maps" | "projects"
+-- Matches #LOAD_PHASES in cmd_map_project.lua; the pointer carries it for progress reporting.
+local PROJECT_LOAD_PHASES = 11
+-- Declared up here because Launch, below, reports download state and both of these are
+-- defined further down with the row rendering.
+local downloading = {}
+local RefreshRowStatus
+
+
+-- Projects live in the write dir as MapProjects/<slug>/project.lua, a plain Lua table. The
+-- terraformer owns their format; this only reads the few fields needed to list them.
+local function ListProjects()
+	local out = {}
+	local dirs = VFS.SubDirs("MapProjects/", "*", VFS.RAW) or {}
+	for i = 1, #dirs do
+		local dir = dirs[i]
+		local raw = VFS.LoadFile(dir .. "project.lua", VFS.RAW)
+		if raw then
+			local chunk = loadstring(raw)
+			local ok, manifest = pcall(chunk)
+			if ok and type(manifest) == "table" and manifest.map then
+				local slug = dir:match("([^/\\]+)[/\\]*$")
+				out[#out + 1] = {
+					slug = slug,
+					name = manifest.name or slug,
+					sourceMap = manifest.map.source_map,
+					sizeX = manifest.map.size_x,
+					sizeZ = manifest.map.size_z,
+					baseHeight = manifest.map.base_height,
+					baseColor = manifest.map.base_color,
+					modified = manifest.modified,
+				}
+			end
+		end
+	end
+	table.sort(out, function(a, b)
+		return (a.name or "") < (b.name or "")
+	end)
+
+	return out
+end
+
+-- Values the terraformer's own New Map path uses; a project load overwrites the terrain
+-- anyway, so these only decide what the canvas looks like for the moment before it streams in.
+local NEWMAP_BASE_HEIGHT = 100
+local NEWMAP_COLOR = { 110, 130, 90 }
+
+-- The terraformer reads this on the next session and streams the project into the blank map.
+-- Writing it here rather than routing through WG.MapProject.open is what keeps this to a
+-- single launch: that path rewrites the RUNNING game's script and restarts, which would throw
+-- away the editor setup this script carries.
+local function WritePendingProject(entry)
+	Spring.CreateDir("Terraform Brush")
+	local file = io.open("Terraform Brush/pending_project.lua", "w")
+	if not file then
+		return false
+	end
+	file:write(string.format(
+		"return { path = %q, size_x = %d, size_z = %d, phase = 0, phases = %d }",
+		"MapProjects/" .. entry.slug .. "/",
+		entry.sizeX,
+		entry.sizeZ,
+		PROJECT_LOAD_PHASES
+	))
+	file:close()
+
+	return true
+end
+
+-- Game-scope keys and the [mapoptions] block the engine needs to synthesise a blank map.
+-- The name keeps the "Editor Flat WxH" prefix the terraformer's own matchers look for, and
+-- carries a timestamp because reusing a generated map name can resolve to a stale archive
+-- cache entry.
+local function BuildBlankMapKeys(entry, seed)
+	local color = entry.baseColor or NEWMAP_COLOR
+
+	return table.concat({
+		"	InitBlank=1;",
+		"	MapSeed=" .. seed .. ";",
+		"",
+		"	[mapoptions]",
+		"	{",
+		"		blank_map_x=" .. entry.sizeX .. ";",
+		"		blank_map_y=" .. entry.sizeZ .. ";",
+		"		blank_map_height=" .. (tonumber(entry.baseHeight) or NEWMAP_BASE_HEIGHT) .. ";",
+		"		blank_map_color_r=" .. color[1] .. ";",
+		"		blank_map_color_g=" .. color[2] .. ";",
+		"		blank_map_color_b=" .. color[3] .. ";",
+		"	}",
+	}, "\n")
+end
+
+-- No teams at all: the start unit is spawned per team, so declaring none is what keeps the
+-- canvas clear. The player joins as a spectator, which is the only way to be in a game with
+-- no teams to belong to. deathmode=neverend still matters, as an empty game ends instantly.
+local function BuildStartScript(mapName, projectEntry, blankSeed)
+	local Configuration = WG.Chobby.Configuration
+	local gameName = Configuration:GetDefaultGameName()
+	if not gameName then
+		return nil, "no game version available"
+	end
+	if string.find(gameName, ":") and not string.find(gameName, "rapid://") then
+		gameName = "rapid://" .. gameName
+	end
+
+	local playerName = Configuration:GetPlayerName()
+
+	return table.concat({
+		"[GAME]",
+		"{",
+		"\tMapname=" .. mapName .. ";",
+		"\tGameType=" .. gameName .. ";",
+		"\tMyPlayerName=" .. playerName .. ";",
+		"\tIsHost=1;",
+		"\tHostIP=127.0.0.1;",
+		"\tHostPort=0;",
+		"\tNoHelperAIs=0;",
+		"\tGameStartDelay=0;",
+		projectEntry and BuildBlankMapKeys(projectEntry, blankSeed) or "",
+		"",
+		"\t[MODOPTIONS]",
+		"\t{",
+		"\t\tdeathmode=neverend;",
+		"\t\tmapeditor=1;",
+		"\t}",
+		"",
+		"\tNumPlayers=1;",
+		"\tNumTeams=0;",
+		"\tNumAllyTeams=0;",
+		"",
+		"\t[PLAYER0]",
+		"\t{",
+		"\t\tName=" .. playerName .. ";",
+		"\t\tSpectator=1;",
+		"\t}",
+		"}",
+	}, "\n")
+end
+
+local function Launch()
+	local Configuration = WG.Chobby.Configuration
+	local mapName, projectEntry, blankSeed
+
+	if listMode == "projects" then
+		if not selectedProject then
+			Spring.Echo("[Map Editor] Pick a project first.")
+			return
+		end
+		projectEntry = selectedProject
+		if not (selectedProject.sizeX and selectedProject.sizeZ) then
+			Spring.Echo("[Map Editor] Project manifest has no map size.")
+			return
+		end
+		os.remove("Terraform Brush/pending_newmap.lua")
+		os.remove("Terraform Brush/pending_newmap_env.lua")
+
+		if not WritePendingProject(selectedProject) then
+			Spring.Echo("[Map Editor] Could not write the pending-project pointer.")
+			return
+		end
+		-- The engine synthesises this map from the blank_map options; the name only has to keep
+		-- the prefix the terraformer matches on, and be unique so it cannot hit a stale archive
+		-- cache entry.
+		blankSeed = os.time()
+		mapName = string.format("Editor Flat %dx%d s%d", selectedProject.sizeX, selectedProject.sizeZ, blankSeed)
+	else
+		if not selectedMap then
+			Spring.Echo("[Map Editor] Pick a map first.")
+			return
+		end
+		if not VFS.HasArchive(selectedMap) then
+			if not (WG.DownloadHandler and WG.DownloadHandler.MaybeDownloadArchive) then
+				Spring.Echo("[Map Editor] No download handler available.")
+				return
+			end
+			downloading[selectedMap] = true
+			WG.DownloadHandler.MaybeDownloadArchive(selectedMap, "map", -1)
+			RefreshRowStatus(selectedMap)
+			Spring.Echo("[Map Editor] Downloading " .. selectedMap .. " ...")
+			return
+		end
+		mapName = selectedMap
+	end
+
+	local script, err = BuildStartScript(mapName, projectEntry, blankSeed)
+	if not script then
+		Spring.Echo("[Map Editor] Cannot launch: " .. tostring(err))
+		return
+	end
+
+	-- The same two paths skirmish takes: hand the script to the wrapper where that is how this
+	-- install starts games, otherwise reload this engine onto it.
+	if
+		Configuration.multiplayerLaunchNewSpring
+		and WG.WrapperLoopback
+		and WG.WrapperLoopback.StartNewSpring
+		and WG.SettingsWindow
+	then
+		WG.WrapperLoopback.StartNewSpring({
+			StartScriptContent = script,
+			Engine = Configuration:GetTruncatedEngineVersion(),
+			SpringSettings = WG.SettingsWindow.GetSettingsString(),
+		})
+		return
+	end
+
+	Spring.Echo("[Map Editor] Launching " .. (projectEntry and projectEntry.slug or mapName) .. " ...")
+	WG.Delay(function()
+		Spring.Reload(script)
+	end, 0.4)
+end
+
+local ROW_HEIGHT = 64
+local IMG_HAVE = LUA_DIRNAME .. "images/downloadready.png"
+local IMG_MISSING = LUA_DIRNAME .. "images/downloadnotready.png"
+-- No third icon ships for "in progress", so the missing one is tinted amber instead.
+local TINT_IDLE = {1, 1, 1, 1}
+local TINT_BUSY = {1, 0.8, 0.2, 1}
+
+-- Columns whose content has a predictable width get a fixed one and are anchored to the right
+-- edge; the name takes whatever is left. A name that still does not fit had no more room to be
+-- given, so clipping there is the honest outcome rather than a layout choice.
+local GAP = 12
+local STATUS_WIDTH = 16
+local FACTS_WIDTH = 450
+local FACTS_RIGHT = GAP + STATUS_WIDTH + GAP
+local NAME_RIGHT = FACTS_RIGHT + FACTS_WIDTH + GAP
+local FOOTER_HEIGHT = 60
+
+local rows = {}
+local projectRows = {}
+local startButton
+local filterText = ""
+local mapList
+local SetSelectedForward
+
+-- One line of facts from the generated mapDetails entry. Kept deliberately small: this panel
+-- is a prototype and its own thing, not a second copy of the map browser.
+local function DescribeMap(mapName, data)
+	if not data then
+		return "unknown"
+	end
+
+	local parts = {}
+	if data.Width and data.Height then
+		parts[#parts + 1] = data.Width .. "x" .. data.Height
+	end
+	if data.PlayerCount then
+		parts[#parts + 1] = data.PlayerCount .. "p"
+	end
+	if data.TeamCount then
+		parts[#parts + 1] = data.TeamCount .. " teams"
+	end
+
+	local kinds = {}
+	if data.Is1v1 then
+		kinds[#kinds + 1] = "1v1"
+	end
+	if data.IsTeam then
+		kinds[#kinds + 1] = "Team"
+	end
+	if data.IsFFA then
+		kinds[#kinds + 1] = "FFA"
+	end
+	if #kinds > 0 then
+		parts[#parts + 1] = table.concat(kinds, "/")
+	end
+
+	local terrain = {}
+	if data.Flat then
+		terrain[#terrain + 1] = "Flat"
+	end
+	if data.Hills then
+		terrain[#terrain + 1] = "Hills"
+	end
+	if data.Water then
+		terrain[#terrain + 1] = "Water"
+	end
+	if data.Special then
+		terrain[#terrain + 1] = data.Special
+	end
+	if #terrain > 0 then
+		parts[#parts + 1] = table.concat(terrain, " ")
+	end
+
+	return table.concat(parts, "  -  ")
+end
+
+local function Highlight(button, chosen)
+	if chosen then
+		ButtonUtilities.SetButtonSelected(button)
+	else
+		ButtonUtilities.SetButtonDeselected(button)
+	end
+end
+
+local function SetSelectedProject(entry)
+	selectedProject = entry
+	for i = 1, #projectRows do
+		Highlight(projectRows[i].button, projectRows[i].entry == entry)
+	end
+
+	if startButton then
+		startButton:SetEnabled(entry ~= nil)
+		startButton:SetCaption("Start")
+	end
+end
+
+SetSelectedForward = function(mapName)
+	selectedMap = mapName
+	for i = 1, #rows do
+		Highlight(rows[i].button, rows[i].mapName == mapName)
+	end
+
+	if not startButton then
+		return
+	end
+
+	local busy = mapName and downloading[mapName]
+	startButton:SetEnabled(mapName ~= nil and not busy)
+	-- mapDetails lists every map the lobby knows of, most of them not downloaded. Rather
+	-- than hide those, the button offers to fetch the one you picked.
+	local have = mapName and VFS.HasArchive(mapName)
+	if busy then
+		startButton:SetCaption("Downloading...")
+	else
+		startButton:SetCaption((mapName and not have) and "Download" or "Start")
+	end
+end
+
+-- Row shell both lists are built on: the panel is what the list positions, the button inside
+-- it is what takes the click and carries the selected tint.
+local function CreateRow(OnPick, OnLaunch)
+	local root = Panel:New {
+		x = 0,
+		y = 0,
+		width = "100%",
+		height = ROW_HEIGHT,
+		resizable = false,
+		draggable = false,
+		padding = {0, 0, 0, 0},
+		noFont = true,
+	}
+
+	local button = Button:New {
+		x = 0,
+		y = 0,
+		right = 0,
+		bottom = 0,
+		caption = "",
+		classname = "battle_default_button",
+		padding = {0, 0, 0, 0},
+		parent = root,
+		OnClick = { OnPick },
+		OnDblClick = { OnLaunch },
+	}
+
+	return root, button
+end
+
+-- Contents are built on first parent, not in GetControl: that runs while Configuration is
+-- still being constructed (the game config includes this file), so Configuration:GetFont has
+-- no font table yet. Same deferral the scenario window uses.
+local function InitializeControls(parent)
+	local Configuration = WG.Chobby.Configuration
+
+	Label:New {
+		parent = parent,
+		x = 15,
+		right = 5,
+		y = 17,
+		height = 20,
+		caption = "Map Editor",
+		objectOverrideFont = Configuration:GetFont(3),
+	}
+
+	local mapsTab, projectsTab
+
+	local searchBox = EditBox:New {
+		parent = parent,
+		right = 15,
+		y = 13,
+		width = 220,
+		height = 33,
+		text = "",
+		hint = "Search",
+		objectOverrideFont = Configuration:GetFont(2),
+		objectOverrideHintFont = Configuration:GetFont(11),
+	}
+
+	local mapHolder = Control:New {
+		parent = parent,
+		x = 12,
+		right = 15,
+		y = 62,
+		bottom = FOOTER_HEIGHT,
+		resizable = false,
+		draggable = false,
+		padding = {0, 0, 0, 0},
+	}
+
+	local projectHolder = Control:New {
+		parent = parent,
+		x = 12,
+		right = 15,
+		y = 62,
+		bottom = FOOTER_HEIGHT,
+		resizable = false,
+		draggable = false,
+		padding = {0, 0, 0, 0},
+	}
+
+	local function ItemInFilter(sortData)
+		return filterText == "" or sortData[1]:find(filterText, 1, true) ~= nil
+	end
+
+	mapList = WG.Chobby.SortableList(mapHolder, {
+		{name = "Name", x = 0, right = NAME_RIGHT},
+		{name = "Details", right = FACTS_RIGHT, width = FACTS_WIDTH},
+	}, ROW_HEIGHT, 1, true, nil, ItemInFilter)
+
+	local projectList = WG.Chobby.SortableList(projectHolder, {
+		{name = "Project", x = 0, right = NAME_RIGHT},
+		{name = "Captured from", right = GAP, width = FACTS_WIDTH},
+	}, ROW_HEIGHT, 1, true)
+
+	-- Same source the map browser uses. VFS.GetMaps is not it: the lobby knows maps through
+	-- the generated mapDetails config, which is also what carries their metadata.
+	local maps = {}
+	for mapName in pairs(Configuration.gameConfig.mapDetails or {}) do
+		maps[#maps + 1] = mapName
+	end
+	table.sort(maps)
+
+	rows = {}
+	local mapItems = {}
+	for i = 1, #maps do
+		local mapName = maps[i]
+		local data = Configuration.gameConfig.mapDetails[mapName]
+		local root, button = CreateRow(function()
+			SetSelectedForward(mapName)
+		end, function()
+			SetSelectedForward(mapName)
+			Launch()
+		end)
+
+		local minimap = Panel:New {
+			name = "minimap",
+			x = 3,
+			y = 3,
+			width = ROW_HEIGHT - 6,
+			height = ROW_HEIGHT - 6,
+			padding = {1, 1, 1, 1},
+			parent = button,
+		}
+
+		local mapImageFile, needDownload = Configuration:GetMinimapImage(mapName)
+		Image:New {
+			x = 0,
+			y = 0,
+			right = 0,
+			bottom = 0,
+			file = mapImageFile,
+			fallbackFile = Configuration:GetLoadingImage(3),
+			checkFileExists = needDownload,
+			parent = minimap,
+		}
+
+		Label:New {
+			parent = button,
+			x = ROW_HEIGHT + 6,
+			y = 0,
+			right = NAME_RIGHT,
+			height = ROW_HEIGHT,
+			valign = "center",
+			caption = mapName,
+			objectOverrideFont = Configuration:GetFont(3),
+		}
+
+		local facts = DescribeMap(mapName, data)
+		Label:New {
+			parent = button,
+			right = FACTS_RIGHT,
+			y = 0,
+			width = FACTS_WIDTH,
+			height = ROW_HEIGHT,
+			valign = "center",
+			caption = facts,
+			objectOverrideFont = Configuration:GetFont(1),
+		}
+
+		-- An icon rather than the words: the browser uses these same two for exactly this.
+		local statusImage = Image:New {
+			parent = button,
+			right = GAP,
+			y = math.floor((ROW_HEIGHT - 20) / 2),
+			width = STATUS_WIDTH,
+			height = 20,
+			file = VFS.HasArchive(mapName) and IMG_HAVE or IMG_MISSING,
+			tooltip = VFS.HasArchive(mapName) and "Installed" or "Not downloaded",
+		}
+
+		rows[i] = {
+			button = button,
+			status = statusImage,
+			mapName = mapName,
+		}
+		mapItems[i] = {mapName, root, {mapName:lower(), facts}}
+	end
+	mapList:AddItems(mapItems)
+
+	projectRows = {}
+	local projects = ListProjects()
+	local projectItems = {}
+	for i = 1, #projects do
+		local entry = projects[i]
+		local root, button = CreateRow(function()
+			SetSelectedProject(entry)
+		end, function()
+			SetSelectedProject(entry)
+			Launch()
+		end)
+
+		Label:New {
+			parent = button,
+			x = 12,
+			y = 0,
+			right = NAME_RIGHT,
+			height = ROW_HEIGHT,
+			valign = "center",
+			caption = entry.name,
+			objectOverrideFont = Configuration:GetFont(3),
+		}
+
+		local facts = string.format(
+			"%dx%d  -  %s  -  %s",
+			entry.sizeX or 0,
+			entry.sizeZ or 0,
+			tostring(entry.sourceMap),
+			tostring(entry.modified)
+		)
+		Label:New {
+			parent = button,
+			right = GAP,
+			y = 0,
+			width = FACTS_WIDTH,
+			height = ROW_HEIGHT,
+			valign = "center",
+			caption = facts,
+			objectOverrideFont = Configuration:GetFont(1),
+		}
+
+		projectRows[i] = {button = button, entry = entry}
+		projectItems[i] = {entry.slug, root, {entry.name:lower(), facts}}
+	end
+	projectList:AddItems(projectItems)
+
+	startButton = Button:New {
+		parent = parent,
+		right = 15,
+		bottom = 8,
+		width = 160,
+		height = 45,
+		caption = "Start",
+		classname = "action_button",
+		objectOverrideFont = Configuration:GetFont(3),
+		OnClick = { Launch },
+	}
+
+	local function SetMode(mode)
+		listMode = mode
+		mapHolder:SetVisibility(mode == "maps")
+		projectHolder:SetVisibility(mode == "projects")
+		searchBox:SetVisibility(mode == "maps")
+		Highlight(mapsTab, mode == "maps")
+		Highlight(projectsTab, mode == "projects")
+		if mode == "maps" then
+			SetSelectedForward(selectedMap)
+		else
+			SetSelectedProject(selectedProject)
+		end
+	end
+
+	mapsTab = Button:New {
+		parent = parent,
+		x = 150,
+		y = 7,
+		width = 110,
+		height = 45,
+		caption = "Maps",
+		classname = "option_button",
+		objectOverrideFont = Configuration:GetFont(2),
+		OnClick = {
+			function()
+				SetMode("maps")
+			end,
+		},
+	}
+
+	-- Projects are the terraformer's own saves; keeping them on a separate list avoids implying
+	-- a project is just another map, which it is not (it restarts into a blank canvas).
+	projectsTab = Button:New {
+		parent = parent,
+		x = 266,
+		y = 7,
+		width = 110,
+		height = 45,
+		caption = "Projects",
+		classname = "option_button",
+		objectOverrideFont = Configuration:GetFont(2),
+		OnClick = {
+			function()
+				SetMode("projects")
+			end,
+		},
+	}
+
+	SetMode(listMode)
+
+	-- One handler only. Hooking both OnKeyPress and OnTextInput ran the filter twice per key.
+	searchBox.OnKeyPress = searchBox.OnKeyPress or {}
+	searchBox.OnKeyPress[#searchBox.OnKeyPress + 1] = function(obj)
+		filterText = (obj.text or ""):lower()
+		mapList:RecalculateDisplay()
+	end
+end
+
+function TerraformerWindow.GetControl()
+	return Control:New {
+		name = "terraformerWindow",
+		x = "0%",
+		y = "0%",
+		width = "100%",
+		height = "100%",
+		padding = {0, 0, 0, 0},
+		OnParent = {
+			function(obj)
+				if obj:IsEmpty() then
+					InitializeControls(obj)
+				end
+			end,
+		},
+	}
+end
+
+-- Without this the button keeps reading Download after the map has arrived, until the user
+-- reselects it.
+RefreshRowStatus = function(mapName)
+	for i = 1, #rows do
+		local row = rows[i]
+		if row.mapName == mapName and row.status then
+			local have = VFS.HasArchive(mapName)
+			local busy = downloading[mapName]
+			row.status.file = have and IMG_HAVE or IMG_MISSING
+			row.status.color = busy and TINT_BUSY or TINT_IDLE
+			row.status.tooltip = (busy and "Downloading...")
+				or (have and "Installed")
+				or "Not downloaded"
+			row.status:Invalidate()
+		end
+	end
+	if mapName == selectedMap then
+		SetSelectedForward(selectedMap)
+	end
+end
+
+local function OnDownloadStarted(_, _, thingName)
+	if thingName and downloading[thingName] ~= nil then
+		downloading[thingName] = true
+		RefreshRowStatus(thingName)
+	end
+end
+
+local function OnDownloadFinished(_, _, thingName)
+	if thingName then
+		downloading[thingName] = nil
+		RefreshRowStatus(thingName)
+	end
+end
+
+local function OnDownloadFailed(_, _, _, thingName)
+	if thingName then
+		downloading[thingName] = nil
+		RefreshRowStatus(thingName)
+		Spring.Echo("[Map Editor] Download failed: " .. tostring(thingName))
+	end
+end
+
+function widget:Initialize()
+	CHOBBY_DIR = LUA_DIRNAME .. "widgets/chobby/"
+	VFS.Include(LUA_DIRNAME .. "widgets/chobby/headers/exports.lua", nil, VFS.RAW_FIRST)
+
+	WG.DownloadHandler.AddListener("DownloadStarted", OnDownloadStarted)
+	WG.DownloadHandler.AddListener("DownloadFinished", OnDownloadFinished)
+	WG.DownloadHandler.AddListener("DownloadFailed", OnDownloadFailed)
+
+	WG.TerraformerWindow = TerraformerWindow
+end

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -22,6 +22,9 @@ local PROJECT_LOAD_PHASES = 11
 local downloading = {}
 local RefreshRowStatus
 local startButton
+-- A row click keeps arriving after the double click that launched, and would put "Start" back
+-- on the button; the caption belongs to the launch until the lobby is on screen again.
+local launching = false
 
 
 -- Projects live in the write dir as MapProjects/<slug>/project.lua, a plain Lua table. The
@@ -296,6 +299,7 @@ local function Launch()
 		return
 	end
 
+	launching = true
 	if startButton then
 		startButton:SetEnabled(false)
 		startButton:SetCaption("Starting")
@@ -326,6 +330,9 @@ end
 local ROW_HEIGHT = 64
 local IMG_HAVE = LUA_DIRNAME .. "images/downloadready.png"
 local IMG_MISSING = LUA_DIRNAME .. "images/downloadnotready.png"
+-- The combobox chevron, borrowed the way the map browser borrows the skin's star. It points
+-- down as drawn, so ascending flips it.
+local IMG_SORT_ARROW = LUA_DIRNAME .. "widgets/chili/skins/Armada Blues/combobox_ctrl_arrow.png"
 -- No third icon ships for "in progress", so the missing one is tinted amber instead.
 local TINT_IDLE = {1, 1, 1, 1}
 local TINT_BUSY = {1, 0.8, 0.2, 1}
@@ -438,7 +445,7 @@ local function SetSelectedProject(entry)
 		Highlight(projectRows[i].button, projectRows[i].entry == entry)
 	end
 
-	if startButton then
+	if startButton and not launching then
 		startButton:SetEnabled(entry ~= nil)
 		startButton:SetCaption("Start")
 	end
@@ -450,7 +457,7 @@ SetSelectedForward = function(mapName)
 		Highlight(rows[i].button, rows[i].mapName == mapName)
 	end
 
-	if not startButton then
+	if not startButton or launching then
 		return
 	end
 
@@ -576,6 +583,46 @@ local function InitializeControls(parent)
 
 	local projectList =
 		WG.Chobby.SortableList(projectHolder, PROJECT_COLUMNS, ROW_HEIGHT, COLUMN_MODIFIED, false, nil, ItemInFilter)
+
+	-- SortableList knows which column it is ordering by but draws nothing to say so, and its
+	-- headings are plain buttons. Appending to their click handlers runs after the list has
+	-- already moved sortBy, so the mark lands on the column that just took over.
+	-- Sits on the holder rather than inside the heading button: the button skin pads 10 all round,
+	-- which would cap the glyph at half this size.
+	local function MarkSortedColumn(list, columns, holder)
+		local arrows = {}
+		for i = 1, #list.headingButtons do
+			arrows[i] = Image:New {
+				parent = holder,
+				right = columns[i].right,
+				y = 7,
+				width = 34,
+				height = 24,
+				keepAspect = true,
+				file = IMG_SORT_ARROW,
+			}
+		end
+
+		local function Apply()
+			for i = 1, #list.headingButtons do
+				local active = i == list.sortBy
+				Highlight(list.headingButtons[i], active)
+				arrows[i]:SetVisibility(active)
+				arrows[i].flip = list.smallToLarge
+				arrows[i]:Invalidate()
+			end
+		end
+
+		for i = 1, #list.headingButtons do
+			local heading = list.headingButtons[i]
+			heading.OnClick[#heading.OnClick + 1] = Apply
+		end
+
+		Apply()
+	end
+
+	MarkSortedColumn(mapList, MAP_COLUMNS, mapHolder)
+	MarkSortedColumn(projectList, PROJECT_COLUMNS, projectHolder)
 
 	-- Same source the map browser uses. VFS.GetMaps is not it: the lobby knows maps through
 	-- the generated mapDetails config, which is also what carries their metadata.
@@ -892,6 +939,7 @@ local function OnDownloadFailed(_, _, _, thingName)
 end
 
 function widget:ActivateMenu()
+	launching = false
 	if RefreshProjects then
 		RefreshProjects()
 	end

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -71,6 +71,15 @@ end
 -- Mirrors the defaults the terraformer's own New Map path uses.
 local NEWMAP_BASE_HEIGHT = 100
 local NEWMAP_COLOR = { 110, 130, 90 }
+local NEWMAP_SIZE = 12
+
+local NEW_PROJECT = {
+	slug = "\0newmap",
+	name = "New Map",
+	sizeX = NEWMAP_SIZE,
+	sizeZ = NEWMAP_SIZE,
+	isNew = true,
+}
 
 -- Bypasses WG.MapProject.open, which restarts a running game and loses the editor setup.
 local function WritePendingProject(entry)
@@ -87,6 +96,23 @@ local function WritePendingProject(entry)
 		PROJECT_LOAD_PHASES
 	))
 	file:close()
+
+	return true
+end
+
+-- The terraformer reads an existing but empty recipe as "flat map, default environment", where a
+-- missing one leaves whatever the last session wrote in place.
+local function WriteNewMapRecipe()
+	Spring.CreateDir("Terraform Brush")
+	os.remove("Terraform Brush/pending_project.lua")
+
+	for _, name in ipairs({"pending_newmap.lua", "pending_newmap_env.lua"}) do
+		local file = io.open("Terraform Brush/" .. name, "w")
+		if not file then
+			return false
+		end
+		file:close()
+	end
 
 	return true
 end
@@ -229,6 +255,11 @@ local function BuildStartScript(mapName, projectEntry, blankSeed)
 end
 
 local function Launch()
+	-- Chobby stays up alongside the editor, and the panel is reachable again while it runs.
+	if launching then
+		return
+	end
+
 	local Configuration = WG.Chobby.Configuration
 	local mapName, projectEntry, blankSeed
 
@@ -242,12 +273,20 @@ local function Launch()
 			Spring.Echo("[Map Editor] Project manifest has no map size.")
 			return
 		end
-		os.remove("Terraform Brush/pending_newmap.lua")
-		os.remove("Terraform Brush/pending_newmap_env.lua")
 
-		if not WritePendingProject(selectedProject) then
-			Spring.Echo("[Map Editor] Could not write the pending-project pointer.")
-			return
+		if selectedProject.isNew then
+			if not WriteNewMapRecipe() then
+				Spring.Echo("[Map Editor] Could not clear the pending New Map recipe.")
+				return
+			end
+		else
+			os.remove("Terraform Brush/pending_newmap.lua")
+			os.remove("Terraform Brush/pending_newmap_env.lua")
+
+			if not WritePendingProject(selectedProject) then
+				Spring.Echo("[Map Editor] Could not write the pending-project pointer.")
+				return
+			end
 		end
 		-- Keeps the prefix the terraformer matches on; the stamp dodges a stale archive cache entry.
 		blankSeed = os.time()
@@ -280,7 +319,7 @@ local function Launch()
 	launching = true
 	if startButton then
 		startButton:SetEnabled(false)
-		startButton:SetCaption("Starting")
+		startButton:SetCaption("Running")
 	end
 
 	-- The same two paths skirmish takes.
@@ -536,7 +575,8 @@ local function InitializeControls(parent)
 	}
 
 	local function ItemInFilter(sortData)
-		return filterText == "" or (sortData.search or ""):find(filterText, 1, true) ~= nil
+		return sortData.alwaysShow or filterText == ""
+			or (sortData.search or ""):find(filterText, 1, true) ~= nil
 	end
 
 	mapList = WG.Chobby.SortableList(mapHolder, MAP_COLUMNS, ROW_HEIGHT, 1, true, nil, ItemInFilter)
@@ -685,6 +725,7 @@ local function InitializeControls(parent)
 	local function BuildProjectItems()
 		projectRows = {}
 		local projects = ListProjects()
+		table.insert(projects, 1, NEW_PROJECT)
 		local projectItems = {}
 		for i = 1, #projects do
 			local entry = projects[i]
@@ -698,7 +739,7 @@ local function InitializeControls(parent)
 			local sourceMap = entry.sourceMap or "-"
 			local cells = {
 				{caption = entry.name, font = 3},
-				{caption = sourceMap, font = 1},
+				{caption = entry.isNew and "Blank canvas" or sourceMap, font = 1},
 				{caption = string.format("%dx%d", entry.sizeX or 0, entry.sizeZ or 0), font = 1},
 				{caption = FormatModified(entry.modified), font = 1},
 			}
@@ -725,6 +766,11 @@ local function InitializeControls(parent)
 				entry.modified or "",
 			}
 			sortData.search = entry.name:lower() .. " " .. sourceMap:lower()
+			-- Starting fresh is always an option, so it outranks both sort directions and the
+			-- search box rather than being something you have to find.
+			if entry.isNew then
+				sortData.alwaysShow = true
+			end
 
 			projectRows[i] = {button = button, entry = entry}
 			projectItems[i] = {entry.slug, root, sortData}
@@ -733,6 +779,7 @@ local function InitializeControls(parent)
 		return projectItems
 	end
 
+	projectList.priorityList[NEW_PROJECT.slug] = true
 	projectList:AddItems(BuildProjectItems())
 
 	startButton = Button:New {

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -14,21 +14,16 @@ local TerraformerWindow = {}
 
 local selectedMap
 local selectedProject
-local listMode = "maps" -- "maps" | "projects"
--- Matches #LOAD_PHASES in cmd_map_project.lua; the pointer carries it for progress reporting.
+local listMode = "maps"
+-- Must match #LOAD_PHASES in the game's cmd_map_project.lua.
 local PROJECT_LOAD_PHASES = 11
--- Declared up here because Launch, below, reports download and launch state, and all three are
--- defined further down with the row rendering.
 local downloading = {}
 local RefreshRowStatus
 local startButton
--- A row click keeps arriving after the double click that launched, and would put "Start" back
--- on the button; the caption belongs to the launch until the lobby is on screen again.
+-- Chili delivers a row's OnClick alongside its OnDblClick, so the launch has to lock the caption.
 local launching = false
 
 
--- Projects live in the write dir as MapProjects/<slug>/project.lua, a plain Lua table. The
--- terraformer owns their format; this only reads the few fields needed to list them.
 local function ListProjects()
 	local out = {}
 	local dirs = VFS.SubDirs("MapProjects/", "*", VFS.RAW) or {}
@@ -59,8 +54,7 @@ local function ListProjects()
 	return out
 end
 
--- Manifests record modified as a fixed-width UTC ISO stamp, which sorts lexically. Only the
--- display goes through the local-time conversion; the raw string stays the sort key.
+-- Manifests record modified as a fixed-width UTC ISO stamp, so the raw string sorts lexically.
 local function FormatModified(iso)
 	if not iso then
 		return "-"
@@ -74,15 +68,11 @@ local function FormatModified(iso)
 	return string.format("%04d-%02d-%02d %02d:%02d", t[6], t[5], t[4], t[3], t[2])
 end
 
--- Values the terraformer's own New Map path uses; a project load overwrites the terrain
--- anyway, so these only decide what the canvas looks like for the moment before it streams in.
+-- Mirrors the defaults the terraformer's own New Map path uses.
 local NEWMAP_BASE_HEIGHT = 100
 local NEWMAP_COLOR = { 110, 130, 90 }
 
--- The terraformer reads this on the next session and streams the project into the blank map.
--- Writing it here rather than routing through WG.MapProject.open is what keeps this to a
--- single launch: that path rewrites the RUNNING game's script and restarts, which would throw
--- away the editor setup this script carries.
+-- Bypasses WG.MapProject.open, which restarts a running game and loses the editor setup.
 local function WritePendingProject(entry)
 	Spring.CreateDir("Terraform Brush")
 	local file = io.open("Terraform Brush/pending_project.lua", "w")
@@ -101,10 +91,7 @@ local function WritePendingProject(entry)
 	return true
 end
 
--- A blank canvas ships no SSMF splat textures, so the detail normals the project was captured
--- with have to be handed to the generator or the terrain loads as flat diffuse. The project
--- carries its own copies under assets/, which is why these resolve against the project rather
--- than the shared library.
+-- A blank canvas ships no SSMF splat textures, so without these the terrain loads as flat diffuse.
 local function BuildSplatKeys(entry)
 	local dnts = entry.dnts
 	if type(dnts) ~= "table" then
@@ -126,8 +113,7 @@ local function BuildSplatKeys(entry)
 		end
 	end
 
-	-- Older SMFReadMap paths only switch splats on when a detail texture is present, even where
-	-- the normals are the real source, so channel 1 stands in when the project captured none.
+	-- Older SMFReadMap paths only switch splats on when a detail texture is present.
 	local detail = dnts.detail or textures[1]
 	if type(detail) == "string" and detail ~= "" then
 		keys[#keys + 1] = "blank_map_splatdetailtex=" .. prefix .. detail .. ";"
@@ -160,10 +146,6 @@ local function FindSkybox(name)
 	return nil
 end
 
--- Game-scope keys and the [mapoptions] block the engine needs to synthesise a blank map.
--- The name keeps the "Editor Flat WxH" prefix the terraformer's own matchers look for, and
--- carries a timestamp because reusing a generated map name can resolve to a stale archive
--- cache entry.
 local function BuildBlankMapKeys(entry, seed)
 	local color = entry.baseColor or NEWMAP_COLOR
 
@@ -201,9 +183,7 @@ local function BuildBlankMapKeys(entry, seed)
 	}, "\n")
 end
 
--- No teams at all: the start unit is spawned per team, so declaring none is what keeps the
--- canvas clear. The player joins as a spectator, which is the only way to be in a game with
--- no teams to belong to. deathmode=neverend still matters, as an empty game ends instantly.
+-- The game spawns a start unit per team, and an empty game ends instantly without neverend.
 local function BuildStartScript(mapName, projectEntry, blankSeed)
 	local Configuration = WG.Chobby.Configuration
 	local gameName = Configuration:GetDefaultGameName()
@@ -269,9 +249,7 @@ local function Launch()
 			Spring.Echo("[Map Editor] Could not write the pending-project pointer.")
 			return
 		end
-		-- The engine synthesises this map from the blank_map options; the name only has to keep
-		-- the prefix the terraformer matches on, and be unique so it cannot hit a stale archive
-		-- cache entry.
+		-- Keeps the prefix the terraformer matches on; the stamp dodges a stale archive cache entry.
 		blankSeed = os.time()
 		mapName = string.format("Editor Flat %dx%d s%d", selectedProject.sizeX, selectedProject.sizeZ, blankSeed)
 	else
@@ -305,8 +283,7 @@ local function Launch()
 		startButton:SetCaption("Starting")
 	end
 
-	-- The same two paths skirmish takes: hand the script to the wrapper where that is how this
-	-- install starts games, otherwise reload this engine onto it.
+	-- The same two paths skirmish takes.
 	if
 		Configuration.multiplayerLaunchNewSpring
 		and WG.WrapperLoopback
@@ -330,8 +307,7 @@ end
 local ROW_HEIGHT = 64
 local IMG_HAVE = LUA_DIRNAME .. "images/downloadready.png"
 local IMG_MISSING = LUA_DIRNAME .. "images/downloadnotready.png"
--- The combobox chevron, borrowed the way the map browser borrows the skin's star. It points
--- down as drawn, so ascending flips it.
+-- Points down as drawn, so ascending flips it.
 local IMG_SORT_ARROW = LUA_DIRNAME .. "widgets/chili/skins/Armada Blues/combobox_ctrl_arrow.png"
 -- No third icon ships for "in progress", so the missing one is tinted amber instead.
 local TINT_IDLE = {1, 1, 1, 1}
@@ -339,13 +315,8 @@ local TINT_BUSY = {1, 0.8, 0.2, 1}
 
 local FOOTER_HEIGHT = 60
 
--- One spec drives both the heading buttons and the row cells, so a cell can never sit anywhere
--- but under its own heading. Edges are percentages because the panel is as wide as the lobby
--- window: fixed pixel columns would leave the table bunched on the left of a big screen. The
--- gaps between the percentages are what stops adjacent heading buttons touching.
---
--- Heading captions are centred by the button skin, so cells centre too; the leading name column
--- is the exception, since it reads as the row's label rather than as a value.
+-- The scroll panel takes width off the right edge once the list scrolls, so right-anchored cells
+-- drift out from under their heading.
 local MAP_COLUMNS = {
 	{name = "Name", x = "0%", right = "70%", align = "left"},
 	{name = "Size", x = "30.5%", right = "61%"},
@@ -371,12 +342,9 @@ local projectRows = {}
 local filterText = ""
 local mapList
 local SetSelectedForward
--- LuaMenu survives Spring.Reload, so the panel built on first show outlives every editor
--- session launched from it. Assigned in InitializeControls, called on the way back.
+-- LuaMenu survives Spring.Reload, so this panel outlives every editor session launched from it.
 local RefreshProjects
 
--- One entry per column between Name and Status, in that order. Sort values are kept apart from
--- the captions so the counts order by magnitude rather than by how they read.
 local function DescribeMap(data)
 	data = data or {}
 
@@ -422,7 +390,6 @@ local function DescribeMap(data)
 	}
 end
 
--- Sorted as text so the Status heading orders installed maps first, then in-flight, then the rest.
 local function StatusSortKey(mapName)
 	if VFS.HasArchive(mapName) then
 		return "1 installed"
@@ -463,8 +430,7 @@ SetSelectedForward = function(mapName)
 
 	local busy = mapName and downloading[mapName]
 	startButton:SetEnabled(mapName ~= nil and not busy)
-	-- mapDetails lists every map the lobby knows of, most of them not downloaded. Rather
-	-- than hide those, the button offers to fetch the one you picked.
+	-- mapDetails lists every map the lobby knows of, most of them not downloaded.
 	local have = mapName and VFS.HasArchive(mapName)
 	if busy then
 		startButton:SetCaption("Downloading...")
@@ -473,8 +439,6 @@ SetSelectedForward = function(mapName)
 	end
 end
 
--- Row shell both lists are built on: the panel is what the list positions, the button inside
--- it is what takes the click and carries the selected tint.
 local function CreateRow(OnPick, OnLaunch)
 	local root = Panel:New {
 		x = 0,
@@ -503,9 +467,7 @@ local function CreateRow(OnPick, OnLaunch)
 	return root, button
 end
 
--- Contents are built on first parent, not in GetControl: that runs while Configuration is
--- still being constructed (the game config includes this file), so Configuration:GetFont has
--- no font table yet. Same deferral the scenario window uses.
+-- GetControl runs while Configuration is still being built, so GetFont has no font table yet.
 local function InitializeControls(parent)
 	local Configuration = WG.Chobby.Configuration
 
@@ -573,8 +535,6 @@ local function InitializeControls(parent)
 		padding = {0, 0, 0, 0},
 	}
 
-	-- Sort fields hold whatever each column orders by, counts included, so the text to match a
-	-- query against rides alongside them under its own key.
 	local function ItemInFilter(sortData)
 		return filterText == "" or (sortData.search or ""):find(filterText, 1, true) ~= nil
 	end
@@ -584,11 +544,8 @@ local function InitializeControls(parent)
 	local projectList =
 		WG.Chobby.SortableList(projectHolder, PROJECT_COLUMNS, ROW_HEIGHT, COLUMN_MODIFIED, false, nil, ItemInFilter)
 
-	-- SortableList knows which column it is ordering by but draws nothing to say so, and its
-	-- headings are plain buttons. Appending to their click handlers runs after the list has
-	-- already moved sortBy, so the mark lands on the column that just took over.
-	-- Sits on the holder rather than inside the heading button: the button skin pads 10 all round,
-	-- which would cap the glyph at half this size.
+	-- Appending to a heading handler runs after the list has moved sortBy. The arrow sits on the
+	-- holder because the button skin pads 10 all round and would cap the glyph at half this size.
 	local function MarkSortedColumn(list, columns, holder)
 		local arrows = {}
 		for i = 1, #list.headingButtons do
@@ -624,8 +581,7 @@ local function InitializeControls(parent)
 	MarkSortedColumn(mapList, MAP_COLUMNS, mapHolder)
 	MarkSortedColumn(projectList, PROJECT_COLUMNS, projectHolder)
 
-	-- Same source the map browser uses. VFS.GetMaps is not it: the lobby knows maps through
-	-- the generated mapDetails config, which is also what carries their metadata.
+	-- VFS.GetMaps is not the source: the lobby knows maps through the generated mapDetails config.
 	local maps = {}
 	for mapName in pairs(Configuration.gameConfig.mapDetails or {}) do
 		maps[#maps + 1] = mapName
@@ -701,7 +657,6 @@ local function InitializeControls(parent)
 			searchable[#searchable + 1] = facts[f].caption:lower()
 		end
 
-		-- An icon rather than the words: the browser uses these same two for exactly this.
 		-- keepAspect is what centres it in the column, since the image spans the whole cell.
 		local statusColumn = MAP_COLUMNS[COLUMN_STATUS]
 		local statusImage = Image:New {
@@ -811,8 +766,6 @@ local function InitializeControls(parent)
 		end
 	end
 
-	-- Rows carry the manifest table they were built from, and selection is identity on that
-	-- table, so the pick has to be re-resolved by slug against the rebuilt rows.
 	RefreshProjects = function()
 		local selectedSlug = selectedProject and selectedProject.slug
 
@@ -846,8 +799,6 @@ local function InitializeControls(parent)
 		},
 	}
 
-	-- Projects are the terraformer's own saves; keeping them on a separate list avoids implying
-	-- a project is just another map, which it is not (it restarts into a blank canvas).
 	projectsTab = Button:New {
 		parent = parent,
 		x = 266,
@@ -866,7 +817,6 @@ local function InitializeControls(parent)
 
 	SetMode(listMode)
 
-	-- One handler only. Hooking both OnKeyPress and OnTextInput ran the filter twice per key.
 	searchBox.OnKeyPress = searchBox.OnKeyPress or {}
 	searchBox.OnKeyPress[#searchBox.OnKeyPress + 1] = function(obj)
 		filterText = (obj.text or ""):lower()
@@ -892,8 +842,6 @@ function TerraformerWindow.GetControl()
 	}
 end
 
--- Without this the button keeps reading Download after the map has arrived, until the user
--- reselects it.
 RefreshRowStatus = function(mapName)
 	for i = 1, #rows do
 		local row = rows[i]

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -68,10 +68,13 @@ local function FormatModified(iso)
 	return string.format("%04d-%02d-%02d %02d:%02d", t[6], t[5], t[4], t[3], t[2])
 end
 
--- Mirrors the defaults the terraformer's own New Map path uses.
+-- Mirrors the defaults the terraformer's own New Map path uses, including the even-only
+-- sizes its sliders snap to.
 local NEWMAP_BASE_HEIGHT = 100
 local NEWMAP_COLOR = { 110, 130, 90 }
 local NEWMAP_SIZE = 12
+local NEWMAP_MIN_SIZE = 4
+local NEWMAP_MAX_SIZE = 32
 
 local NEW_PROJECT = {
 	slug = "\0newmap",
@@ -80,6 +83,17 @@ local NEW_PROJECT = {
 	sizeZ = NEWMAP_SIZE,
 	isNew = true,
 }
+
+local NEWMAP_SIZES = {}
+for size = NEWMAP_MIN_SIZE, NEWMAP_MAX_SIZE, 2 do
+	NEWMAP_SIZES[#NEWMAP_SIZES + 1] = tostring(size)
+end
+
+local function SizeToItem(size)
+	return (size - NEWMAP_MIN_SIZE) / 2 + 1
+end
+
+local UpdateNewMapControls
 
 -- Bypasses WG.MapProject.open, which restarts a running game and loses the editor setup.
 local function WritePendingProject(entry)
@@ -459,12 +473,20 @@ local function SetSelectedProject(entry)
 		startButton:SetEnabled(entry ~= nil)
 		startButton:SetCaption("Start")
 	end
+
+	if UpdateNewMapControls then
+		UpdateNewMapControls()
+	end
 end
 
 SetSelectedForward = function(mapName)
 	selectedMap = mapName
 	for i = 1, #rows do
 		Highlight(rows[i].button, rows[i].mapName == mapName)
+	end
+
+	if UpdateNewMapControls then
+		UpdateNewMapControls()
 	end
 
 	if not startButton or launching then
@@ -726,6 +748,8 @@ local function InitializeControls(parent)
 	end
 	mapList:AddItems(mapItems)
 
+	local newMapSizeLabel
+
 	local function BuildProjectItems()
 		projectRows = {}
 		local projects = ListProjects()
@@ -749,7 +773,7 @@ local function InitializeControls(parent)
 			}
 			for c = 1, #cells do
 				local column = PROJECT_COLUMNS[c]
-				Label:New {
+				local cell = Label:New {
 					parent = button,
 					x = column.cellX or column.x,
 					y = 0,
@@ -761,6 +785,9 @@ local function InitializeControls(parent)
 					caption = cells[c].caption,
 					objectOverrideFont = Configuration:GetFont(cells[c].font),
 				}
+				if entry.isNew and column.name == "Size" then
+					newMapSizeLabel = cell
+				end
 			end
 
 			local sortData = {
@@ -797,6 +824,86 @@ local function InitializeControls(parent)
 		objectOverrideFont = Configuration:GetFont(3),
 		OnClick = { Launch },
 	}
+
+	local sizeLabel = Label:New {
+		parent = parent,
+		right = 345,
+		bottom = 20,
+		width = 100,
+		height = 20,
+		align = "right",
+		caption = "New map size",
+		objectOverrideFont = Configuration:GetFont(2),
+	}
+
+	local widthCombo, heightCombo
+
+	local function SetNewMapSize(axis, size)
+		if axis == "x" then
+			NEW_PROJECT.sizeX = size
+		else
+			NEW_PROJECT.sizeZ = size
+		end
+		if newMapSizeLabel then
+			newMapSizeLabel:SetCaption(string.format("%dx%d", NEW_PROJECT.sizeX, NEW_PROJECT.sizeZ))
+		end
+	end
+
+	widthCombo = ComboBox:New {
+		parent = parent,
+		right = 275,
+		bottom = 15,
+		width = 65,
+		height = 30,
+		items = NEWMAP_SIZES,
+		selected = SizeToItem(NEW_PROJECT.sizeX),
+		itemHeight = 22,
+		objectOverrideFont = Configuration:GetFont(2),
+		tooltip = "Width in map units, 512 elmos each",
+		OnSelect = {
+			function (obj, itemIndex)
+				SetNewMapSize("x", NEWMAP_MIN_SIZE + (itemIndex - 1) * 2)
+			end
+		},
+	}
+
+	local byLabel = Label:New {
+		parent = parent,
+		right = 255,
+		bottom = 20,
+		width = 20,
+		height = 20,
+		align = "center",
+		caption = "x",
+		objectOverrideFont = Configuration:GetFont(2),
+	}
+
+	heightCombo = ComboBox:New {
+		parent = parent,
+		right = 185,
+		bottom = 15,
+		width = 65,
+		height = 30,
+		items = NEWMAP_SIZES,
+		selected = SizeToItem(NEW_PROJECT.sizeZ),
+		itemHeight = 22,
+		objectOverrideFont = Configuration:GetFont(2),
+		tooltip = "Height in map units, 512 elmos each",
+		OnSelect = {
+			function (obj, itemIndex)
+				SetNewMapSize("z", NEWMAP_MIN_SIZE + (itemIndex - 1) * 2)
+			end
+		},
+	}
+
+	UpdateNewMapControls = function()
+		local show = listMode == "projects" and selectedProject ~= nil and selectedProject.isNew
+		sizeLabel:SetVisibility(show)
+		widthCombo:SetVisibility(show)
+		byLabel:SetVisibility(show)
+		heightCombo:SetVisibility(show)
+	end
+	UpdateNewMapControls()
 
 	local function ApplyFilter()
 		mapList:RecalculateDisplay()

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -840,21 +840,10 @@ local function InitializeControls(parent)
 		parent = parent,
 		right = 185,
 		bottom = 8,
-		width = 260,
+		width = 154,
 		height = 45,
 		padding = {0, 0, 0, 0},
 		noFont = true,
-	}
-
-	Label:New {
-		parent = newMapSizePanel,
-		x = 0,
-		y = 12,
-		width = 100,
-		height = 20,
-		align = "right",
-		caption = "New map size",
-		objectOverrideFont = Configuration:GetFont(2),
 	}
 
 	local function RefreshNewMapSizeCell()
@@ -865,7 +854,7 @@ local function InitializeControls(parent)
 
 	ComboBox:New {
 		parent = newMapSizePanel,
-		x = 108,
+		x = 0,
 		y = 7,
 		width = 65,
 		height = 30,
@@ -873,7 +862,6 @@ local function InitializeControls(parent)
 		selected = SizeToItem(NEW_PROJECT.sizeX),
 		itemHeight = 22,
 		objectOverrideFont = Configuration:GetFont(2),
-		tooltip = "Width in map units, 512 elmos each",
 		OnSelect = {
 			function (obj, itemIndex)
 				NEW_PROJECT.sizeX = NEWMAP_MIN_SIZE + (itemIndex - 1) * 2
@@ -884,7 +872,7 @@ local function InitializeControls(parent)
 
 	Label:New {
 		parent = newMapSizePanel,
-		x = 177,
+		x = 69,
 		y = 12,
 		width = 16,
 		height = 20,
@@ -895,7 +883,7 @@ local function InitializeControls(parent)
 
 	ComboBox:New {
 		parent = newMapSizePanel,
-		x = 195,
+		x = 89,
 		y = 7,
 		width = 65,
 		height = 30,
@@ -903,7 +891,6 @@ local function InitializeControls(parent)
 		selected = SizeToItem(NEW_PROJECT.sizeZ),
 		itemHeight = 22,
 		objectOverrideFont = Configuration:GetFont(2),
-		tooltip = "Height in map units, 512 elmos each",
 		OnSelect = {
 			function (obj, itemIndex)
 				NEW_PROJECT.sizeZ = NEWMAP_MIN_SIZE + (itemIndex - 1) * 2

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -49,11 +49,23 @@ local function ListProjects()
 			end
 		end
 	end
-	table.sort(out, function(a, b)
-		return (a.name or "") < (b.name or "")
-	end)
 
 	return out
+end
+
+-- Manifests record modified as a fixed-width UTC ISO stamp, which sorts lexically. Only the
+-- display goes through the local-time conversion; the raw string stays the sort key.
+local function FormatModified(iso)
+	if not iso then
+		return "-"
+	end
+
+	local t = Spring.Utilities.UtcToLocal(iso)
+	if not t then
+		return iso
+	end
+
+	return string.format("%04d-%02d-%02d %02d:%02d", t[6], t[5], t[4], t[3], t[2])
 end
 
 -- Values the terraformer's own New Map path uses; a project load overwrites the terrain
@@ -233,15 +245,38 @@ local IMG_MISSING = LUA_DIRNAME .. "images/downloadnotready.png"
 local TINT_IDLE = {1, 1, 1, 1}
 local TINT_BUSY = {1, 0.8, 0.2, 1}
 
--- Columns whose content has a predictable width get a fixed one and are anchored to the right
--- edge; the name takes whatever is left. A name that still does not fit had no more room to be
--- given, so clipping there is the honest outcome rather than a layout choice.
-local GAP = 12
-local STATUS_WIDTH = 16
-local FACTS_WIDTH = 450
-local FACTS_RIGHT = GAP + STATUS_WIDTH + GAP
-local NAME_RIGHT = FACTS_RIGHT + FACTS_WIDTH + GAP
 local FOOTER_HEIGHT = 60
+
+-- One spec drives both the heading buttons and the row cells, the way the map browser and the
+-- download list do it. Columns are measured from the left: rows live inside a scroll panel that
+-- takes width off the RIGHT edge, and only once the list is long enough to scroll, so anything
+-- anchored that way slides out from under its heading the moment a scrollbar appears.
+local CELL_INSET = 2
+
+local MAP_COLUMNS = {
+	{name = "Name", x = 0, width = 620, align = "left"},
+	{name = "Details", x = 628, width = 620},
+	{name = "", x = 1256, width = 60, image = IMG_HAVE, imageSize = 20, tooltip = "Installed locally"},
+}
+
+local PROJECT_COLUMNS = {
+	{name = "Project", x = 0, width = 620, align = "left"},
+	{name = "Captured from", x = 628, width = 340},
+	{name = "Size", x = 976, width = 130},
+	{name = "Modified", x = 1114, width = 210},
+}
+
+local COLUMN_MODIFIED = 4
+
+-- Heading captions are centred by the button skin, so a cell only lines up with the words above
+-- it when it centres too. The name column is the exception: it reads as the row's label.
+local function CellBounds(column)
+	return {
+		x = column.x + CELL_INSET,
+		width = column.width - CELL_INSET * 2,
+		align = column.align or "center",
+	}
+end
 
 local rows = {}
 local projectRows = {}
@@ -249,6 +284,9 @@ local startButton
 local filterText = ""
 local mapList
 local SetSelectedForward
+-- LuaMenu survives Spring.Reload, so the panel built on first show outlives every editor
+-- session launched from it. Assigned in InitializeControls, called on the way back.
+local RefreshProjects
 
 -- One line of facts from the generated mapDetails entry. Kept deliberately small: this panel
 -- is a prototype and its own thing, not a second copy of the map browser.
@@ -394,14 +432,32 @@ local function InitializeControls(parent)
 
 	local searchBox = EditBox:New {
 		parent = parent,
+		x = 520,
 		right = 15,
-		y = 13,
-		width = 220,
-		height = 33,
+		y = 11,
+		height = 37,
 		text = "",
 		hint = "Search",
 		objectOverrideFont = Configuration:GetFont(2),
 		objectOverrideHintFont = Configuration:GetFont(11),
+	}
+
+	-- The maps list comes from a static config, so only the projects list has anything to rescan.
+	local refreshButton = Button:New {
+		parent = parent,
+		x = 382,
+		y = 7,
+		width = 120,
+		height = 45,
+		caption = i18n("refresh"),
+		classname = "option_button",
+		objectOverrideFont = Configuration:GetFont(2),
+		tooltip = "Rescan the MapProjects folder",
+		OnClick = {
+			function()
+				RefreshProjects()
+			end,
+		},
 	}
 
 	local mapHolder = Control:New {
@@ -426,19 +482,17 @@ local function InitializeControls(parent)
 		padding = {0, 0, 0, 0},
 	}
 
+	-- Both lists put their searchable text in the first two sort fields.
 	local function ItemInFilter(sortData)
-		return filterText == "" or sortData[1]:find(filterText, 1, true) ~= nil
+		return filterText == ""
+			or sortData[1]:find(filterText, 1, true) ~= nil
+			or sortData[2]:find(filterText, 1, true) ~= nil
 	end
 
-	mapList = WG.Chobby.SortableList(mapHolder, {
-		{name = "Name", x = 0, right = NAME_RIGHT},
-		{name = "Details", right = FACTS_RIGHT, width = FACTS_WIDTH},
-	}, ROW_HEIGHT, 1, true, nil, ItemInFilter)
+	mapList = WG.Chobby.SortableList(mapHolder, MAP_COLUMNS, ROW_HEIGHT, 1, true, nil, ItemInFilter)
 
-	local projectList = WG.Chobby.SortableList(projectHolder, {
-		{name = "Project", x = 0, right = NAME_RIGHT},
-		{name = "Captured from", right = GAP, width = FACTS_WIDTH},
-	}, ROW_HEIGHT, 1, true)
+	local projectList =
+		WG.Chobby.SortableList(projectHolder, PROJECT_COLUMNS, ROW_HEIGHT, COLUMN_MODIFIED, false, nil, ItemInFilter)
 
 	-- Same source the map browser uses. VFS.GetMaps is not it: the lobby knows maps through
 	-- the generated mapDetails config, which is also what carries their metadata.
@@ -482,35 +536,42 @@ local function InitializeControls(parent)
 			parent = minimap,
 		}
 
+		local nameCell = CellBounds(MAP_COLUMNS[1])
 		Label:New {
 			parent = button,
-			x = ROW_HEIGHT + 6,
+			x = nameCell.x + ROW_HEIGHT + 6,
 			y = 0,
-			right = NAME_RIGHT,
+			width = nameCell.width - ROW_HEIGHT - 6,
 			height = ROW_HEIGHT,
+			align = nameCell.align,
+			autosize = false,
 			valign = "center",
 			caption = mapName,
 			objectOverrideFont = Configuration:GetFont(3),
 		}
 
 		local facts = DescribeMap(mapName, data)
+		local factsCell = CellBounds(MAP_COLUMNS[2])
 		Label:New {
 			parent = button,
-			right = FACTS_RIGHT,
+			x = factsCell.x,
 			y = 0,
-			width = FACTS_WIDTH,
+			width = factsCell.width,
 			height = ROW_HEIGHT,
+			align = factsCell.align,
+			autosize = false,
 			valign = "center",
 			caption = facts,
 			objectOverrideFont = Configuration:GetFont(1),
 		}
 
 		-- An icon rather than the words: the browser uses these same two for exactly this.
+		local statusCell = CellBounds(MAP_COLUMNS[3])
 		local statusImage = Image:New {
 			parent = button,
-			right = GAP,
+			x = statusCell.x + math.floor((statusCell.width - 16) / 2),
 			y = math.floor((ROW_HEIGHT - 20) / 2),
-			width = STATUS_WIDTH,
+			width = 16,
 			height = 20,
 			file = VFS.HasArchive(mapName) and IMG_HAVE or IMG_MISSING,
 			tooltip = VFS.HasArchive(mapName) and "Installed" or "Not downloaded",
@@ -521,55 +582,63 @@ local function InitializeControls(parent)
 			status = statusImage,
 			mapName = mapName,
 		}
-		mapItems[i] = {mapName, root, {mapName:lower(), facts}}
+		mapItems[i] = {mapName, root, {mapName:lower(), facts:lower()}}
 	end
 	mapList:AddItems(mapItems)
 
-	projectRows = {}
-	local projects = ListProjects()
-	local projectItems = {}
-	for i = 1, #projects do
-		local entry = projects[i]
-		local root, button = CreateRow(function()
-			SetSelectedProject(entry)
-		end, function()
-			SetSelectedProject(entry)
-			Launch()
-		end)
+	local function BuildProjectItems()
+		projectRows = {}
+		local projects = ListProjects()
+		local projectItems = {}
+		for i = 1, #projects do
+			local entry = projects[i]
+			local root, button = CreateRow(function()
+				SetSelectedProject(entry)
+			end, function()
+				SetSelectedProject(entry)
+				Launch()
+			end)
 
-		Label:New {
-			parent = button,
-			x = 12,
-			y = 0,
-			right = NAME_RIGHT,
-			height = ROW_HEIGHT,
-			valign = "center",
-			caption = entry.name,
-			objectOverrideFont = Configuration:GetFont(3),
-		}
+			local sourceMap = entry.sourceMap or "-"
+			local cells = {
+				{caption = entry.name, font = 3},
+				{caption = sourceMap, font = 1},
+				{caption = string.format("%dx%d", entry.sizeX or 0, entry.sizeZ or 0), font = 1},
+				{caption = FormatModified(entry.modified), font = 1},
+			}
+			for c = 1, #cells do
+				local bounds = CellBounds(PROJECT_COLUMNS[c])
+				Label:New {
+					parent = button,
+					x = bounds.x,
+					y = 0,
+					width = bounds.width,
+					height = ROW_HEIGHT,
+					align = bounds.align,
+					autosize = false,
+					valign = "center",
+					caption = cells[c].caption,
+					objectOverrideFont = Configuration:GetFont(cells[c].font),
+				}
+			end
 
-		local facts = string.format(
-			"%dx%d  -  %s  -  %s",
-			entry.sizeX or 0,
-			entry.sizeZ or 0,
-			tostring(entry.sourceMap),
-			tostring(entry.modified)
-		)
-		Label:New {
-			parent = button,
-			right = GAP,
-			y = 0,
-			width = FACTS_WIDTH,
-			height = ROW_HEIGHT,
-			valign = "center",
-			caption = facts,
-			objectOverrideFont = Configuration:GetFont(1),
-		}
+			projectRows[i] = {button = button, entry = entry}
+			projectItems[i] = {
+				entry.slug,
+				root,
+				{
+					entry.name:lower(),
+					sourceMap:lower(),
+					(entry.sizeX or 0) * (entry.sizeZ or 0),
+					entry.modified or "",
+				},
+			}
+		end
 
-		projectRows[i] = {button = button, entry = entry}
-		projectItems[i] = {entry.slug, root, {entry.name:lower(), facts}}
+		return projectItems
 	end
-	projectList:AddItems(projectItems)
+
+	projectList:AddItems(BuildProjectItems())
 
 	startButton = Button:New {
 		parent = parent,
@@ -583,17 +652,45 @@ local function InitializeControls(parent)
 		OnClick = { Launch },
 	}
 
+	local function ApplyFilter()
+		mapList:RecalculateDisplay()
+		projectList:RecalculateDisplay()
+	end
+
 	local function SetMode(mode)
 		listMode = mode
 		mapHolder:SetVisibility(mode == "maps")
 		projectHolder:SetVisibility(mode == "projects")
-		searchBox:SetVisibility(mode == "maps")
+		refreshButton:SetVisibility(mode == "projects")
 		Highlight(mapsTab, mode == "maps")
 		Highlight(projectsTab, mode == "projects")
 		if mode == "maps" then
 			SetSelectedForward(selectedMap)
 		else
 			SetSelectedProject(selectedProject)
+		end
+	end
+
+	-- Rows carry the manifest table they were built from, and selection is identity on that
+	-- table, so the pick has to be re-resolved by slug against the rebuilt rows.
+	RefreshProjects = function()
+		local selectedSlug = selectedProject and selectedProject.slug
+
+		projectList:Clear()
+		projectList:AddItems(BuildProjectItems())
+
+		local restored
+		for i = 1, #projectRows do
+			if projectRows[i].entry.slug == selectedSlug then
+				restored = projectRows[i].entry
+				break
+			end
+		end
+
+		if listMode == "projects" then
+			SetSelectedProject(restored)
+		else
+			selectedProject = restored
 		end
 	end
 
@@ -637,7 +734,7 @@ local function InitializeControls(parent)
 	searchBox.OnKeyPress = searchBox.OnKeyPress or {}
 	searchBox.OnKeyPress[#searchBox.OnKeyPress + 1] = function(obj)
 		filterText = (obj.text or ""):lower()
-		mapList:RecalculateDisplay()
+		ApplyFilter()
 	end
 end
 
@@ -699,6 +796,12 @@ local function OnDownloadFailed(_, _, _, thingName)
 		downloading[thingName] = nil
 		RefreshRowStatus(thingName)
 		Spring.Echo("[Map Editor] Download failed: " .. tostring(thingName))
+	end
+end
+
+function widget:ActivateMenu()
+	if RefreshProjects then
+		RefreshProjects()
 	end
 end
 

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -354,6 +354,10 @@ local TINT_BUSY = {1, 0.8, 0.2, 1}
 
 local FOOTER_HEIGHT = 60
 
+-- Project rows have no thumbnail to sit behind, so the text needs the inset the heading
+-- buttons get from their own skin padding.
+local CELL_INSET = 10
+
 -- The scroll panel takes width off the right edge once the list scrolls, so right-anchored cells
 -- drift out from under their heading.
 local MAP_COLUMNS = {
@@ -367,7 +371,7 @@ local MAP_COLUMNS = {
 }
 
 local PROJECT_COLUMNS = {
-	{name = "Project", x = "0%", right = "58%", align = "left"},
+	{name = "Project", x = "0%", cellX = CELL_INSET, right = "58%", align = "left"},
 	{name = "Captured from", x = "42.5%", right = "34%"},
 	{name = "Size", x = "66.5%", right = "24%"},
 	{name = "Modified", x = "76.5%", right = "0%"},
@@ -747,7 +751,7 @@ local function InitializeControls(parent)
 				local column = PROJECT_COLUMNS[c]
 				Label:New {
 					parent = button,
-					x = column.x,
+					x = column.cellX or column.x,
 					y = 0,
 					right = column.right,
 					height = ROW_HEIGHT,

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -17,10 +17,11 @@ local selectedProject
 local listMode = "maps" -- "maps" | "projects"
 -- Matches #LOAD_PHASES in cmd_map_project.lua; the pointer carries it for progress reporting.
 local PROJECT_LOAD_PHASES = 11
--- Declared up here because Launch, below, reports download state and both of these are
+-- Declared up here because Launch, below, reports download and launch state, and all three are
 -- defined further down with the row rendering.
 local downloading = {}
 local RefreshRowStatus
+local startButton
 
 
 -- Projects live in the write dir as MapProjects/<slug>/project.lua, a plain Lua table. The
@@ -44,6 +45,8 @@ local function ListProjects()
 					sizeZ = manifest.map.size_z,
 					baseHeight = manifest.map.base_height,
 					baseColor = manifest.map.base_color,
+					dnts = manifest.map.dnts,
+					skybox = manifest.map.skybox,
 					modified = manifest.modified,
 				}
 			end
@@ -95,6 +98,65 @@ local function WritePendingProject(entry)
 	return true
 end
 
+-- A blank canvas ships no SSMF splat textures, so the detail normals the project was captured
+-- with have to be handed to the generator or the terrain loads as flat diffuse. The project
+-- carries its own copies under assets/, which is why these resolve against the project rather
+-- than the shared library.
+local function BuildSplatKeys(entry)
+	local dnts = entry.dnts
+	if type(dnts) ~= "table" then
+		return {}
+	end
+
+	local prefix = "MapProjects/" .. entry.slug .. "/"
+	local textures = type(dnts.textures) == "table" and dnts.textures or {}
+	local scales = dnts.scales or {}
+	local mults = dnts.mults or {}
+
+	local keys = {}
+	for ch = 1, 4 do
+		local texture = textures[ch]
+		if type(texture) == "string" and texture ~= "" then
+			keys[#keys + 1] = "blank_map_splatdetailnormaltex" .. ch .. "=" .. prefix .. texture .. ";"
+			keys[#keys + 1] = "blank_map_splattexscale" .. ch .. "=" .. (scales[ch] or 0.01) .. ";"
+			keys[#keys + 1] = "blank_map_splattexmult" .. ch .. "=" .. (mults[ch] or 1.0) .. ";"
+		end
+	end
+
+	-- Older SMFReadMap paths only switch splats on when a detail texture is present, even where
+	-- the normals are the real source, so channel 1 stands in when the project captured none.
+	local detail = dnts.detail or textures[1]
+	if type(detail) == "string" and detail ~= "" then
+		keys[#keys + 1] = "blank_map_splatdetailtex=" .. prefix .. detail .. ";"
+	end
+
+	if #keys > 0 then
+		local diffuseAlpha = (tonumber(dnts.diffuse_alpha) == 1) and 1 or 0
+		keys[#keys + 1] = "blank_map_splatdetailnormaldiffusealpha=" .. diffuseAlpha .. ";"
+	end
+
+	return keys
+end
+
+-- Manifests record only the skybox's file name, so it has to be found in the library again.
+local function FindSkybox(name)
+	if type(name) ~= "string" or name == "" then
+		return nil
+	end
+
+	local files = VFS.DirList("Terraform Brush/SkyBoxes/", "*.dds", VFS.RAW_FIRST) or {}
+	for i = 1, #files do
+		local file = files[i]:gsub("\\", "/")
+		if file:match("([^/]+)$") == name then
+			return file
+		end
+	end
+
+	Spring.Echo("[Map Editor] Project skybox '" .. name .. "' is not in the library; launching without one.")
+
+	return nil
+end
+
 -- Game-scope keys and the [mapoptions] block the engine needs to synthesise a blank map.
 -- The name keeps the "Editor Flat WxH" prefix the terraformer's own matchers look for, and
 -- carries a timestamp because reusing a generated map name can resolve to a stale archive
@@ -102,19 +164,37 @@ end
 local function BuildBlankMapKeys(entry, seed)
 	local color = entry.baseColor or NEWMAP_COLOR
 
+	local options = {
+		"blank_map_x=" .. entry.sizeX .. ";",
+		"blank_map_y=" .. entry.sizeZ .. ";",
+		"blank_map_height=" .. (tonumber(entry.baseHeight) or NEWMAP_BASE_HEIGHT) .. ";",
+		"blank_map_color_r=" .. color[1] .. ";",
+		"blank_map_color_g=" .. color[2] .. ";",
+		"blank_map_color_b=" .. color[3] .. ";",
+	}
+
+	local skybox = FindSkybox(entry.skybox)
+	if skybox then
+		options[#options + 1] = "blank_map_skybox=" .. skybox .. ";"
+	end
+
+	local splat = BuildSplatKeys(entry)
+	for i = 1, #splat do
+		options[#options + 1] = splat[i]
+	end
+
+	for i = 1, #options do
+		options[i] = "\t\t" .. options[i]
+	end
+
 	return table.concat({
-		"	InitBlank=1;",
-		"	MapSeed=" .. seed .. ";",
+		"\tInitBlank=1;",
+		"\tMapSeed=" .. seed .. ";",
 		"",
-		"	[mapoptions]",
-		"	{",
-		"		blank_map_x=" .. entry.sizeX .. ";",
-		"		blank_map_y=" .. entry.sizeZ .. ";",
-		"		blank_map_height=" .. (tonumber(entry.baseHeight) or NEWMAP_BASE_HEIGHT) .. ";",
-		"		blank_map_color_r=" .. color[1] .. ";",
-		"		blank_map_color_g=" .. color[2] .. ";",
-		"		blank_map_color_b=" .. color[3] .. ";",
-		"	}",
+		"\t[mapoptions]",
+		"\t{",
+		table.concat(options, "\n"),
+		"\t}",
 	}, "\n")
 end
 
@@ -216,6 +296,11 @@ local function Launch()
 		return
 	end
 
+	if startButton then
+		startButton:SetEnabled(false)
+		startButton:SetCaption("Starting")
+	end
+
 	-- The same two paths skirmish takes: hand the script to the wrapper where that is how this
 	-- install starts games, otherwise reload this engine onto it.
 	if
@@ -253,10 +338,15 @@ local FOOTER_HEIGHT = 60
 -- anchored that way slides out from under its heading the moment a scrollbar appears.
 local CELL_INSET = 2
 
+-- The installed icon is the one column that keeps to the right edge: it belongs against the
+-- panel border rather than at the end of the text, and an icon shows no drift the way a line
+-- of text under a centred heading would.
+local STATUS_WIDTH = 60
+
 local MAP_COLUMNS = {
 	{name = "Name", x = 0, width = 620, align = "left"},
-	{name = "Details", x = 628, width = 620},
-	{name = "", x = 1256, width = 60, image = IMG_HAVE, imageSize = 20, tooltip = "Installed locally"},
+	{name = "Details", x = 628, right = STATUS_WIDTH + 12, align = "left"},
+	{name = "", right = 5, width = STATUS_WIDTH, image = IMG_HAVE, imageSize = 20, tooltip = "Installed locally"},
 }
 
 local PROJECT_COLUMNS = {
@@ -272,15 +362,15 @@ local COLUMN_MODIFIED = 4
 -- it when it centres too. The name column is the exception: it reads as the row's label.
 local function CellBounds(column)
 	return {
-		x = column.x + CELL_INSET,
-		width = column.width - CELL_INSET * 2,
+		x = column.x and (column.x + CELL_INSET) or nil,
+		width = column.width and (column.width - CELL_INSET * 2) or nil,
+		right = column.right and (column.right + CELL_INSET) or nil,
 		align = column.align or "center",
 	}
 end
 
 local rows = {}
 local projectRows = {}
-local startButton
 local filterText = ""
 local mapList
 local SetSelectedForward
@@ -556,7 +646,7 @@ local function InitializeControls(parent)
 			parent = button,
 			x = factsCell.x,
 			y = 0,
-			width = factsCell.width,
+			right = factsCell.right,
 			height = ROW_HEIGHT,
 			align = factsCell.align,
 			autosize = false,
@@ -569,7 +659,7 @@ local function InitializeControls(parent)
 		local statusCell = CellBounds(MAP_COLUMNS[3])
 		local statusImage = Image:New {
 			parent = button,
-			x = statusCell.x + math.floor((statusCell.width - 16) / 2),
+			right = statusCell.right + math.floor((statusCell.width - 16) / 2),
 			y = math.floor((ROW_HEIGHT - 20) / 2),
 			width = 16,
 			height = 20,
@@ -679,19 +769,15 @@ local function InitializeControls(parent)
 		projectList:Clear()
 		projectList:AddItems(BuildProjectItems())
 
-		local restored
+		selectedProject = nil
 		for i = 1, #projectRows do
 			if projectRows[i].entry.slug == selectedSlug then
-				restored = projectRows[i].entry
+				selectedProject = projectRows[i].entry
 				break
 			end
 		end
 
-		if listMode == "projects" then
-			SetSelectedProject(restored)
-		else
-			selectedProject = restored
-		end
+		SetMode(listMode)
 	end
 
 	mapsTab = Button:New {

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -332,42 +332,32 @@ local TINT_BUSY = {1, 0.8, 0.2, 1}
 
 local FOOTER_HEIGHT = 60
 
--- One spec drives both the heading buttons and the row cells, the way the map browser and the
--- download list do it. Columns are measured from the left: rows live inside a scroll panel that
--- takes width off the RIGHT edge, and only once the list is long enough to scroll, so anything
--- anchored that way slides out from under its heading the moment a scrollbar appears.
-local CELL_INSET = 2
-
--- The installed icon is the one column that keeps to the right edge: it belongs against the
--- panel border rather than at the end of the text, and an icon shows no drift the way a line
--- of text under a centred heading would.
-local STATUS_WIDTH = 60
-
+-- One spec drives both the heading buttons and the row cells, so a cell can never sit anywhere
+-- but under its own heading. Edges are percentages because the panel is as wide as the lobby
+-- window: fixed pixel columns would leave the table bunched on the left of a big screen. The
+-- gaps between the percentages are what stops adjacent heading buttons touching.
+--
+-- Heading captions are centred by the button skin, so cells centre too; the leading name column
+-- is the exception, since it reads as the row's label rather than as a value.
 local MAP_COLUMNS = {
-	{name = "Name", x = 0, width = 620, align = "left"},
-	{name = "Details", x = 628, right = STATUS_WIDTH + 12, align = "left"},
-	{name = "", right = 5, width = STATUS_WIDTH, image = IMG_HAVE, imageSize = 20, tooltip = "Installed locally"},
+	{name = "Name", x = "0%", right = "70%", align = "left"},
+	{name = "Size", x = "30.5%", right = "61%"},
+	{name = "Players", x = "39.5%", right = "54%", tooltip = "Ideal player count in total"},
+	{name = "Teams", x = "46.5%", right = "47%"},
+	{name = "Type", x = "53.5%", right = "34%"},
+	{name = "Terrain", x = "66.5%", right = "11%"},
+	{name = "Status", x = "89.5%", right = "0%", tooltip = "Whether the map archive is installed locally"},
 }
 
 local PROJECT_COLUMNS = {
-	{name = "Project", x = 0, width = 620, align = "left"},
-	{name = "Captured from", x = 628, width = 340},
-	{name = "Size", x = 976, width = 130},
-	{name = "Modified", x = 1114, width = 210},
+	{name = "Project", x = "0%", right = "58%", align = "left"},
+	{name = "Captured from", x = "42.5%", right = "34%"},
+	{name = "Size", x = "66.5%", right = "24%"},
+	{name = "Modified", x = "76.5%", right = "0%"},
 }
 
 local COLUMN_MODIFIED = 4
-
--- Heading captions are centred by the button skin, so a cell only lines up with the words above
--- it when it centres too. The name column is the exception: it reads as the row's label.
-local function CellBounds(column)
-	return {
-		x = column.x and (column.x + CELL_INSET) or nil,
-		width = column.width and (column.width - CELL_INSET * 2) or nil,
-		right = column.right and (column.right + CELL_INSET) or nil,
-		align = column.align or "center",
-	}
-end
+local COLUMN_STATUS = #MAP_COLUMNS
 
 local rows = {}
 local projectRows = {}
@@ -378,23 +368,15 @@ local SetSelectedForward
 -- session launched from it. Assigned in InitializeControls, called on the way back.
 local RefreshProjects
 
--- One line of facts from the generated mapDetails entry. Kept deliberately small: this panel
--- is a prototype and its own thing, not a second copy of the map browser.
-local function DescribeMap(mapName, data)
-	if not data then
-		return "unknown"
-	end
+-- One entry per column between Name and Status, in that order. Sort values are kept apart from
+-- the captions so the counts order by magnitude rather than by how they read.
+local function DescribeMap(data)
+	data = data or {}
 
-	local parts = {}
-	if data.Width and data.Height then
-		parts[#parts + 1] = data.Width .. "x" .. data.Height
-	end
-	if data.PlayerCount then
-		parts[#parts + 1] = data.PlayerCount .. "p"
-	end
-	if data.TeamCount then
-		parts[#parts + 1] = data.TeamCount .. " teams"
-	end
+	local width = tonumber(data.Width)
+	local height = tonumber(data.Height)
+	local players = tonumber(data.PlayerCount)
+	local teams = tonumber(data.TeamCount)
 
 	local kinds = {}
 	if data.Is1v1 then
@@ -405,9 +387,6 @@ local function DescribeMap(mapName, data)
 	end
 	if data.IsFFA then
 		kinds[#kinds + 1] = "FFA"
-	end
-	if #kinds > 0 then
-		parts[#parts + 1] = table.concat(kinds, "/")
 	end
 
 	local terrain = {}
@@ -423,11 +402,26 @@ local function DescribeMap(mapName, data)
 	if data.Special then
 		terrain[#terrain + 1] = data.Special
 	end
-	if #terrain > 0 then
-		parts[#parts + 1] = table.concat(terrain, " ")
+
+	local kindText = table.concat(kinds, "/")
+	local terrainText = table.concat(terrain, " ")
+
+	return {
+		{caption = (width and height) and (width .. "x" .. height) or "-", sort = (width or 0) * (height or 0)},
+		{caption = players and tostring(players) or "-", sort = players or 0},
+		{caption = teams and tostring(teams) or "-", sort = teams or 0},
+		{caption = kindText ~= "" and kindText or "-", sort = kindText:lower()},
+		{caption = terrainText ~= "" and terrainText or "-", sort = terrainText:lower()},
+	}
+end
+
+-- Sorted as text so the Status heading orders installed maps first, then in-flight, then the rest.
+local function StatusSortKey(mapName)
+	if VFS.HasArchive(mapName) then
+		return "1 installed"
 	end
 
-	return table.concat(parts, "  -  ")
+	return downloading[mapName] and "2 downloading" or "3 not downloaded"
 end
 
 local function Highlight(button, chosen)
@@ -522,8 +516,8 @@ local function InitializeControls(parent)
 
 	local searchBox = EditBox:New {
 		parent = parent,
-		x = 520,
-		right = 15,
+		x = 400,
+		right = 147,
 		y = 11,
 		height = 37,
 		text = "",
@@ -535,7 +529,7 @@ local function InitializeControls(parent)
 	-- The maps list comes from a static config, so only the projects list has anything to rescan.
 	local refreshButton = Button:New {
 		parent = parent,
-		x = 382,
+		right = 15,
 		y = 7,
 		width = 120,
 		height = 45,
@@ -572,11 +566,10 @@ local function InitializeControls(parent)
 		padding = {0, 0, 0, 0},
 	}
 
-	-- Both lists put their searchable text in the first two sort fields.
+	-- Sort fields hold whatever each column orders by, counts included, so the text to match a
+	-- query against rides alongside them under its own key.
 	local function ItemInFilter(sortData)
-		return filterText == ""
-			or sortData[1]:find(filterText, 1, true) ~= nil
-			or sortData[2]:find(filterText, 1, true) ~= nil
+		return filterText == "" or (sortData.search or ""):find(filterText, 1, true) ~= nil
 	end
 
 	mapList = WG.Chobby.SortableList(mapHolder, MAP_COLUMNS, ROW_HEIGHT, 1, true, nil, ItemInFilter)
@@ -626,53 +619,64 @@ local function InitializeControls(parent)
 			parent = minimap,
 		}
 
-		local nameCell = CellBounds(MAP_COLUMNS[1])
 		Label:New {
 			parent = button,
-			x = nameCell.x + ROW_HEIGHT + 6,
+			x = ROW_HEIGHT + 6,
 			y = 0,
-			width = nameCell.width - ROW_HEIGHT - 6,
+			right = MAP_COLUMNS[1].right,
 			height = ROW_HEIGHT,
-			align = nameCell.align,
+			align = MAP_COLUMNS[1].align,
 			autosize = false,
 			valign = "center",
 			caption = mapName,
 			objectOverrideFont = Configuration:GetFont(3),
 		}
 
-		local facts = DescribeMap(mapName, data)
-		local factsCell = CellBounds(MAP_COLUMNS[2])
-		Label:New {
-			parent = button,
-			x = factsCell.x,
-			y = 0,
-			right = factsCell.right,
-			height = ROW_HEIGHT,
-			align = factsCell.align,
-			autosize = false,
-			valign = "center",
-			caption = facts,
-			objectOverrideFont = Configuration:GetFont(1),
-		}
+		local sortData = {mapName:lower()}
+		local searchable = {mapName:lower()}
+
+		local facts = DescribeMap(data)
+		for f = 1, #facts do
+			local column = MAP_COLUMNS[f + 1]
+			Label:New {
+				parent = button,
+				x = column.x,
+				y = 0,
+				right = column.right,
+				height = ROW_HEIGHT,
+				align = column.align or "center",
+				autosize = false,
+				valign = "center",
+				caption = facts[f].caption,
+				objectOverrideFont = Configuration:GetFont(1),
+			}
+			sortData[f + 1] = facts[f].sort
+			searchable[#searchable + 1] = facts[f].caption:lower()
+		end
 
 		-- An icon rather than the words: the browser uses these same two for exactly this.
-		local statusCell = CellBounds(MAP_COLUMNS[3])
+		-- keepAspect is what centres it in the column, since the image spans the whole cell.
+		local statusColumn = MAP_COLUMNS[COLUMN_STATUS]
 		local statusImage = Image:New {
 			parent = button,
-			right = statusCell.right + math.floor((statusCell.width - 16) / 2),
+			x = statusColumn.x,
 			y = math.floor((ROW_HEIGHT - 20) / 2),
-			width = 16,
+			right = statusColumn.right,
 			height = 20,
+			keepAspect = true,
 			file = VFS.HasArchive(mapName) and IMG_HAVE or IMG_MISSING,
 			tooltip = VFS.HasArchive(mapName) and "Installed" or "Not downloaded",
 		}
 
+		sortData[COLUMN_STATUS] = StatusSortKey(mapName)
+		sortData.search = table.concat(searchable, " ")
 		rows[i] = {
 			button = button,
 			status = statusImage,
 			mapName = mapName,
+			sortData = sortData,
 		}
-		mapItems[i] = {mapName, root, {mapName:lower(), facts:lower()}}
+		mapItems[i] = {mapName, root, sortData}
 	end
 	mapList:AddItems(mapItems)
 
@@ -697,14 +701,14 @@ local function InitializeControls(parent)
 				{caption = FormatModified(entry.modified), font = 1},
 			}
 			for c = 1, #cells do
-				local bounds = CellBounds(PROJECT_COLUMNS[c])
+				local column = PROJECT_COLUMNS[c]
 				Label:New {
 					parent = button,
-					x = bounds.x,
+					x = column.x,
 					y = 0,
-					width = bounds.width,
+					right = column.right,
 					height = ROW_HEIGHT,
-					align = bounds.align,
+					align = column.align or "center",
 					autosize = false,
 					valign = "center",
 					caption = cells[c].caption,
@@ -712,17 +716,16 @@ local function InitializeControls(parent)
 				}
 			end
 
-			projectRows[i] = {button = button, entry = entry}
-			projectItems[i] = {
-				entry.slug,
-				root,
-				{
-					entry.name:lower(),
-					sourceMap:lower(),
-					(entry.sizeX or 0) * (entry.sizeZ or 0),
-					entry.modified or "",
-				},
+			local sortData = {
+				entry.name:lower(),
+				sourceMap:lower(),
+				(entry.sizeX or 0) * (entry.sizeZ or 0),
+				entry.modified or "",
 			}
+			sortData.search = entry.name:lower() .. " " .. sourceMap:lower()
+
+			projectRows[i] = {button = button, entry = entry}
+			projectItems[i] = {entry.slug, root, sortData}
 		end
 
 		return projectItems
@@ -856,6 +859,9 @@ RefreshRowStatus = function(mapName)
 				or (have and "Installed")
 				or "Not downloaded"
 			row.status:Invalidate()
+
+			row.sortData[COLUMN_STATUS] = StatusSortKey(mapName)
+			mapList:UpdateItemSorting(mapName, row.sortData)
 		end
 	end
 	if mapName == selectedMap then

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -345,6 +345,9 @@ local function Launch()
 		startButton:SetEnabled(false)
 		startButton:SetCaption("Running")
 	end
+	if UpdateNewMapControls then
+		UpdateNewMapControls()
+	end
 
 	-- The same two paths skirmish takes.
 	if
@@ -899,9 +902,12 @@ local function InitializeControls(parent)
 		},
 	}
 
+	-- Hidden rather than disabled while the editor runs: chili only dims a disabled control,
+	-- it still opens the dropdown and takes the click.
 	UpdateNewMapControls = function()
 		newMapSizePanel:SetVisibility(
-			(listMode == "projects" and selectedProject ~= nil and selectedProject.isNew) or false
+			(not launching and listMode == "projects" and selectedProject ~= nil and selectedProject.isNew)
+				or false
 		)
 	end
 	UpdateNewMapControls()

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -24,20 +24,25 @@ local startButton
 local launching = false
 
 
+local PROJECTS_DIR = "MapProjects/"
+
+-- Recursive: the terraformer files projects into folders, and the slug carries the path
+-- under MapProjects/ because that is what the pointer and the DNTS paths are built from.
 local function ListProjects()
 	local out = {}
-	local dirs = VFS.SubDirs("MapProjects/", "*", VFS.RAW) or {}
+	local dirs = VFS.SubDirs(PROJECTS_DIR, "*", VFS.RAW, true) or {}
 	for i = 1, #dirs do
-		local dir = dirs[i]
+		local dir = dirs[i]:gsub("\\", "/"):gsub("/*$", "") .. "/"
 		local raw = VFS.LoadFile(dir .. "project.lua", VFS.RAW)
 		if raw then
 			local chunk = loadstring(raw)
 			local ok, manifest = pcall(chunk)
 			if ok and type(manifest) == "table" and manifest.map then
-				local slug = dir:match("([^/\\]+)[/\\]*$")
+				local slug = dir:gsub("^" .. PROJECTS_DIR, ""):gsub("/$", "")
 				out[#out + 1] = {
 					slug = slug,
-					name = manifest.name or slug,
+					folder = slug:match("^(.*)/[^/]+$"),
+					name = manifest.name or slug:match("([^/]+)$") or slug,
 					sourceMap = manifest.map.source_map,
 					sizeX = manifest.map.size_x,
 					sizeZ = manifest.map.size_z,
@@ -104,7 +109,7 @@ local function WritePendingProject(entry)
 	end
 	file:write(string.format(
 		"return { path = %q, size_x = %d, size_z = %d, phase = 0, phases = %d }",
-		"MapProjects/" .. entry.slug .. "/",
+		PROJECTS_DIR .. entry.slug .. "/",
 		entry.sizeX,
 		entry.sizeZ,
 		PROJECT_LOAD_PHASES
@@ -138,7 +143,7 @@ local function BuildSplatKeys(entry)
 		return {}
 	end
 
-	local prefix = "MapProjects/" .. entry.slug .. "/"
+	local prefix = PROJECTS_DIR .. entry.slug .. "/"
 	local textures = type(dnts.textures) == "table" and dnts.textures or {}
 	local scales = dnts.scales or {}
 	local mults = dnts.mults or {}
@@ -765,8 +770,9 @@ local function InitializeControls(parent)
 			end)
 
 			local sourceMap = entry.sourceMap or "-"
+			local label = entry.folder and (entry.folder .. "/" .. entry.name) or entry.name
 			local cells = {
-				{caption = entry.name, font = 3},
+				{caption = label, font = 3},
 				{caption = entry.isNew and "Blank canvas" or sourceMap, font = 1},
 				{caption = string.format("%dx%d", entry.sizeX or 0, entry.sizeZ or 0), font = 1},
 				{caption = FormatModified(entry.modified), font = 1},
@@ -791,12 +797,12 @@ local function InitializeControls(parent)
 			end
 
 			local sortData = {
-				entry.name:lower(),
+				label:lower(),
 				sourceMap:lower(),
 				(entry.sizeX or 0) * (entry.sizeZ or 0),
 				entry.modified or "",
 			}
-			sortData.search = entry.name:lower() .. " " .. sourceMap:lower()
+			sortData.search = label:lower() .. " " .. sourceMap:lower()
 			-- Starting fresh is always an option, so it outranks both sort directions and the
 			-- search box rather than being something you have to find.
 			if entry.isNew then

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -26,13 +26,13 @@ local launching = false
 
 local PROJECTS_DIR = "MapProjects/"
 
--- Recursive: the terraformer files projects into folders, and the slug carries the path
--- under MapProjects/ because that is what the pointer and the DNTS paths are built from.
+-- Walks into folders, since the terraformer files projects under them, and the slug carries
+-- the path because that is what the pointer and the DNTS paths are built from.
 local function ListProjects()
 	local out = {}
-	local dirs = VFS.SubDirs(PROJECTS_DIR, "*", VFS.RAW, true) or {}
-	for i = 1, #dirs do
-		local dir = dirs[i]:gsub("\\", "/"):gsub("/*$", "") .. "/"
+	local pending = {PROJECTS_DIR}
+	while #pending > 0 do
+		local dir = table.remove(pending)
 		local raw = VFS.LoadFile(dir .. "project.lua", VFS.RAW)
 		if raw then
 			local chunk = loadstring(raw)
@@ -52,6 +52,11 @@ local function ListProjects()
 					skybox = manifest.map.skybox,
 					modified = manifest.modified,
 				}
+			end
+		else
+			local subs = VFS.SubDirs(dir, "*", VFS.RAW) or {}
+			for i = 1, #subs do
+				pending[#pending + 1] = subs[i]:gsub("\\", "/"):gsub("/*$", "") .. "/"
 			end
 		end
 	end
@@ -831,9 +836,6 @@ local function InitializeControls(parent)
 		OnClick = { Launch },
 	}
 
-	-- One container rather than four loose siblings: chili restores a hidden child by
-	-- looking for the neighbour it recorded, and hiding a whole run of them at once leaves
-	-- each one hunting for a neighbour that is also hidden.
 	local newMapSizePanel = Control:New {
 		parent = parent,
 		right = 185,
@@ -855,13 +857,7 @@ local function InitializeControls(parent)
 		objectOverrideFont = Configuration:GetFont(2),
 	}
 
-	local function SetNewMapSize(axis, size)
-		if axis == "x" then
-			NEW_PROJECT.sizeX = size
-		else
-			NEW_PROJECT.sizeZ = size
-		end
-
+	local function RefreshNewMapSizeCell()
 		if newMapSizeLabel then
 			newMapSizeLabel:SetCaption(string.format("%dx%d", NEW_PROJECT.sizeX, NEW_PROJECT.sizeZ))
 		end
@@ -880,7 +876,8 @@ local function InitializeControls(parent)
 		tooltip = "Width in map units, 512 elmos each",
 		OnSelect = {
 			function (obj, itemIndex)
-				SetNewMapSize("x", NEWMAP_MIN_SIZE + (itemIndex - 1) * 2)
+				NEW_PROJECT.sizeX = NEWMAP_MIN_SIZE + (itemIndex - 1) * 2
+				RefreshNewMapSizeCell()
 			end
 		},
 	}
@@ -909,7 +906,8 @@ local function InitializeControls(parent)
 		tooltip = "Height in map units, 512 elmos each",
 		OnSelect = {
 			function (obj, itemIndex)
-				SetNewMapSize("z", NEWMAP_MIN_SIZE + (itemIndex - 1) * 2)
+				NEW_PROJECT.sizeZ = NEWMAP_MIN_SIZE + (itemIndex - 1) * 2
+				RefreshNewMapSizeCell()
 			end
 		},
 	}

--- a/LuaMenu/widgets/gui_terraformer_window.lua
+++ b/LuaMenu/widgets/gui_terraformer_window.lua
@@ -825,10 +825,23 @@ local function InitializeControls(parent)
 		OnClick = { Launch },
 	}
 
-	local sizeLabel = Label:New {
+	-- One container rather than four loose siblings: chili restores a hidden child by
+	-- looking for the neighbour it recorded, and hiding a whole run of them at once leaves
+	-- each one hunting for a neighbour that is also hidden.
+	local newMapSizePanel = Control:New {
 		parent = parent,
-		right = 345,
-		bottom = 20,
+		right = 185,
+		bottom = 8,
+		width = 260,
+		height = 45,
+		padding = {0, 0, 0, 0},
+		noFont = true,
+	}
+
+	Label:New {
+		parent = newMapSizePanel,
+		x = 0,
+		y = 12,
 		width = 100,
 		height = 20,
 		align = "right",
@@ -836,23 +849,22 @@ local function InitializeControls(parent)
 		objectOverrideFont = Configuration:GetFont(2),
 	}
 
-	local widthCombo, heightCombo
-
 	local function SetNewMapSize(axis, size)
 		if axis == "x" then
 			NEW_PROJECT.sizeX = size
 		else
 			NEW_PROJECT.sizeZ = size
 		end
+
 		if newMapSizeLabel then
 			newMapSizeLabel:SetCaption(string.format("%dx%d", NEW_PROJECT.sizeX, NEW_PROJECT.sizeZ))
 		end
 	end
 
-	widthCombo = ComboBox:New {
-		parent = parent,
-		right = 275,
-		bottom = 15,
+	ComboBox:New {
+		parent = newMapSizePanel,
+		x = 108,
+		y = 7,
 		width = 65,
 		height = 30,
 		items = NEWMAP_SIZES,
@@ -867,21 +879,21 @@ local function InitializeControls(parent)
 		},
 	}
 
-	local byLabel = Label:New {
-		parent = parent,
-		right = 255,
-		bottom = 20,
-		width = 20,
+	Label:New {
+		parent = newMapSizePanel,
+		x = 177,
+		y = 12,
+		width = 16,
 		height = 20,
 		align = "center",
 		caption = "x",
 		objectOverrideFont = Configuration:GetFont(2),
 	}
 
-	heightCombo = ComboBox:New {
-		parent = parent,
-		right = 185,
-		bottom = 15,
+	ComboBox:New {
+		parent = newMapSizePanel,
+		x = 195,
+		y = 7,
 		width = 65,
 		height = 30,
 		items = NEWMAP_SIZES,
@@ -897,11 +909,9 @@ local function InitializeControls(parent)
 	}
 
 	UpdateNewMapControls = function()
-		local show = listMode == "projects" and selectedProject ~= nil and selectedProject.isNew
-		sizeLabel:SetVisibility(show)
-		widthCombo:SetVisibility(show)
-		byLabel:SetVisibility(show)
-		heightCombo:SetVisibility(show)
+		newMapSizePanel:SetVisibility(
+			(listMode == "projects" and selectedProject ~= nil and selectedProject.isNew) or false
+		)
 	end
 	UpdateNewMapControls()
 


### PR DESCRIPTION
Adds a dev-only Map Editor entry to the singleplayer menu that launches straight into a terraformer session on a chosen map or a saved project, instead of starting a normal game and setting it up by hand every time.

Depends on beyond-all-reason/Beyond-All-Reason#8886. The start script sets the `mapeditor` modoption and nothing else, so without the game-side widget reading it you land in an empty spectator session with no editor at all.

The map list is its own implementation rather than a second caller of the map browser's row builder, since this is a prototype we expect to reshape. Verified by launching both a map and a saved project from the lobby.

AI disclosure: written with assistance from Claude Code.
