### PR TITLE
Require a start box for every team

### DIFF
--- a/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
+++ b/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
@@ -175,7 +175,7 @@ local function decodeBlob(encoded)
   return parsed
 end
 
-local function decodeStartboxesSet(encoded)
+local function parseStartboxesSet(encoded)
   local parsed = decodeBlob(encoded)
   if not parsed then return nil end
   -- parsed is keyed by team count; flatten to the array the selector expects.
@@ -190,7 +190,7 @@ local function getStartboxesSet(mapName)
   local cached = startboxesSetByMap[mapName]
   if cached ~= nil then return cached or nil end
   local entry = mapDetails[mapName]
-  local arrangements = entry and entry.StartboxesSet and decodeStartboxesSet(entry.StartboxesSet)
+  local arrangements = entry and entry.StartboxesSet and parseStartboxesSet(entry.StartboxesSet)
   if entry and entry.StartboxesSet and not arrangements then
     Spring.Log("mapStartBoxes", LOG.WARNING, "Could not decode StartboxesSet for", mapName)
   end
@@ -287,22 +287,25 @@ end
 
 -- MP twin of loadPolygonStartboxes: same selection and build, but fed by the
 -- server-set mapmetadata_startboxes_set modoption instead of local mapDetails.
-local function loadPolygonStartboxesFromBlob(encoded, allyTeamCount)
+-- Rect-only arrangements come back too: the game resolves this modoption ahead of
+-- the engine startrects, so the lobby has to draw the arrangement either way.
+local function decodeStartboxesSet(encoded, allyTeamCount)
   if not encoded or encoded == "" or encoded == "0" then return nil end
-  local startboxesSet = decodeStartboxesSet(encoded)
+  local startboxesSet = parseStartboxesSet(encoded)
   if not startboxesSet or #startboxesSet == 0 then return nil end
 
