### PR TITLE
Swallow !start when a team has no start box

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -4367,6 +4367,16 @@ local function InitializeControls(battleID, oldLobby, topPoportion, setupData)
 	UpdateBattleTitle()
 
 	local function MessageListener(message)
+		local startboxShortfall = (not battle.isRunning) and message:lower():match("^%s*!start%s*$")
+			and GetStartboxShortfallMessage()
+		if startboxShortfall then
+			if AddLocalBattleWarning then
+				AddLocalBattleWarning(startboxShortfall)
+			end
+
+			return
+		end
+
 		if message:starts("/me ") then
 			battleLobby:SayBattleEx(message:sub(5))
 		else


### PR DESCRIPTION
Shows the missing start box warning in the console instead of sending the command, so typing !start does the same thing as the disabled Start button. Follows up on #1250.

!forcestart still goes through, deliberately, since it is the way out if the check ever reads a room wrong.

AI disclosure: written with assistance from Claude Code.