-  local ok, config = pcall(function()
+  local ok, config, hasPolygon = pcall(function()
     local arrangement = selectArrangementForAllyTeamCount(startboxesSet, allyTeamCount or 2)
-    if not arrangement or not arrangementHasPolygon(arrangement) then return nil end
-    return buildPolygonConfig(arrangement)
+    if not arrangement then return nil end
+
+    return buildPolygonConfig(arrangement), arrangementHasPolygon(arrangement)
   end)
   if not ok then
     Spring.Log("mapStartBoxes", LOG.WARNING, "Skipping malformed startboxes set modoption")
     return nil
   end
 
-  return config
+  return config, hasPolygon
 end
 
 -- Game accepts 3+ point polygons here (expandPoly), so this has to as well.
@@ -478,7 +481,7 @@ return {
   encodeStartboxesSetModoption = encodeStartboxesSetModoption,
   encodeStartboxOverrideModoption = encodeStartboxOverrideModoption,
   loadPolygonStartboxes = loadPolygonStartboxes,
-  loadPolygonStartboxesFromBlob = loadPolygonStartboxesFromBlob,
+  decodeStartboxesSet = decodeStartboxesSet,
   decodeStartboxOverride = decodeStartboxOverride,
   getBox = getBox,
   clearBoxes = clearBoxes,

--- a/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
+++ b/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
@@ -267,33 +267,13 @@ local function buildPolygonConfig(arrangement)
   return config
 end
 
-local function loadPolygonStartboxes(mapName, allyTeamCount)
-  local startboxesSet = getStartboxesSet(mapName)
-  if not startboxesSet or #startboxesSet == 0 then return nil end
-
-  -- hand-edited mapDetails can be valid JSON of the wrong shape; keep a malformed set from crashing the build
-  local ok, config = pcall(function()
-    local arrangement = selectArrangementForAllyTeamCount(startboxesSet, allyTeamCount or 2)
-    if not arrangement or not arrangementHasPolygon(arrangement) then return nil end
-    return buildPolygonConfig(arrangement)
-  end)
-  if not ok then
-    Spring.Log("mapStartBoxes", LOG.WARNING, "Skipping malformed polygon startboxes for", mapName)
-    return nil
-  end
-
-  return config
-end
-
--- MP twin of loadPolygonStartboxes: same selection and build, but fed by the
--- server-set mapmetadata_startboxes_set modoption instead of local mapDetails.
--- Rect-only arrangements come back too: the game resolves this modoption ahead of
--- the engine startrects, so the lobby has to draw the arrangement either way.
-local function decodeStartboxesSet(encoded, allyTeamCount)
-  if not encoded or encoded == "" or encoded == "0" then return nil end
-  local startboxesSet = parseStartboxesSet(encoded)
+-- Skirmish reads its set from mapDetails and multiplayer from the modoption, but the
+-- selection, the build and the shapes handed back are the same for both. Third return
+-- marks a set that was there and could not be used.
+local function resolveStartboxesSet(startboxesSet, allyTeamCount, source)
   if not startboxesSet or #startboxesSet == 0 then return nil, nil, true end
 
+  -- hand-edited mapDetails can be valid JSON of the wrong shape; keep a malformed set from crashing the build
   local ok, config, hasPolygon = pcall(function()
     local arrangement = selectArrangementForAllyTeamCount(startboxesSet, allyTeamCount or 2)
     if not arrangement then return nil end
@@ -301,11 +281,24 @@ local function decodeStartboxesSet(encoded, allyTeamCount)
     return buildPolygonConfig(arrangement), arrangementHasPolygon(arrangement)
   end)
   if not ok or not config then
-    Spring.Log("mapStartBoxes", LOG.WARNING, "Skipping malformed startboxes set modoption")
+    Spring.Log("mapStartBoxes", LOG.WARNING, "Skipping malformed startboxes set for", source)
     return nil, nil, true
   end
 
   return config, hasPolygon
+end
+
+local function loadStartboxesSet(mapName, allyTeamCount)
+  local startboxesSet = getStartboxesSet(mapName)
+  if not startboxesSet then return nil end
+
+  return resolveStartboxesSet(startboxesSet, allyTeamCount, mapName)
+end
+
+local function decodeStartboxesSet(encoded, allyTeamCount)
+  if not encoded or encoded == "" or encoded == "0" then return nil end
+
+  return resolveStartboxesSet(parseStartboxesSet(encoded), allyTeamCount, "modoption")
 end
 
 -- Game accepts 3+ point polygons here (expandPoly), so this has to as well.
@@ -413,13 +406,18 @@ end
 -- mapmetadata_startboxes_set when its box count matches the team count. Boxes
 -- are 0-200 rects (two opposite corners). '=' padding is stripped so the value
 -- matches the base64url SPADS allows for this modoption.
+-- Accepts the lobby's raw left/top/right/bottom values, the chili box windows
+-- skirmish keeps in singleplayerboxes, and the 0-200 arrays addBox stores.
 local function encodeStartboxOverrideModoption(boxes)
   if not boxes then return nil end
 
   local startboxes = {}
   local i = 1
   while boxes[i] do
-    local b = boxes[i]
+    local b = boxes[i].spadsSizes or boxes[i]
+    if b[1] then
+      b = { left = b[1], top = b[2], right = b[3], bottom = b[4] }
+    end
     startboxes[i] = { poly = {
       { x = math.floor(b.left + 0.5),  y = math.floor(b.top + 0.5) },
       { x = math.floor(b.right + 0.5), y = math.floor(b.bottom + 0.5) },
@@ -482,7 +480,7 @@ return {
   makeAllyTeamBoxFromPolygon = makeAllyTeamBoxFromPolygon,
   encodeStartboxesSetModoption = encodeStartboxesSetModoption,
   encodeStartboxOverrideModoption = encodeStartboxOverrideModoption,
-  loadPolygonStartboxes = loadPolygonStartboxes,
+  loadStartboxesSet = loadStartboxesSet,
   decodeStartboxesSet = decodeStartboxesSet,
   decodeStartboxOverride = decodeStartboxOverride,
   getBox = getBox,

--- a/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
+++ b/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
@@ -292,7 +292,7 @@ end
 local function decodeStartboxesSet(encoded, allyTeamCount)
   if not encoded or encoded == "" or encoded == "0" then return nil end
   local startboxesSet = parseStartboxesSet(encoded)
-  if not startboxesSet or #startboxesSet == 0 then return nil end
+  if not startboxesSet or #startboxesSet == 0 then return nil, nil, true end
 
   local ok, config, hasPolygon = pcall(function()
     local arrangement = selectArrangementForAllyTeamCount(startboxesSet, allyTeamCount or 2)
@@ -300,28 +300,30 @@ local function decodeStartboxesSet(encoded, allyTeamCount)
 
     return buildPolygonConfig(arrangement), arrangementHasPolygon(arrangement)
   end)
-  if not ok then
+  if not ok or not config then
     Spring.Log("mapStartBoxes", LOG.WARNING, "Skipping malformed startboxes set modoption")
-    return nil
+    return nil, nil, true
   end
 
   return config, hasPolygon
 end
 
 -- Game accepts 3+ point polygons here (expandPoly), so this has to as well.
+-- Third return marks a value that was set but unusable, so the lobby can say so
+-- rather than quietly showing the map default boxes.
 local function decodeStartboxOverride(encoded)
   if not encoded or encoded == "" or encoded == "0" then return nil end
   local parsed = decodeBlob(encoded)
-  if not parsed or type(parsed.startboxes) ~= "table" then return nil end
-  if #parsed.startboxes == 0 then return nil end
+  if not parsed or type(parsed.startboxes) ~= "table" then return nil, nil, true end
+  if #parsed.startboxes == 0 then return nil, nil, true end
 
   for _, box in ipairs(parsed.startboxes) do
     local poly = type(box) == "table" and box.poly
-    if type(poly) ~= "table" or #poly < 2 then return nil end
+    if type(poly) ~= "table" or #poly < 2 then return nil, nil, true end
     for _, point in ipairs(poly) do
-      if type(point) ~= "table" then return nil end
+      if type(point) ~= "table" then return nil, nil, true end
       local x, y = tonumber(point.x), tonumber(point.y)
-      if not (x and y) then return nil end
+      if not (x and y) then return nil, nil, true end
       point.x, point.y = x, y
     end
   end
@@ -329,7 +331,7 @@ local function decodeStartboxOverride(encoded)
   local ok, config = pcall(buildPolygonConfig, parsed)
   if not ok or not config then
     Spring.Log("mapStartBoxes", LOG.WARNING, "Skipping malformed startbox override modoption")
-    return nil
+    return nil, nil, true
   end
 
   return config, arrangementHasPolygon(parsed)

--- a/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
+++ b/LuaMenu/configs/gameConfig/byar/mapStartBoxes.lua
@@ -435,42 +435,25 @@ local function encodeStartboxOverrideModoption(boxes)
   return (Spring.Utilities.Base64Encode(compressed):gsub("=+$", ""))
 end
 
--- how about some more helpers?
-local function initCustomBox(mapName)
-    singleplayerboxes = {}
-end
-
-local function addBox(left,top, right, bottom, allyTeam) --in spads order
-  initCustomBox()
-  singleplayerboxes[allyTeam] = {left,top,right,bottom}
-  -- if online then: function Interface:AddStartRect(allyNo, left, top, right, bottom)
-end
-
-local function removeBox(allyTeam)
-  initCustomBox()
-  if singleplayerboxes[allyTeam] then
+-- Emptied in place rather than reassigned: the table is handed out by reference in the
+-- return block below, so rebinding the local would leave every reader holding the old one.
+local function clearBoxes()
+  for allyTeam in pairs(singleplayerboxes) do
     singleplayerboxes[allyTeam] = nil
   end
 end
 
-local function clearBoxes()
-  initCustomBox()
-  singleplayerboxes = {}
-end
+-- The boxes a skirmish launches with are written here as a whole set when Start is
+-- pressed, keyed the same way the lobby keys its own rects.
+local function setBoxes(boxes)
+  clearBoxes()
+  if not boxes then
+    return
+  end
 
-local function getBox(allyTeam)
-  if savedBoxes[mapName] == nil then
-    initCustomBox(mapName)
+  for allyTeam, box in pairs(boxes) do
+    singleplayerboxes[allyTeam] = box
   end
-  if singleplayerboxes then
-    return singleplayerboxes[allyTeam]
-  else
-    local defaultboxes =  selectStartBoxesForAllyTeamCount(mapName,2)
-    if defaultboxes then
-      return defaultboxes[allyTeam]
-    end
-  end
-  return nil
 end
 
 return {
@@ -483,9 +466,7 @@ return {
   loadStartboxesSet = loadStartboxesSet,
   decodeStartboxesSet = decodeStartboxesSet,
   decodeStartboxOverride = decodeStartboxOverride,
-  getBox = getBox,
   clearBoxes = clearBoxes,
-  removeBox = removeBox,
-  addBox = addBox,
+  setBoxes = setBoxes,
   singleplayerboxes = singleplayerboxes,
 }

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -878,11 +878,7 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 
 					if battleLobby.name == "singleplayer" then
 						local Configuration = WG.Chobby.Configuration
-						if Configuration.gameConfig.mapStartBoxes.singleplayerboxes then
-							if currentStartRects ~= {} then
-								Configuration.gameConfig.mapStartBoxes.singleplayerboxes = currentStartRects
-							end
-						end
+						Configuration.gameConfig.mapStartBoxes.setBoxes(currentStartRects)
 						battle.startPosType = Configuration.singleplayerStartPosType ~= nil and Configuration.singleplayerStartPosType or 2
 						WG.Analytics.SendOnetimeEvent("lobby:singleplayer:skirmish:start")
 						WG.SteamCoopHandler.AttemptGameStart("skirmish", battle.gameName, battle.mapName)
@@ -1942,7 +1938,6 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 
 						obj:Invalidate() --doesnt do much
 						if battleLobby.name == "singleplayer" then
-							WG.Chobby.Configuration.gameConfig.mapStartBoxes.addBox(l,t,r,b,obj.caption)
 							obj.spadsSizes = {left = l, top = t, right = r, bottom = b, caption = obj.caption}
 						else
 							obj.spadsSizes = {left = l, top = t, right = r, bottom = b, caption = obj.caption}
@@ -2036,6 +2031,62 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		end
 	end
 
+	-- Rows across the 0-200 startbox space. The minimap is a couple of hundred pixels tall, so
+	-- one row per unit is finer than a pixel and the seams do not show.
+	local POLYGON_FILL_ROWS = 200
+
+	-- Even-odd scanline spans, the same rule the game's own inside test uses, so a box that
+	-- excludes its middle shades the same in both places. A triangle fan cannot express that:
+	-- it fills from a centre point outwards and swallows any hole.
+	local function BuildPolygonFillSpans(polygon)
+		local spans = {}
+		local n = #polygon
+		if n < 3 then
+			return spans
+		end
+
+		local minY, maxY = math.huge, -math.huge
+		for i = 1, n do
+			local y = polygon[i][2]
+			minY = math.min(minY, y)
+			maxY = math.max(maxY, y)
+		end
+
+		local step = 200 / POLYGON_FILL_ROWS
+		local crossings = {}
+		local rowTop = minY
+		while rowTop < maxY do
+			local y = rowTop + (step * 0.5)
+			local count = 0
+			for i = 1, n do
+				local a = polygon[i]
+				local b = polygon[(i % n) + 1]
+				if (a[2] > y) ~= (b[2] > y) then
+					count = count + 1
+					crossings[count] = b[1] + (y - b[2]) * (a[1] - b[1]) / (a[2] - b[2])
+				end
+			end
+
+			-- Insertion sort: a scanline crosses a handful of edges even on a busy polygon.
+			for i = 2, count do
+				local value, k = crossings[i], i - 1
+				while k > 0 and crossings[k] > value do
+					crossings[k + 1] = crossings[k]
+					k = k - 1
+				end
+				crossings[k + 1] = value
+			end
+
+			for i = 1, count - 1, 2 do
+				spans[#spans + 1] = { crossings[i], rowTop, crossings[i + 1], math.min(rowTop + step, maxY) }
+			end
+
+			rowTop = rowTop + step
+		end
+
+		return spans
+	end
+
 	-- Chosen to match the rectangular startbox_window's TileImage skin.
 	local polygonFillColor = {0.1, 0.1, 0.1, 0.7}
 	local polygonBorderColor = {1, 1, 1, 0.7}
@@ -2121,7 +2172,7 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 					end
 				end
 			else
-				-- !split v 20
+				-- 20% of the map to each team
 				externalFunctions.AddStartRect(0,0,0,40,200)
 				externalFunctions.AddStartRect(1,160,0,200,200)
 			end
@@ -2234,8 +2285,6 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 
 					for _, polygon in ipairs(entry.boxes) do
 						if #polygon >= 3 then
-							-- Centroid-fan fill; may artifact on highly concave polygons.
-							-- The outline below is always correct regardless of shape.
 							local cx, cy = 0, 0
 							for _, v in ipairs(polygon) do
 								cx = cx + (w * v[1] / 200)
@@ -2244,13 +2293,24 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 							cx = cx / #polygon
 							cy = cy / #polygon
 
+							local spans = polygon.fillSpans
+							if not spans then
+								spans = BuildPolygonFillSpans(polygon)
+								polygon.fillSpans = spans
+							end
+
 							gl.Color(polygonFillColor[1], polygonFillColor[2], polygonFillColor[3], polygonFillColor[4])
 							gl.BeginEnd(GL.TRIANGLES, function()
-								for i = 1, #polygon do
-									local j = (i % #polygon) + 1
-									gl.Vertex(cx, cy)
-									gl.Vertex(w * polygon[i][1] / 200, h * polygon[i][2] / 200)
-									gl.Vertex(w * polygon[j][1] / 200, h * polygon[j][2] / 200)
+								for i = 1, #spans do
+									local s = spans[i]
+									local x1, y1 = w * s[1] / 200, h * s[2] / 200
+									local x2, y2 = w * s[3] / 200, h * s[4] / 200
+									gl.Vertex(x1, y1)
+									gl.Vertex(x2, y1)
+									gl.Vertex(x2, y2)
+									gl.Vertex(x1, y1)
+									gl.Vertex(x2, y2)
+									gl.Vertex(x1, y2)
 								end
 							end)
 
@@ -3964,11 +4024,7 @@ local function SetupEasySetupPanel(mainWindow, standardSubPanel, setupData)
 		if startGame then
 			if haveMapAndGame then
 				local Configuration = WG.Chobby.Configuration
-					if Configuration.gameConfig.mapStartBoxes.singleplayerboxes then
-						if currentStartRects ~= {} then
-							Configuration.gameConfig.mapStartBoxes.singleplayerboxes = currentStartRects
-						end
-					end
+				Configuration.gameConfig.mapStartBoxes.setBoxes(currentStartRects)
 				WG.SteamCoopHandler.AttemptGameStart("skirmish", battle.gameName, battle.mapName, nil, true)
 			else
 				MaybeDownloadMap(battle)

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -30,8 +30,9 @@ local startRectValues = {} -- for exporting the raw values
 local spadsRectValues = {} -- SPADS-sent AABBs, tracked even while not rendered
 local polygonStartboxesActive = false
 local activePolygonConfig = nil
--- true while the boxes on screen come from a modoption arrangement. SPADS' own rects
--- are bookkeeping while it is set: the game resolves the modoption ahead of them.
+-- Multiplayer only: true while the boxes on screen come from a modoption arrangement.
+-- SPADS' own rects are bookkeeping while it is set, since the game resolves the
+-- modoption ahead of them.
 local arrangementActive = false
 -- false while a custom preset is applied; true once defaults reload.
 local defaultStartboxMode = true
@@ -1998,12 +1999,12 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		return currentStartRects
 	end
 
-	-- An arrangement only boxes in the allyteams it covers; the rest keep whatever the
-	-- engine startrect holds (resolveArrangement in the game's startbox_utilities.lua),
-	-- so they start somewhere the lobby never showed. Rooms with no arrangement are the
-	-- old startrect-only world and are left alone.
+	-- We launch with the boxes we drew, and an allyteam without one falls back to the
+	-- engine's own start box, which covers the whole map. Counted the same way for
+	-- skirmish and multiplayer, rects and polygons, sets and overrides; an empty table
+	-- means the boxes have not arrived yet rather than that a team is missing one.
 	function externalFunctions.GetStartboxShortfallMessage()
-		if not arrangementActive then
+		if next(startRectValues) == nil then
 			return nil
 		end
 
@@ -2085,11 +2086,8 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		externalFunctions.RemoveStartRect()
 		mapStartBoxes.clearBoxes()
 
-		-- Matches interface_skirmish: the encoded set modoption is only sent when the
-		-- map has polygon data, so without it the launch is startrects only.
 		local polygonConfig = mapStartBoxes.loadPolygonStartboxes
 			and mapStartBoxes.loadPolygonStartboxes(mapName, allyTeamCount)
-		arrangementActive = (polygonConfig ~= nil)
 
 		if polygonConfig then
 			externalFunctions.AddPolygonStartboxes(polygonConfig, allyTeamCount)

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -87,26 +87,14 @@ local function HasGame(gameName)
 	return VFS.HasArchive(gameName)
 end
 
-local function UpdateArchiveStatus(updateSync)
-	if not battleLobby or not battleLobby:GetMyBattleID() then
-		return
-	end
-	local battle = battleLobby:GetBattle(battleLobby:GetMyBattleID())
-	if not battle then
-		haveMapAndGame = false
-		return
-	end
-	local haveGame = HasGame(battle.gameName)
-	local haveMap = VFS.HasArchive(battle.mapName)
+local function GetStartboxShortfallMessage()
+	local infoHandler = mainWindowFunctions and mainWindowFunctions.GetInfoHandler
+		and mainWindowFunctions.GetInfoHandler()
 
+	return infoHandler and infoHandler.GetStartboxShortfallMessage and infoHandler.GetStartboxShortfallMessage()
+end
 
-	if mainWindowFunctions and mainWindowFunctions.GetInfoHandler() then
-		local infoHandler = mainWindowFunctions.GetInfoHandler()
-		infoHandler.SetHaveGame(haveGame)
-		infoHandler.SetHaveMap(haveMap)
-	end
-	haveMapAndGame = (haveGame and haveMap)
-
+local function UpdateStartButton(battle)
 	if btnStartBattle then
 		if haveMapAndGame then
 			--btnStartBattle.tooltip = "Start the game, or call a vote to start multiplayer, or join a running game"
@@ -147,7 +135,55 @@ local function UpdateArchiveStatus(updateSync)
 			end
 		end
 
+		local startboxShortfall = (not battle.isRunning) and GetStartboxShortfallMessage()
+		if haveMapAndGame and startboxShortfall then
+			btnStartBattle.tooltip = startboxShortfall
+			btnStartBattle:StyleOff()
+			btnStartBattle:SetEnabled(false)
+			btnStartBattle.suppressButtonReaction = true
+		end
 	end
+end
+
+-- Team counts and box edits both land without an event worth listening to, so the
+-- button is rechecked from the minimap tick. Only a change in the shortfall touches
+-- the button, otherwise every tick would restyle it.
+local shownStartboxShortfall
+local function RefreshStartButtonForStartboxes()
+	local shortfall = GetStartboxShortfallMessage()
+	if shortfall == shownStartboxShortfall then
+		return
+	end
+	shownStartboxShortfall = shortfall
+
+	local battleID = battleLobby and battleLobby:GetMyBattleID()
+	local battle = battleID and battleLobby:GetBattle(battleID)
+	if battle then
+		UpdateStartButton(battle)
+	end
+end
+
+local function UpdateArchiveStatus(updateSync)
+	if not battleLobby or not battleLobby:GetMyBattleID() then
+		return
+	end
+	local battle = battleLobby:GetBattle(battleLobby:GetMyBattleID())
+	if not battle then
+		haveMapAndGame = false
+		return
+	end
+	local haveGame = HasGame(battle.gameName)
+	local haveMap = VFS.HasArchive(battle.mapName)
+
+
+	if mainWindowFunctions and mainWindowFunctions.GetInfoHandler() then
+		local infoHandler = mainWindowFunctions.GetInfoHandler()
+		infoHandler.SetHaveGame(haveGame)
+		infoHandler.SetHaveMap(haveMap)
+	end
+	haveMapAndGame = (haveGame and haveMap)
+
+	UpdateStartButton(battle)
 
 	if updateSync and battleLobby then
 		battleLobby:SetBattleStatus({
@@ -366,6 +402,7 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 	spadsRectValues = {}
 
 	local externalFunctions = {}
+	local ApplySingleplayerDefaultBoxes
 
 	-- battle.nbTeams only arrives via the s.battle.teams protocol extension, so hosts
 	-- that never send it need the occupied-team count rather than an assumed two.
@@ -828,6 +865,15 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 						WG.Chobby.ConfirmationPopup(RejoinBattleFunc, "Are you sure you want to leave your current game to rejoin this one?", nil, 315, 200)
 					end
 				else
+					local startboxShortfall = externalFunctions.GetStartboxShortfallMessage()
+					if startboxShortfall then
+						if AddLocalBattleWarning then
+							AddLocalBattleWarning(startboxShortfall)
+						end
+
+						return
+					end
+
 					if battleLobby.name == "singleplayer" then
 						local Configuration = WG.Chobby.Configuration
 						if Configuration.gameConfig.mapStartBoxes.singleplayerboxes then
@@ -1702,7 +1748,6 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 			local isSingleplayer = (battleLobby.name == "singleplayer")
 			local mapName = battleInfo.mapName
 			local allyTeamCount = GetAllyTeamCount(isSingleplayer)
-			local Configuration = WG.Chobby and WG.Chobby.Configuration
 
 			-- UPDATEBATTLEINFO carries mapName on unrelated updates (spectator count,
 			-- lock) too, and only a map change re-renders, so tearing down on every
@@ -1717,51 +1762,7 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 			if isSingleplayer then
 				imMinimap.children = {}
 				if startBoxPanel then startBoxPanel:SetVisibility(true) end
-			end
-
-			-- Singleplayer reads polygon data from local mapDetails; multiplayer must
-			-- render only what the server says (modoptions), or the lobby can show
-			-- boxes the game won't use.
-			local polygonConfig = nil
-			if isSingleplayer and Configuration.gameConfig and
-					Configuration.gameConfig.useDefaultStartBoxes and
-					Configuration.gameConfig.mapStartBoxes and
-					Configuration.gameConfig.mapStartBoxes.loadPolygonStartboxes then
-				polygonConfig = Configuration.gameConfig.mapStartBoxes.loadPolygonStartboxes(mapName, allyTeamCount)
-			end
-
-			if isSingleplayer then
-				if Configuration.gameConfig and
-						Configuration.gameConfig.useDefaultStartBoxes and
-						Configuration.gameConfig.mapStartBoxes and
-						Configuration.gameConfig.mapStartBoxes.savedBoxes then
-
-					local mapStartBoxes = Configuration.gameConfig.mapStartBoxes
-					externalFunctions.RemoveStartRect()
-					mapStartBoxes.clearBoxes()
-
-					if polygonConfig then
-						externalFunctions.AddPolygonStartboxes(polygonConfig, allyTeamCount)
-					else
-						local startBoxes = Configuration.gameConfig.mapStartBoxes.savedBoxes[mapName]
-						startBoxes = Configuration.gameConfig.mapStartBoxes.selectStartBoxesForAllyTeamCount(startBoxes,allyTeamCount)
-						if startBoxes then
-							for i = 1, allyTeamCount do
-								if startBoxes[i] then
-									externalFunctions.AddStartRect(i-1,200*startBoxes[i][1],200*startBoxes[i][2],200*startBoxes[i][3],200*startBoxes[i][4])
-								end
-							end
-						else
-							-- !split v 20
-							externalFunctions.AddStartRect(0,0,0,40,200)
-							externalFunctions.AddStartRect(1,160,0,200,200)
-						end
-					end
-
-					StartBoxComboBoxSelectDefault()
-				else
-					Spring.Echo("No map startBoxes found or disabled for map",mapName,"teamcount:",allyTeamCount)
-				end
+				ApplySingleplayerDefaultBoxes(mapName, allyTeamCount)
 			elseif mapChanged then
 				-- UPDATEBATTLEINFO carries mapName on every update (spec count, lock,
 				-- ...), and refreshing each tick would tear down mid-edit boxes that
@@ -1861,7 +1862,6 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		-- it doesnt even know how big it is right nowhere
 		-- Spring.Utilities.TraceFullEcho()
 
-		-- Capture happens before the early return so script export works in either mode.
 		startRectValues[allyNo+1]={["left"]=left, ["top"]=top, ["right"]=right, ["bottom"]=bottom}
 
 		if polygonStartboxesActive then
@@ -1998,6 +1998,30 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		return currentStartRects
 	end
 
+	-- An arrangement only boxes in the allyteams it covers; the rest keep whatever the
+	-- engine startrect holds (resolveArrangement in the game's startbox_utilities.lua),
+	-- so they start somewhere the lobby never showed. Rooms with no arrangement are the
+	-- old startrect-only world and are left alone.
+	function externalFunctions.GetStartboxShortfallMessage()
+		if not arrangementActive then
+			return nil
+		end
+
+		local allyTeamCount = GetAllyTeamCount(battleLobby.name == "singleplayer")
+		local boxedTeams = 0
+		for i = 1, allyTeamCount do
+			if startRectValues[i] then
+				boxedTeams = boxedTeams + 1
+			end
+		end
+
+		if boxedTeams >= allyTeamCount then
+			return nil
+		end
+
+		return "Cannot start: only " .. boxedTeams .. " of " .. allyTeamCount .. " teams have a start box."
+	end
+
 	function externalFunctions.ApplyStartBoxes(boxes)
 		externalFunctions.RemovePolygonOverlays()
 		externalFunctions.RemoveStartRect()
@@ -2037,17 +2061,69 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		end
 	end
 
-	-- Nothing announces a team-count change: no modoption echo, no SPADS message, and
-	-- Add Team fires no lobby event at all. Hence driven off the minimap tick, gated on
-	-- the count actually changing so a rebuild never lands mid-edit.
 	local renderedAllyTeamCount
-	function externalFunctions.RefreshStartboxesOnTeamChange()
-		if battleLobby.name == "singleplayer" then
+
+	-- Singleplayer reads polygon data from local mapDetails; multiplayer must render
+	-- only what the server says (modoptions), or the lobby can show boxes the game
+	-- won't use. The team count picks the arrangement, so this runs again whenever it
+	-- moves rather than only on map change.
+	function ApplySingleplayerDefaultBoxes(mapName, allyTeamCount)
+		local Configuration = WG.Chobby and WG.Chobby.Configuration
+		renderedAllyTeamCount = allyTeamCount
+
+		if not (mapName and Configuration.gameConfig and
+				Configuration.gameConfig.useDefaultStartBoxes and
+				Configuration.gameConfig.mapStartBoxes and
+				Configuration.gameConfig.mapStartBoxes.savedBoxes) then
+			Spring.Echo("No map startBoxes found or disabled for map",mapName,"teamcount:",allyTeamCount)
+
 			return
 		end
 
-		local count = GetAllyTeamCount(false)
+		local mapStartBoxes = Configuration.gameConfig.mapStartBoxes
+		externalFunctions.RemovePolygonOverlays()
+		externalFunctions.RemoveStartRect()
+		mapStartBoxes.clearBoxes()
+
+		-- Matches interface_skirmish: the encoded set modoption is only sent when the
+		-- map has polygon data, so without it the launch is startrects only.
+		local polygonConfig = mapStartBoxes.loadPolygonStartboxes
+			and mapStartBoxes.loadPolygonStartboxes(mapName, allyTeamCount)
+		arrangementActive = (polygonConfig ~= nil)
+
+		if polygonConfig then
+			externalFunctions.AddPolygonStartboxes(polygonConfig, allyTeamCount)
+		else
+			local startBoxes = mapStartBoxes.selectStartBoxesForAllyTeamCount(mapStartBoxes.savedBoxes[mapName], allyTeamCount)
+			if startBoxes then
+				for i = 1, allyTeamCount do
+					if startBoxes[i] then
+						externalFunctions.AddStartRect(i-1,200*startBoxes[i][1],200*startBoxes[i][2],200*startBoxes[i][3],200*startBoxes[i][4])
+					end
+				end
+			else
+				-- !split v 20
+				externalFunctions.AddStartRect(0,0,0,40,200)
+				externalFunctions.AddStartRect(1,160,0,200,200)
+			end
+		end
+
+		StartBoxComboBoxSelectDefault()
+	end
+
+	-- Nothing announces a team-count change: no modoption echo, no SPADS message, and
+	-- Add Team fires no lobby event at all. Hence driven off the minimap tick, gated on
+	-- the count actually changing so a rebuild never lands mid-edit.
+	function externalFunctions.RefreshStartboxesOnTeamChange()
+		local isSingleplayer = (battleLobby.name == "singleplayer")
+		local count = GetAllyTeamCount(isSingleplayer)
 		if count == renderedAllyTeamCount then
+			return
+		end
+
+		if isSingleplayer then
+			ApplySingleplayerDefaultBoxes(startBoxMapName, count)
+
 			return
 		end
 
@@ -5331,6 +5407,7 @@ function BattleRoomWindow.UpdateMinimapstartBoxes()
 		infoHandler.rightInfo:Invalidate()
 		infoHandler.UpdateStartRectPositionsInMinimap()
 		infoHandler.rightInfo:UpdateClientArea()
+		RefreshStartButtonForStartboxes()
 	end
 
 	if WG.Delay then

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -5001,9 +5001,9 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 
 	-- SPADS keeps sending its own rects (map change, !addbox, !loadboxes) but the game
 	-- resolves the modoption arrangement ahead of them, so they only reach the minimap
-	-- when no arrangement claims the boxes and the player isn't mid-edit.
+	-- when neither an arrangement nor a custom override claims the boxes.
 	local function SpadsRectsRendered()
-		return battleLobby.name == "singleplayer" or (not arrangementActive and defaultStartboxMode)
+		return not arrangementActive and defaultStartboxMode
 	end
 
 	local function OnRemoveStartRect(listener, allyNo)

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -2174,10 +2174,10 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 
 		if overrideConfig then
 			arrangementActive = true
-			-- Spare boxes past the team count keep rendering: the game accepts an
-			-- override with more boxes than teams, and dropping them mid-edit would
-			-- look like the box the player just added never took.
-			RenderArrangement(overrideConfig, overrideHasPolygon, math.max(allyTeamCount, #overrideConfig))
+			-- Every override box renders, spares included: someone in the room made
+			-- these by hand, so hiding the one they just added reads as a bug. The
+			-- game takes an override with more boxes than teams too.
+			RenderArrangement(overrideConfig, overrideHasPolygon, #overrideConfig)
 
 			return
 		end

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -401,6 +401,7 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 	local mapLinkWidth = 150
 	currentStartRects = {}
 	spadsRectValues = {}
+	startRectValues = {}
 
 	local externalFunctions = {}
 	local ApplySingleplayerDefaultBoxes

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -57,6 +57,8 @@ local MINIMAP_TOOLTIP_PREFIX = "minimap_tooltip_"
 local MINIMUM_QUICKPLAY_PLAYERS = 4 -- Hax until the server tells me a number.
 
 local lastUserToChangeStartBoxes = ''
+local reportedStartboxDecodeFailures = {}
+local AddLocalBattleWarning
 
 local readyButton
 local btnStartBattle = nil
@@ -330,6 +332,24 @@ local function ApplySingleplayerSkirmishSetup(singleplayerDefault)
 	end, 0.12)
 end
 
+-- Every client decodes the same modoption, so the ones that cannot read it complain
+-- locally instead of each pushing a message into the room.
+local function ReportStartboxDecodeFailure(modoptionName, failedValue, message)
+	if not failedValue then
+		reportedStartboxDecodeFailures[modoptionName] = nil
+
+		return
+	end
+
+	if reportedStartboxDecodeFailures[modoptionName] == failedValue or not AddLocalBattleWarning then
+		return
+	end
+	reportedStartboxDecodeFailures[modoptionName] = failedValue
+
+	Spring.Log("Chobby gui_battle_room_window.lua", LOG.WARNING, "Could not decode " .. modoptionName)
+	AddLocalBattleWarning(message)
+end
+
 local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUserName, showRandomSkirmishButton)
 	local config = WG.Chobby.Configuration
 	local minimapBottomClearance = 172
@@ -366,9 +386,17 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 			return
 		end
 
+		local encoded = mapStartBoxes.encodeStartboxOverrideModoption(startRectValues)
+		if not encoded and next(startRectValues) ~= nil then
+			if AddLocalBattleWarning then
+				AddLocalBattleWarning("These start boxes could not be encoded, so they were not sent to the room.")
+			end
+
+			return
+		end
+
 		-- "0" rather than "" when clearing: SPADS drops empty values on the floor
 		-- (sendBattleSetting skips ''), same trick as gui_modoptions_panel.
-		local encoded = mapStartBoxes.encodeStartboxOverrideModoption(startRectValues)
 		battleLobby:SetModOptions({ mapmetadata_startbox_override = encoded or "0" })
 
 		-- Boxes stay on whatever the server currently holds until the echo says
@@ -2058,11 +2086,14 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		renderedAllyTeamCount = GetAllyTeamCount(false)
 		local allyTeamCount = renderedAllyTeamCount
 
-		local overrideConfig, overrideHasPolygon
+		local overrideConfig, overrideHasPolygon, overrideUnreadable
 		if mapStartBoxes and mapStartBoxes.decodeStartboxOverride then
-			overrideConfig, overrideHasPolygon =
+			overrideConfig, overrideHasPolygon, overrideUnreadable =
 				mapStartBoxes.decodeStartboxOverride(modoptions.mapmetadata_startbox_override)
 		end
+		ReportStartboxDecodeFailure("mapmetadata_startbox_override",
+			overrideUnreadable and modoptions.mapmetadata_startbox_override,
+			"The custom start boxes in this room could not be read, so the game will use the map default boxes.")
 		defaultStartboxMode = (overrideConfig == nil)
 
 		if overrideConfig then
@@ -2075,12 +2106,15 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 			return
 		end
 
-		local setConfig, setHasPolygon
+		local setConfig, setHasPolygon, setUnreadable
 		if Configuration.gameConfig and Configuration.gameConfig.useDefaultStartBoxes
 				and mapStartBoxes and mapStartBoxes.decodeStartboxesSet then
-			setConfig, setHasPolygon =
+			setConfig, setHasPolygon, setUnreadable =
 				mapStartBoxes.decodeStartboxesSet(modoptions.mapmetadata_startboxes_set, allyTeamCount)
 		end
+		ReportStartboxDecodeFailure("mapmetadata_startboxes_set",
+			setUnreadable and modoptions.mapmetadata_startboxes_set,
+			"The map start boxes for this room could not be read, so the game will fall back to its own boxes.")
 
 		if setConfig then
 			arrangementActive = true
@@ -4239,6 +4273,10 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 	local battleRoomConsole = WG.Chobby.Console("Battleroom Chat", MessageListener, true, nil, true)
 	WG.BattleRoomChatInput = battleRoomConsole.ebInputText
 
+	AddLocalBattleWarning = function(message)
+		battleRoomConsole:AddMessage(message, nil, nil, Configuration.warningColor, true)
+	end
+
 	-- Oversized paste: throttle multiplayer or apply via singleplayer MessageListener (SPADS / UI).
 	do
 		local chatInput = battleRoomConsole.ebInputText
@@ -5066,6 +5104,8 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		WG.BattleStatusPanel.RemoveBattleTab()
 		WG.BattleRoomChatInput = nil
 		WG.BattleRoomInlineProgress = nil
+		AddLocalBattleWarning = nil
+		reportedStartboxDecodeFailures = {}
 	end
 
 	mainWindow.OnDispose = mainWindow.OnDispose or {}

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -2064,10 +2064,28 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 
 	local renderedAllyTeamCount
 
-	-- Singleplayer reads polygon data from local mapDetails; multiplayer must render
-	-- only what the server says (modoptions), or the lobby can show boxes the game
-	-- won't use. The team count picks the arrangement, so this runs again whenever it
-	-- moves rather than only on map change.
+	local function RenderArrangement(config, hasPolygon, boxCount)
+		if hasPolygon then
+			externalFunctions.AddPolygonStartboxes(config, boxCount)
+
+			return
+		end
+
+		externalFunctions.RemovePolygonOverlays()
+		externalFunctions.RemoveStartRect()
+		for i = 1, boxCount do
+			local entry = config[i]
+			if entry and entry.boundingBox then
+				local box = entry.boundingBox
+				externalFunctions.AddStartRect(i - 1, box.left, box.top, box.right, box.bottom)
+			end
+		end
+	end
+
+	-- Skirmish reads its set from the local mapDetails where multiplayer reads the
+	-- modoption, and renders it through the same path from there. savedBoxes.dat is
+	-- only for maps with no set at all. The team count picks the arrangement, so this
+	-- runs again whenever it moves rather than only on map change.
 	function ApplySingleplayerDefaultBoxes(mapName, allyTeamCount)
 		local Configuration = WG.Chobby and WG.Chobby.Configuration
 		renderedAllyTeamCount = allyTeamCount
@@ -2086,11 +2104,13 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		externalFunctions.RemoveStartRect()
 		mapStartBoxes.clearBoxes()
 
-		local polygonConfig = mapStartBoxes.loadPolygonStartboxes
-			and mapStartBoxes.loadPolygonStartboxes(mapName, allyTeamCount)
+		local setConfig, setHasPolygon
+		if mapStartBoxes.loadStartboxesSet then
+			setConfig, setHasPolygon = mapStartBoxes.loadStartboxesSet(mapName, allyTeamCount)
+		end
 
-		if polygonConfig then
-			externalFunctions.AddPolygonStartboxes(polygonConfig, allyTeamCount)
+		if setConfig then
+			RenderArrangement(setConfig, setHasPolygon, allyTeamCount)
 		else
 			local startBoxes = mapStartBoxes.selectStartBoxesForAllyTeamCount(mapStartBoxes.savedBoxes[mapName], allyTeamCount)
 			if startBoxes then
@@ -2126,24 +2146,6 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		end
 
 		externalFunctions.RefreshStartboxes()
-	end
-
-	local function RenderArrangement(config, hasPolygon, boxCount)
-		if hasPolygon then
-			externalFunctions.AddPolygonStartboxes(config, boxCount)
-
-			return
-		end
-
-		externalFunctions.RemovePolygonOverlays()
-		externalFunctions.RemoveStartRect()
-		for i = 1, boxCount do
-			local entry = config[i]
-			if entry and entry.boundingBox then
-				local box = entry.boundingBox
-				externalFunctions.AddStartRect(i - 1, box.left, box.top, box.right, box.bottom)
-			end
-		end
 	end
 
 	-- MP render priority: override modoption > startboxes set modoption > SPADS

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -30,8 +30,10 @@ local startRectValues = {} -- for exporting the raw values
 local spadsRectValues = {} -- SPADS-sent AABBs, tracked even while not rendered
 local polygonStartboxesActive = false
 local activePolygonConfig = nil
--- false while a custom preset is applied; true once defaults reload. Drives whether
--- AddStartRect renders SPADS-sent AABBs or defers to the polygon overlay.
+-- true while the boxes on screen come from a modoption arrangement. SPADS' own rects
+-- are bookkeeping while it is set: the game resolves the modoption ahead of them.
+local arrangementActive = false
+-- false while a custom preset is applied; true once defaults reload.
 local defaultStartboxMode = true
 
 local singleplayerWrapper
@@ -355,9 +357,9 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		return count
 	end
 
-	-- Custom boxes travel as the mapmetadata_startbox_override modoption only;
-	-- one !bSet per edit (one vote), no !addbox/!split/!clearbox. The game and
-	-- every client render from the modoption once SPADS echoes it back.
+	-- Custom boxes travel as the mapmetadata_startbox_override modoption, one !bSet
+	-- per edit (one vote). The game and every client render from the modoption once
+	-- SPADS echoes it back.
 	local function SendStartboxOverride()
 		local mapStartBoxes = WG.Chobby.Configuration.gameConfig and WG.Chobby.Configuration.gameConfig.mapStartBoxes
 		if not (mapStartBoxes and mapStartBoxes.encodeStartboxOverrideModoption) then
@@ -476,8 +478,7 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 				if selected == "Default Boxes" then
 					local function defaultBoxes()
 						-- Leaving custom boxes: clear the override so the game uses the
-						-- default set. SPADS' own boxes were never touched (no !addbox in
-						-- this flow), so there is nothing to !loadboxes back.
+						-- default set.
 						if battleLobby.name == "singleplayer" then
 							defaultStartboxMode = true
 							battleLobby:SelectMap(battle.mapName)
@@ -1835,11 +1836,6 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		-- Capture happens before the early return so script export works in either mode.
 		startRectValues[allyNo+1]={["left"]=left, ["top"]=top, ["right"]=right, ["bottom"]=bottom}
 
-		-- SPADS-sent AABBs in default mode are bounding boxes of the polygons we're already drawing.
-		if polygonStartboxesActive and defaultStartboxMode then
-			return
-		end
-
 		if polygonStartboxesActive then
 			externalFunctions.RemovePolygonOverlays()
 		end
@@ -1974,6 +1970,18 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		return currentStartRects
 	end
 
+	function externalFunctions.ApplyStartBoxes(boxes)
+		externalFunctions.RemovePolygonOverlays()
+		externalFunctions.RemoveStartRect()
+		for i, box in ipairs(boxes) do
+			externalFunctions.AddStartRect(i - 1, box.left, box.top, box.right, box.bottom)
+		end
+
+		if battleLobby.name ~= "singleplayer" then
+			SendStartboxOverride()
+		end
+	end
+
 	-- Chosen to match the rectangular startbox_window's TileImage skin.
 	local polygonFillColor = {0.1, 0.1, 0.1, 0.7}
 	local polygonBorderColor = {1, 1, 1, 0.7}
@@ -2018,7 +2026,25 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		externalFunctions.RefreshStartboxes()
 	end
 
-	-- MP render priority: override modoption > set modoption (polygons) > SPADS
+	local function RenderArrangement(config, hasPolygon, boxCount)
+		if hasPolygon then
+			externalFunctions.AddPolygonStartboxes(config, boxCount)
+
+			return
+		end
+
+		externalFunctions.RemovePolygonOverlays()
+		externalFunctions.RemoveStartRect()
+		for i = 1, boxCount do
+			local entry = config[i]
+			if entry and entry.boundingBox then
+				local box = entry.boundingBox
+				externalFunctions.AddStartRect(i - 1, box.left, box.top, box.right, box.bottom)
+			end
+		end
+	end
+
+	-- MP render priority: override modoption > startboxes set modoption > SPADS
 	-- engine rects. Modoptions arrive via SETSCRIPTTAGS once SPADS applies the
 	-- !bSet, so every client (the editor included) re-renders from server state.
 	function externalFunctions.RefreshStartboxes()
@@ -2030,40 +2056,40 @@ local function SetupInfoButtonsPanel(leftInfo, rightInfo, battle, battleID, myUs
 		local mapStartBoxes = Configuration.gameConfig and Configuration.gameConfig.mapStartBoxes
 		local modoptions = battleLobby.modoptions or {}
 		renderedAllyTeamCount = GetAllyTeamCount(false)
+		local allyTeamCount = renderedAllyTeamCount
 
 		local overrideConfig, overrideHasPolygon
 		if mapStartBoxes and mapStartBoxes.decodeStartboxOverride then
 			overrideConfig, overrideHasPolygon =
 				mapStartBoxes.decodeStartboxOverride(modoptions.mapmetadata_startbox_override)
 		end
+		defaultStartboxMode = (overrideConfig == nil)
+
 		if overrideConfig then
-			defaultStartboxMode = false
-			if overrideHasPolygon then
-				externalFunctions.AddPolygonStartboxes(overrideConfig, renderedAllyTeamCount)
-			else
-				externalFunctions.RemovePolygonOverlays()
-				externalFunctions.RemoveStartRect()
-				for i, entry in ipairs(overrideConfig) do
-					local box = entry.boundingBox
-					externalFunctions.AddStartRect(i - 1, box.left, box.top, box.right, box.bottom)
-				end
-			end
+			arrangementActive = true
+			-- Spare boxes past the team count keep rendering: the game accepts an
+			-- override with more boxes than teams, and dropping them mid-edit would
+			-- look like the box the player just added never took.
+			RenderArrangement(overrideConfig, overrideHasPolygon, math.max(allyTeamCount, #overrideConfig))
 
 			return
 		end
 
-		defaultStartboxMode = true
-		local allyTeamCount = renderedAllyTeamCount
+		local setConfig, setHasPolygon
+		if Configuration.gameConfig and Configuration.gameConfig.useDefaultStartBoxes
+				and mapStartBoxes and mapStartBoxes.decodeStartboxesSet then
+			setConfig, setHasPolygon =
+				mapStartBoxes.decodeStartboxesSet(modoptions.mapmetadata_startboxes_set, allyTeamCount)
+		end
 
-		local polygonConfig = Configuration.gameConfig and Configuration.gameConfig.useDefaultStartBoxes
-			and mapStartBoxes and mapStartBoxes.loadPolygonStartboxesFromBlob
-			and mapStartBoxes.loadPolygonStartboxesFromBlob(modoptions.mapmetadata_startboxes_set, allyTeamCount)
-		if polygonConfig then
-			externalFunctions.AddPolygonStartboxes(polygonConfig, allyTeamCount)
+		if setConfig then
+			arrangementActive = true
+			RenderArrangement(setConfig, setHasPolygon, allyTeamCount)
 
 			return
 		end
 
+		arrangementActive = false
 		externalFunctions.RemovePolygonOverlays()
 		externalFunctions.RemoveStartRect()
 		for i, rect in pairs(spadsRectValues) do
@@ -4272,6 +4298,7 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		if battleID == closedBattleID and mainWindow then
 			polygonStartboxesActive = false
 			activePolygonConfig = nil
+			arrangementActive = false
 			mainWindow:Dispose()
 			mainWindow = nil
 			if wrapperControl and wrapperControl.visible and wrapperControl.parent then
@@ -4638,15 +4665,6 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		end
 		if string.match(message, "%(mapmetadata_startbox_override=") then return true end
 
-		-- Every client sees this confirmation, so clearing the override here would put
-		-- one !bSet per client on the wire; the sender does it (see ParseUserMessage).
-		-- Plain find because map names carry quotes and non-word characters.
-		if string.find(message, "Loaded boxes of map", 1, true) then
-			infoHandler.RefreshStartboxes()
-			StartBoxComboBoxSelectDefault()
-			return false
-		end
-
 		-- Restore default position on startbox selector when map, preset or teamcount changes
 		if string.match(message, "Global setting changed by .- %((nbTeams=%d+)%)$")
 		or string.match(message, "Map changed by .-%: .+$")
@@ -4686,17 +4704,6 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 
 	local function ParseUserMessage(userName,message) -- returns hidemessage bool
 		local mine = userName == battleLobby:GetMyUserName() 
-
-		if string.match(message, "^!split ") or string.match(message, "^!addbox ") then
-			lastUserToChangeStartBoxes = userName
-			if not mine then return true end
-		end
-
-		-- SPADS reloading its own boxes says nothing about the override, which outranks
-		-- them in game; clear it from the sender only so the room gets one !bSet.
-		if mine and string.match(message, "^!loadboxes") then
-			battleLobby:SetModOptions({ mapmetadata_startbox_override = "0" })
-		end
 
 		-- The startbox override is an opaque base64 blob; never show its !bSet in chat.
 		if string.match(message, "^!b[Ss]et mapmetadata_startbox_override") then return true end
@@ -4878,12 +4885,17 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 		battleRoomConsole:AddMessage(message, userName, false, chatColour, true)
 	end
 
+	-- SPADS keeps sending its own rects (map change, !addbox, !loadboxes) but the game
+	-- resolves the modoption arrangement ahead of them, so they only reach the minimap
+	-- when no arrangement claims the boxes and the player isn't mid-edit.
+	local function SpadsRectsRendered()
+		return battleLobby.name == "singleplayer" or (not arrangementActive and defaultStartboxMode)
+	end
+
 	local function OnRemoveStartRect(listener, allyNo)
 		--Spring.Log("Chobby gui_battle_room_window.lua",LOG.INFO,"OnRemoveStartRect", allyNo)
 		spadsRectValues[allyNo + 1] = nil
-		-- While an override is active, SPADS' rects are default-box bookkeeping:
-		-- track them for the fallback render but leave the override boxes alone.
-		if battleLobby.name ~= "singleplayer" and not defaultStartboxMode then
+		if not SpadsRectsRendered() then
 			return
 		end
 		infoHandler.RemoveStartRect(allyNo)
@@ -4892,7 +4904,7 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 	local function OnAddStartRect(listener, allyNo, left, top, right, bottom)
 		--Spring.Log("Chobby gui_battle_room_window.lua",LOG.WARNING,"OnAddStartRect", allyNo, left, top, right, bottom)
 		spadsRectValues[allyNo + 1] = {left = left, top = top, right = right, bottom = bottom}
-		if battleLobby.name ~= "singleplayer" and not defaultStartboxMode then
+		if not SpadsRectsRendered() then
 			return
 		end
 		infoHandler.AddStartRect(allyNo, left, top, right, bottom)
@@ -5355,12 +5367,20 @@ function BattleRoomWindow.GetCurrentStartRects()
 end
 
 function BattleRoomWindow.AddStartRect(allyNo, left, top, right, bottom)
-	if battleLobby.name == "singleplayer" then
-		local infoHandler = mainWindowFunctions.GetInfoHandler()
-		infoHandler.AddStartRect(allyNo, left, top, right, bottom)
-	else
-		battleLobby:SayBattle(string.format("!addbox %d %d %d %d %s", left, top, right, bottom, allyNo+1))
+	if battleLobby.name ~= "singleplayer" then
+		return
 	end
+
+	local infoHandler = mainWindowFunctions.GetInfoHandler()
+	infoHandler.AddStartRect(allyNo, left, top, right, bottom)
+end
+
+function BattleRoomWindow.ApplyStartBoxes(boxes)
+	if not (mainWindowFunctions and mainWindowFunctions.GetInfoHandler()) then
+		return
+	end
+
+	mainWindowFunctions.GetInfoHandler().ApplyStartBoxes(boxes)
 end
 
 function BattleRoomWindow.RemoveStartRect(allyNo)

--- a/LuaMenu/widgets/gui_optionpresets_panel.lua
+++ b/LuaMenu/widgets/gui_optionpresets_panel.lua
@@ -170,15 +170,7 @@ local function applyPreset(presetName, progressCallback, cancelToken)
 		end
 
 		if (presetRectangles ~= nil and enabledOptions["Start Boxes"]) then
-			WG.BattleRoomWindow.RemoveStartRect()
-			for index, value in ipairs(presetRectangles) do
-				local l = value["left"]
-				local r = value["right"]
-				local t = value["top"]
-				local b = value["bottom"]
-
-				WG.BattleRoomWindow.AddStartRect(index - 1, l, t, r, b)
-			end
+			WG.BattleRoomWindow.ApplyStartBoxes(presetRectangles)
 		end
 
 		-- AIs with their settings

--- a/libs/liblobby/lobby/interface_skirmish.lua
+++ b/libs/liblobby/lobby/interface_skirmish.lua
@@ -243,29 +243,28 @@ function InterfaceSkirmish:_StartScript(gameName, mapName, playerName, friendLis
 
 	local startBoxes  = nil
 	local polygonConfig = nil
-	--if Configuration.gameConfig.mapStartBoxes then
-	--  Spring.Echo("Number of mapStartBoxes is",#Configuration.gameConfig.mapStartBoxes, allyTeamCount)
-	--end
+	local customBoxes = nil
 
 	if Configuration.gameConfig and
 		Configuration.gameConfig.useDefaultStartBoxes and
 		Configuration.gameConfig.mapStartBoxes then
 
-		if Configuration.gameConfig.mapStartBoxes.loadPolygonStartboxes then
-			polygonConfig = Configuration.gameConfig.mapStartBoxes.loadPolygonStartboxes(mapName, allyTeamCount)
+		local mapStartBoxes = Configuration.gameConfig.mapStartBoxes
+
+		if mapStartBoxes.loadStartboxesSet then
+			polygonConfig = mapStartBoxes.loadStartboxesSet(mapName, allyTeamCount)
 		end
 
-		if polygonConfig then
-			Spring.Echo("Skirmish: Using polygon startboxes for", mapName)
-		elseif Configuration.gameConfig.mapStartBoxes.singleplayerboxes and next(Configuration.gameConfig.mapStartBoxes.singleplayerboxes) ~= nil then
-			startBoxes = Configuration.gameConfig.mapStartBoxes.singleplayerboxes
+		if mapStartBoxes.singleplayerboxes and next(mapStartBoxes.singleplayerboxes) ~= nil then
+			customBoxes = mapStartBoxes.singleplayerboxes
+			startBoxes = customBoxes
 			Spring.Echo("Skirmish: Using custom startboxes",startBoxes)
-			--Spring.Echo(Spring.Utilities.TableToString(startBoxes))
-		elseif Configuration.gameConfig.mapStartBoxes.savedBoxes and
-			Configuration.gameConfig.mapStartBoxes.savedBoxes[mapName] then
-			startBoxes = Configuration.gameConfig.mapStartBoxes.savedBoxes[mapName]
+		elseif polygonConfig then
+			Spring.Echo("Skirmish: Using the map startboxes set for", mapName)
+		elseif mapStartBoxes.savedBoxes and mapStartBoxes.savedBoxes[mapName] then
+			startBoxes = mapStartBoxes.savedBoxes[mapName]
 			Spring.Echo("Skirmish: Using default startboxes",startBoxes)
-			startBoxes = Configuration.gameConfig.mapStartBoxes.selectStartBoxesForAllyTeamCount(startBoxes,allyTeamCount)
+			startBoxes = mapStartBoxes.selectStartBoxesForAllyTeamCount(startBoxes,allyTeamCount)
 		end
 	else
 		Spring.Echo("No map startBoxes found or disabled for map",mapName)
@@ -273,7 +272,7 @@ function InterfaceSkirmish:_StartScript(gameName, mapName, playerName, friendLis
 
 	for i, teamData in pairs(teams) do
 		if not allyTeams[teamData.AllyTeam] then
-			if polygonConfig then
+			if polygonConfig and not startBoxes then
 				allyTeams[teamData.AllyTeam] = Configuration.gameConfig.mapStartBoxes.makeAllyTeamBoxFromPolygon(polygonConfig, teamData.AllyTeam)
 		    elseif startBoxes then
 				allyTeams[teamData.AllyTeam] = Configuration.gameConfig.mapStartBoxes.makeAllyTeamBox(startBoxes,teamData.AllyTeam)
@@ -339,14 +338,19 @@ function InterfaceSkirmish:_StartScript(gameName, mapName, playerName, friendLis
 	script.modoptions["date_year"] = os.date("%Y")
 	script.modoptions["date_hour"] = os.date("%H")
 
-	-- script.modoptions aliases self.modoptions and persists across launches, so a set
-	-- from a previously launched polygon map would leak into this one; clear before re-adding.
+	-- script.modoptions aliases self.modoptions and persists across launches, so boxes
+	-- from a previously launched map would leak into this one; clear before re-adding.
 	script.modoptions["mapmetadata_startboxes_set"] = nil
-	if polygonConfig and Configuration.gameConfig.mapStartBoxes
-			and Configuration.gameConfig.mapStartBoxes.encodeStartboxesSetModoption then
-		local encoded = Configuration.gameConfig.mapStartBoxes.encodeStartboxesSetModoption(polygonConfig)
-		if encoded then
-			script.modoptions["mapmetadata_startboxes_set"] = encoded
+	script.modoptions["mapmetadata_startbox_override"] = nil
+	local mapStartBoxes = Configuration.gameConfig and Configuration.gameConfig.mapStartBoxes
+	if mapStartBoxes then
+		if polygonConfig and mapStartBoxes.encodeStartboxesSetModoption then
+			script.modoptions["mapmetadata_startboxes_set"] =
+				mapStartBoxes.encodeStartboxesSetModoption(polygonConfig) or nil
+		end
+		if customBoxes and mapStartBoxes.encodeStartboxOverrideModoption then
+			script.modoptions["mapmetadata_startbox_override"] =
+				mapStartBoxes.encodeStartboxOverrideModoption(customBoxes) or nil
 		end
 	end
 

--- a/libs/liblobby/lobby/interface_skirmish.lua
+++ b/libs/liblobby/lobby/interface_skirmish.lua
@@ -255,7 +255,16 @@ function InterfaceSkirmish:_StartScript(gameName, mapName, playerName, friendLis
 			polygonConfig = mapStartBoxes.loadStartboxesSet(mapName, allyTeamCount)
 		end
 
-		if mapStartBoxes.singleplayerboxes and next(mapStartBoxes.singleplayerboxes) ~= nil then
+		-- The game drops an override that does not cover every allyteam (matchOverride in
+		-- startbox_utilities.lua) and resolves the set instead, rewriting every rect, so
+		-- short custom boxes are ignored here too rather than written into a script the
+		-- game will contradict.
+		local customBoxCount = 0
+		while mapStartBoxes.singleplayerboxes and mapStartBoxes.singleplayerboxes[customBoxCount + 1] do
+			customBoxCount = customBoxCount + 1
+		end
+
+		if customBoxCount >= allyTeamCount then
 			customBoxes = mapStartBoxes.singleplayerboxes
 			startBoxes = customBoxes
 			Spring.Echo("Skirmish: Using custom startboxes",startBoxes)


### PR DESCRIPTION
Refuses to start when the arrangement the game resolves leaves a team without a box, and stops the deprecated box commands from moving the preview. Follows up on #1184 and #1243.

The game only boxes in the allyteams its arrangement covers. The rest get no box drawn in game and are placed against whatever the start script left them, which the engine defaults to the whole map. Of the 225 maps shipping an arrangement, 170 ship two-team boxes only, so rooms with three or more teams there now refuse to start.

Skirmish resolves, draws and launches through the multiplayer path now, so both get the same boxes from the same code. The one deliberate difference is that overrides draw every box they carry, since someone placed those by hand, while map arrangements stay capped at the team count. Hand-edited skirmish boxes reset when the team count changes.

AI disclosure: written with assistance from Claude Code.
